### PR TITLE
fix panic when client logout

### DIFF
--- a/message.go
+++ b/message.go
@@ -51,6 +51,10 @@ func (cli *Client) handleEncryptedMessage(node *waBinary.Node) {
 }
 
 func (cli *Client) parseMessageSource(node *waBinary.Node, requireParticipant bool) (source types.MessageSource, err error) {
+	if cli.Store.ID == nil {
+		err = ErrNotLoggedIn
+		return
+	}
 	ag := node.AttrGetter()
 	from := ag.JID("from")
 	if from.Server == types.GroupServer || from.Server == types.BroadcastServer {


### PR DESCRIPTION
In continuation of the #47 

Panic:
> runtime error: invalid memory address or nil pointer dereference\ngoroutine 45019345 [running]:\nruntime/debug.Stack()\n\truntime/debug/stack.go:24 +0x65\[ngo.mau.fi/whatsmeow.(*Client](http://ngo.mau.fi/whatsmeow.(*Client)).handlerQueueLoop.func1.1()\n\[tgo.mau.fi/whatsmeow@v0.0.0-20211130131146-8752ed0761b5/client.go:541](http://tgo.mau.fi/whatsmeow@v0.0.0-20211130131146-8752ed0761b5/client.go:541) +0x7f\npanic({0xbd4d20, 0x1394f50})\n\truntime/panic.go:1038 +0x215\[ngo.mau.fi/whatsmeow.(*Client](http://ngo.mau.fi/whatsmeow.(*Client)).parseMessageSource(0xc0078fe800, 0xc14ceef680)\n\[tgo.mau.fi/whatsmeow@v0.0.0-20211130131146-8752ed0761b5/message.go:63](http://tgo.mau.fi/whatsmeow@v0.0.0-20211130131146-8752ed0761b5/message.go:63) +0x4c6\[ngo.mau.fi/whatsmeow.(*Client](http://ngo.mau.fi/whatsmeow.(*Client)).parseReceipt(0xc08196bed0, 0xc14ceef680)\n\[tgo.mau.fi/whatsmeow@v0.0.0-20211130131146-8752ed0761b5/receipt.go:39](http://tgo.mau.fi/whatsmeow@v0.0.0-20211130131146-8752ed0761b5/receipt.go:39) +0xc5\[ngo.mau.fi/whatsmeow.(*Client](http://ngo.mau.fi/whatsmeow.(*Client)).handleReceipt(0xc0078fe800, 0xc14ceef680)\n\[tgo.mau.fi/whatsmeow@v0.0.0-20211130131146-8752ed0761b5/receipt.go:20](http://tgo.mau.fi/whatsmeow@v0.0.0-20211130131146-8752ed0761b5/receipt.go:20) +0x27\[ngo.mau.fi/whatsmeow.(*Client](http://ngo.mau.fi/whatsmeow.(*Client)).handlerQueueLoop.func1(0xc08196bf70, 0xc08196bf68)\n\[tgo.mau.fi/whatsmeow@v0.0.0-20211130131146-8752ed0761b5/client.go:544](http://tgo.mau.fi/whatsmeow@v0.0.0-20211130131146-8752ed0761b5/client.go:544) +0x8f\[ngo.mau.fi/whatsmeow.(*Client](http://ngo.mau.fi/whatsmeow.(*Client)).handlerQueueLoop(0xc0078fe800, {0xdf8710, 0xc0194d1580})\n\[tgo.mau.fi/whatsmeow@v0.0.0-20211130131146-8752ed0761b5/client.go:545](http://tgo.mau.fi/whatsmeow@v0.0.0-20211130131146-8752ed0761b5/client.go:545) +0x4e\ncreated by [go.mau.fi/whatsmeow.(*Client](http://go.mau.fi/whatsmeow.(*Client)).Connect\n\[tgo.mau.fi/whatsmeow@v0.0.0-20211130131146-8752ed0761b5/client.go:297](http://tgo.mau.fi/whatsmeow@v0.0.0-20211130131146-8752ed0761b5/client.go:297) +0x44f\n%!(EXTRA []interface {}=[])