### PR TITLE
fix race condition when client logout

### DIFF
--- a/message.go
+++ b/message.go
@@ -51,7 +51,8 @@ func (cli *Client) handleEncryptedMessage(node *waBinary.Node) {
 }
 
 func (cli *Client) parseMessageSource(node *waBinary.Node, requireParticipant bool) (source types.MessageSource, err error) {
-	if cli.Store.ID == nil {
+	clientID := cli.Store.ID
+	if clientID == nil {
 		err = ErrNotLoggedIn
 		return
 	}
@@ -65,13 +66,13 @@ func (cli *Client) parseMessageSource(node *waBinary.Node, requireParticipant bo
 		} else {
 			source.Sender = ag.OptionalJIDOrEmpty("participant")
 		}
-		if source.Sender.User == cli.Store.ID.User {
+		if source.Sender.User == clientID.User {
 			source.IsFromMe = true
 		}
 		if from.Server == types.BroadcastServer {
 			source.BroadcastListOwner = ag.OptionalJIDOrEmpty("recipient")
 		}
-	} else if from.User == cli.Store.ID.User {
+	} else if from.User == clientID.User {
 		source.IsFromMe = true
 		source.Sender = from
 		recipient := ag.OptionalJID("recipient")
@@ -399,7 +400,8 @@ func (cli *Client) handleDecryptedMessage(info *types.MessageInfo, msg *waProto.
 }
 
 func (cli *Client) sendProtocolMessageReceipt(id, msgType string) {
-	if len(id) == 0 || cli.Store.ID == nil {
+	clientID := cli.Store.ID
+	if len(id) == 0 || clientID == nil {
 		return
 	}
 	err := cli.sendNode(waBinary.Node{
@@ -407,7 +409,7 @@ func (cli *Client) sendProtocolMessageReceipt(id, msgType string) {
 		Attrs: waBinary.Attrs{
 			"id":   id,
 			"type": msgType,
-			"to":   types.NewJID(cli.Store.ID.User, types.LegacyUserServer),
+			"to":   types.NewJID(clientID.User, types.LegacyUserServer),
 		},
 		Content: nil,
 	})


### PR DESCRIPTION
now it's really good to help #23 

Got it again:
> goroutine 1000150 [running]:
[go.mau.fi/whatsmeow.(*Client](http://go.mau.fi/whatsmeow.(*Client)).sendProtocolMessageReceipt(0xc0b0b52000, {0xc0e6586340, 0x99d6ca}, {0xdee146, 0x9})
 [go.mau.fi/whatsmeow@v0.0.0-20220614154415-5718022af87c/message.go:394](http://go.mau.fi/whatsmeow@v0.0.0-20220614154415-5718022af87c/message.go:394) +0x157
created by [go.mau.fi/whatsmeow.(*Client](http://go.mau.fi/whatsmeow.(*Client)).handleProtocolMessage
 [go.mau.fi/whatsmeow@v0.0.0-20220614154415-5718022af87c/message.go:349](http://go.mau.fi/whatsmeow@v0.0.0-20220614154415-5718022af87c/message.go:349) +0x16f