### PR TITLE
data race issue and retry send message

### DIFF
--- a/client.go
+++ b/client.go
@@ -59,8 +59,8 @@ type Client struct {
 	// even when re-syncing the whole state.
 	EmitAppStateEventsOnFullSync bool
 
-	// IsLoggedIn is set to true after the client is successfully connected and authenticated on WhatsApp.
-	IsLoggedIn bool
+	isLoggedIn     bool
+	isLoggedInLock sync.RWMutex
 
 	appStateProc     *appstate.Processor
 	appStateSyncLock sync.Mutex
@@ -230,6 +230,19 @@ func (cli *Client) autoReconnect() {
 			return
 		}
 	}
+}
+
+func (cli *Client) setIsLoggedIn(b bool) {
+	cli.isLoggedInLock.Lock()
+	cli.isLoggedIn = b
+	cli.isLoggedInLock.Unlock()
+}
+
+// IsLoggedIn is set to true after the client is successfully connected and authenticated on WhatsApp.
+func (cli *Client) IsLoggedIn() bool {
+	cli.isLoggedInLock.RLock()
+	defer cli.isLoggedInLock.RUnlock()
+	return cli.isLoggedIn
 }
 
 // IsConnected checks if the client is connected to the WhatsApp web websocket.

--- a/connectionevents.go
+++ b/connectionevents.go
@@ -15,7 +15,7 @@ import (
 )
 
 func (cli *Client) handleStreamError(node *waBinary.Node) {
-	cli.IsLoggedIn = false
+	cli.setIsLoggedIn(false)
 	code, _ := node.Attrs["code"].(string)
 	switch code {
 	case "515":
@@ -81,7 +81,7 @@ func (cli *Client) handleConnectSuccess(node *waBinary.Node) {
 	cli.Log.Infof("Successfully authenticated")
 	cli.LastSuccessfulConnect = time.Now()
 	cli.AutoReconnectErrors = 0
-	cli.IsLoggedIn = true
+	cli.setIsLoggedIn(true)
 	go func() {
 		if dbCount, err := cli.Store.PreKeys.UploadedPreKeyCount(); err != nil {
 			cli.Log.Errorf("Failed to get number of prekeys in database: %v", err)

--- a/retry.go
+++ b/retry.go
@@ -164,8 +164,34 @@ func (cli *Client) handleRetryReceipt(receipt *events.Receipt, node *waBinary.No
 	if err != nil {
 		return fmt.Errorf("failed to send retry message: %w", err)
 	}
-	cli.Log.Debugf("Sent retry #%d for %s/%s to %s", retryCount, receipt.Chat, messageID, receipt.Sender)
+
+	if cli.canRetry(receipt) {
+		cli.Log.Debugf("Sent retry #%d for %s/%s to %s", retryCount, receipt.Chat, messageID, receipt.Sender)
+		cli.SendMessage(receipt.Chat, messageID, msg)
+	}
 	return nil
+}
+
+// canRetry returns true if account is not verified
+//  if account is a verified account, an retry looping issue occur
+func (cli *Client) canRetry(receipt *events.Receipt) bool {
+	users, err := cli.IsOnWhatsApp([]string{"+" + receipt.Chat.String()})
+
+	if err != nil {
+		return false
+	}
+
+	user := users[0]
+	if user.VerifiedName == nil {
+		return true
+	}
+
+	if user.VerifiedName.Certificate.ServerSignature == nil {
+		return true
+	}
+
+	//ServerSignature not null = verified account
+	return false
 }
 
 // sendRetryReceipt sends a retry receipt for an incoming message.


### PR DESCRIPTION
retry send when first message gets pair key error
canRetry - if account is a verified account, an retry looping issue occur

fix data race issue when check if isConnected