### PR TITLE
Add file logging to the waLog package (util/log.go)

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -27,7 +27,14 @@ func eventHandler(evt interface{}) {
 }
 
 func Example() {
-	dbLog := waLog.Stdout("Database", "DEBUG", true)
+	mainLog, err := waLog.File("", waLog.DebugLevel, "/tmp/whatsmeow.log", false, false)
+	if err != nil {
+		panic(err)
+	}
+	// Alternatively for logging to stdout:
+	//  mainLog := waLog.Stdout("", waLog.DebugLevel, true)
+
+	dbLog := mainLog.Sub("Database")
 	// Make sure you add appropriate DB connector imports, e.g. github.com/mattn/go-sqlite3 for SQLite
 	container, err := sqlstore.New("sqlite3", "file:examplestore.db?_foreign_keys=on", dbLog)
 	if err != nil {
@@ -38,7 +45,7 @@ func Example() {
 	if err != nil {
 		panic(err)
 	}
-	clientLog := waLog.Stdout("Client", "DEBUG", true)
+	clientLog := mainLog.Sub("Client")
 	client := whatsmeow.NewClient(deviceStore, clientLog)
 	client.AddEventHandler(eventHandler)
 

--- a/go.sum
+++ b/go.sum
@@ -9,13 +9,6 @@ go.mau.fi/libsignal v0.0.0-20221015105917-d970e7c3c9cf h1:mzPxXBgDPHKDHMVV1tIWh7
 go.mau.fi/libsignal v0.0.0-20221015105917-d970e7c3c9cf/go.mod h1:XCjaU93vl71YNRPn059jMrK0xRDwVO5gKbxoPxow9mQ=
 golang.org/x/crypto v0.0.0-20221012134737-56aed061732a h1:NmSIgad6KjE6VvHciPZuNRTKxGhlPfD6OA87W/PLkqg=
 golang.org/x/crypto v0.0.0-20221012134737-56aed061732a/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
-golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
-golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=

--- a/util/log/log.go
+++ b/util/log/log.go
@@ -8,27 +8,43 @@
 package waLog
 
 import (
+	"errors"
 	"fmt"
+	"io"
+	"os"
 	"strings"
+	"sync"
 	"time"
+)
+
+const (
+	// Timestamp format
+	timeFormat = "15:04:05.000"
+
+	DebugLevel = "DEBUG" // Loggers initialized with DebugLevel will output Debugf(), Infof(), Warnf() and Errorf().
+	InfoLevel  = "INFO"  // Loggers initialized with InfoLevel will output Infof(), Warnf() and Errorf().
+	WarnLevel  = "WARN"  // Loggers initialized with WarnLevel will output Warnf() and Errorf().
+	ErrorLevel = "ERROR" // Loggers initialized with ErrorLevel will output Errorf().
 )
 
 // Logger is a simple logger interface that can have subloggers for specific areas.
 type Logger interface {
-	Warnf(msg string, args ...interface{})
-	Errorf(msg string, args ...interface{})
-	Infof(msg string, args ...interface{})
-	Debugf(msg string, args ...interface{})
+	Warnf(msg string, args ...interface{}) error
+	Errorf(msg string, args ...interface{}) error
+	Infof(msg string, args ...interface{}) error
+	Debugf(msg string, args ...interface{}) error
 	Sub(module string) Logger
+	Close() error
 }
 
 type noopLogger struct{}
 
-func (n *noopLogger) Errorf(_ string, _ ...interface{}) {}
-func (n *noopLogger) Warnf(_ string, _ ...interface{})  {}
-func (n *noopLogger) Infof(_ string, _ ...interface{})  {}
-func (n *noopLogger) Debugf(_ string, _ ...interface{}) {}
-func (n *noopLogger) Sub(_ string) Logger               { return n }
+func (n *noopLogger) Errorf(_ string, _ ...interface{}) error { return nil }
+func (n *noopLogger) Warnf(_ string, _ ...interface{}) error  { return nil }
+func (n *noopLogger) Infof(_ string, _ ...interface{}) error  { return nil }
+func (n *noopLogger) Debugf(_ string, _ ...interface{}) error { return nil }
+func (n *noopLogger) Sub(_ string) Logger                     { return n }
+func (n *noopLogger) Close() error                            { return nil }
 
 // Noop is a no-op Logger implementation that silently drops everything.
 var Noop Logger = &noopLogger{}
@@ -40,21 +56,21 @@ type stdoutLogger struct {
 }
 
 var colors = map[string]string{
-	"INFO":  "\033[36m",
-	"WARN":  "\033[33m",
-	"ERROR": "\033[31m",
+	InfoLevel:  "\033[36m",
+	WarnLevel:  "\033[33m",
+	ErrorLevel: "\033[31m",
 }
 
 var levelToInt = map[string]int{
-	"":      -1,
-	"DEBUG": 0,
-	"INFO":  1,
-	"WARN":  2,
-	"ERROR": 3,
+	"":         -1,
+	DebugLevel: 0,
+	InfoLevel:  1,
+	WarnLevel:  2,
+	ErrorLevel: 3,
 }
 
 func (s *stdoutLogger) outputf(level, msg string, args ...interface{}) {
-	if levelToInt[level] < s.min {
+	if !shouldOutput(s.min, level) {
 		return
 	}
 	var colorStart, colorReset string
@@ -62,22 +78,213 @@ func (s *stdoutLogger) outputf(level, msg string, args ...interface{}) {
 		colorStart = colors[level]
 		colorReset = "\033[0m"
 	}
-	fmt.Printf("%s%s [%s %s] %s%s\n", time.Now().Format("15:04:05.000"), colorStart, s.mod, level, fmt.Sprintf(msg, args...), colorReset)
+	fmt.Printf("%s%s [%s %s] %s%s\n", timestamp(), colorStart, s.mod, level, fmt.Sprintf(msg, args...), colorReset)
 }
 
-func (s *stdoutLogger) Errorf(msg string, args ...interface{}) { s.outputf("ERROR", msg, args...) }
-func (s *stdoutLogger) Warnf(msg string, args ...interface{})  { s.outputf("WARN", msg, args...) }
-func (s *stdoutLogger) Infof(msg string, args ...interface{})  { s.outputf("INFO", msg, args...) }
-func (s *stdoutLogger) Debugf(msg string, args ...interface{}) { s.outputf("DEBUG", msg, args...) }
+// Errorf outputs an error message, regardless of the minimum level of the logger.
+// The returned error is always nil.
+func (s *stdoutLogger) Errorf(msg string, args ...interface{}) error {
+	s.outputf(ErrorLevel, msg, args...)
+	return nil
+}
+
+// Warnf outputs a warning message when the minimum level of the logger is above ErrorLevel.
+// The returned error is alwyas nil.
+func (s *stdoutLogger) Warnf(msg string, args ...interface{}) error {
+	s.outputf(WarnLevel, msg, args...)
+	return nil
+}
+
+// Infof outputs an informational message when minimum level of the logger is above
+// WarnLevel. The returned error is always nil.
+func (s *stdoutLogger) Infof(msg string, args ...interface{}) error {
+	s.outputf(InfoLevel, msg, args...)
+	return nil
+}
+
+// Debugf outputs a debug message when the minimum level of the logger is above
+// InfoLevel. The returned error is always nil.
+func (s *stdoutLogger) Debugf(msg string, args ...interface{}) error {
+	s.outputf(DebugLevel, msg, args...)
+	return nil
+}
+
+// Sub returns a sub-logger which uses the passed-in module name as a tag.
 func (s *stdoutLogger) Sub(mod string) Logger {
-	return &stdoutLogger{mod: fmt.Sprintf("%s/%s", s.mod, mod), color: s.color, min: s.min}
+	return &stdoutLogger{mod: sub(s.mod, mod), color: s.color, min: s.min}
 }
 
-// Stdout is a simple Logger implementation that outputs to stdout. The module name given is included in log lines.
+// Close is a no-op for the Stdout logger.
+func (s *stdoutLogger) Close() error { return nil }
+
+// Stdout is a simple Logger implementation that outputs to stdout. The module name given is
+// included in log lines.
 //
-// minLevel specifies the minimum log level to output. An empty string will output all logs.
+// If color is true, then info, warn and error logs will be colored cyan, yellow and red
+// respectively using ANSI color escape codes.
 //
-// If color is true, then info, warn and error logs will be colored cyan, yellow and red respectively using ANSI color escape codes.
+// The minLevel is the minimum level to log and can be DebugLevel, InfoLevel, WarnLevel or
+// ErrorLevel.
 func Stdout(module string, minLevel string, color bool) Logger {
 	return &stdoutLogger{mod: module, color: color, min: levelToInt[strings.ToUpper(minLevel)]}
+}
+
+type fileLogger struct {
+	// Input parameters
+	mod      string // module name
+	min      int    // minimal level to log
+	filename string // output file (incase of reopening)
+	reopen   bool   // when true, the output file is reopened when it disappears
+	// Internal and inherited into each sub module
+	writer   io.WriteCloser // output channel
+	mu       *sync.Mutex    // shared mutex by all copies
+	refCount *int           // shared count of loggers using this writer
+	openbits int            // how to reopen (create or append)
+}
+
+// File returns a Logger implementation that outputs to a file. Similar to the Stdout()
+// logger, the module name and timestamp are included in the logs.
+// The minLevel is the minimum level to log and can be DebugLevel, InfoLevel, WarnLevel or
+// ErrorLevel.
+//
+// When reopen is true, then a new output file is created incase it disappears. This slows
+// down logging, but external scripts like "logrotate" can be used to keep the file size
+// in check.
+//
+// When append is true, then the output file is appended. The default is to overwrite.
+func File(module, minLevel, filename string, reopen, append bool) (Logger, error) {
+	refCount := 1
+	l := &fileLogger{
+		mod:      module,
+		min:      levelToInt[strings.ToUpper(minLevel)],
+		filename: filename,
+		reopen:   reopen,
+		mu:       &sync.Mutex{},
+		refCount: &refCount,
+		openbits: os.O_CREATE | os.O_WRONLY,
+	}
+	if reopen {
+		l.openbits |= os.O_APPEND
+	}
+	var err error
+	l.writer, err = os.OpenFile(l.filename, l.openbits, 0644)
+	if err != nil {
+		return nil, err
+	}
+	return l, nil
+}
+
+// Close shuts down the file logger.
+func (l *fileLogger) Close() error {
+	refCount := l.refCount
+	*refCount--
+	if *refCount == 0 {
+		return l.writer.Close()
+	}
+	return nil
+}
+
+// Errorf outputs an error message, regardless of the minimum level of the logger.
+// The returned error is non-nil when reopening of the log file fails.
+func (l *fileLogger) Errorf(msg string, args ...interface{}) error {
+	return l.outputf(ErrorLevel, msg, args...)
+}
+
+// Warnf outputs a warning message when the minimum level of the logger is aboove ErrorLevel.
+// The returned error is non-nil when reopening of the log file fails.
+func (l *fileLogger) Warnf(msg string, args ...interface{}) error {
+	return l.outputf(WarnLevel, msg, args...)
+}
+
+// Infof outputs an informational message when minimum level of the logger is above
+// WarnLevel. The returned error is non-nil when reopening of the log file fails.
+func (l *fileLogger) Infof(msg string, args ...interface{}) error {
+	return l.outputf(InfoLevel, msg, args...)
+}
+
+// Debugf outputs a debug message when the minimum level of the logger is above InfoLevel.
+// The returned error is non-nil when reopening of the log file fails.
+func (l *fileLogger) Debugf(msg string, args ...interface{}) error {
+	return l.outputf(DebugLevel, msg, args...)
+}
+
+// Sub returns a new file logger with an extended module name, which is used in the logging
+// output. Module names of sub loggers are slash-separated appended to the module names of
+// "parent" loggers.
+//
+// Example:
+//
+//	l1, err := File("", "WARN", "/tmp/wa.log", true, true)
+//	l1.Warnf("a warning")  // no module name will be in the log statement
+//	l2 := l1.Sub("mod")
+//	l2.Warnf("a warning")  // module name "mod" will appear
+//	l3 := l2.Sub("sub")
+//	l3.Warnf("a warning")  // module name "mod/sub" will appear
+func (l *fileLogger) Sub(module string) Logger {
+	refCount := l.refCount
+	*refCount++
+	return &fileLogger{
+		mod:      sub(l.mod, module),
+		min:      l.min,
+		filename: l.filename,
+		reopen:   l.reopen,
+		writer:   l.writer,
+		mu:       l.mu,
+		refCount: l.refCount,
+		openbits: l.openbits,
+	}
+}
+
+// outputf is a helper for the file logger to, if necessary, reopen the output and.
+func (l *fileLogger) outputf(level, msg string, args ...interface{}) error {
+	if !shouldOutput(l.min, level) {
+		return nil
+	}
+
+	// Don't use closed loggers.
+	if refCount := l.refCount; *refCount == 0 {
+		return errors.New("logger is closed, cannot send output")
+	}
+
+	// Lock all IO to this writer.
+	(*l.mu).Lock()
+	defer (*l.mu).Unlock()
+
+	// Check that the file is still there.
+	_, err := os.Stat(l.filename)
+	if err != nil {
+		l.writer.Close()
+		l.writer, err = os.OpenFile(l.filename, l.openbits, 0644)
+		if err != nil {
+			return nil
+		}
+	}
+	txt := fmt.Sprintf(msg, args...)
+	mod := l.mod
+	if mod != "" {
+		mod += " "
+	}
+	l.writer.Write([]byte(fmt.Sprintf("%s [%s%s] %s\n", timestamp(), mod, level, txt)))
+	return nil
+}
+
+// sub is a helper to consistently propagate the name of a submodule for all loggers.
+func sub(existing, new string) string {
+	out := existing
+	if out != "" && new != "" {
+		out += "/"
+	}
+	out += new
+	return out
+}
+
+// timestamp is a helper to return a consistently formatted time stamp for all loggers.
+func timestamp() string {
+	return time.Now().Format(timeFormat)
+}
+
+// shouldOutput returns true when the the logger's level vs. the message's level indicates
+// that the log should be sent. This is separated-out for consistency across loggers.
+func shouldOutput(loggerLevel int, messageLevel string) bool {
+	return levelToInt[messageLevel] >= loggerLevel
 }

--- a/util/log/log_test.go
+++ b/util/log/log_test.go
@@ -1,0 +1,370 @@
+package waLog
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// newLogFile ensures that loggers in these tests get their own unique file.
+var nr int
+
+func newFile() string {
+	f := fmt.Sprintf("/tmp/logger_test_%d.log", nr)
+	nr++
+	return f
+}
+
+// TestSub tests the propagation of sub module names.
+func TestSub(t *testing.T) {
+	for _, test := range []struct {
+		existing string
+		new      string
+		want     string
+	}{
+		{
+			// Empty names
+			existing: "",
+			new:      "",
+			want:     "",
+		},
+		{
+			// No new name
+			existing: "existing",
+			new:      "",
+			want:     "existing",
+		},
+		{
+			// No existing name
+			existing: "",
+			new:      "new",
+			want:     "new",
+		},
+		{
+			// Both existing and new
+			existing: "existing",
+			new:      "new",
+			want:     "existing/new",
+		},
+	} {
+		if got := sub(test.existing, test.new); got != test.want {
+			t.Errorf("sub(%q, %q) = %q, want %q", test.existing, test.new, got, test.want)
+		}
+	}
+}
+
+// TestShouldOutput tests the comparison of the verbosity level of a logger vs. that of a message.
+func TestShouldOutput(t *testing.T) {
+	for _, test := range []struct {
+		loggerLevel  int
+		messageLevel string
+		shouldLog    bool
+	}{
+		// Unknown level, all should log
+		{
+			loggerLevel:  -1,
+			messageLevel: DebugLevel,
+			shouldLog:    true,
+		},
+		{
+			loggerLevel:  -1,
+			messageLevel: InfoLevel,
+			shouldLog:    true,
+		},
+		{
+			loggerLevel:  -1,
+			messageLevel: WarnLevel,
+			shouldLog:    true,
+		},
+		{
+			loggerLevel:  -1,
+			messageLevel: ErrorLevel,
+			shouldLog:    true,
+		},
+		// DEBUG level, all should log
+		{
+			loggerLevel:  0,
+			messageLevel: DebugLevel,
+			shouldLog:    true,
+		},
+		{
+			loggerLevel:  0,
+			messageLevel: InfoLevel,
+			shouldLog:    true,
+		},
+		{
+			loggerLevel:  0,
+			messageLevel: WarnLevel,
+			shouldLog:    true,
+		},
+		{
+			loggerLevel:  0,
+			messageLevel: ErrorLevel,
+			shouldLog:    true,
+		},
+		// INFO level, all bug DEBUG should log
+		{
+			loggerLevel:  1,
+			messageLevel: DebugLevel,
+			shouldLog:    false,
+		},
+		{
+			loggerLevel:  1,
+			messageLevel: InfoLevel,
+			shouldLog:    true,
+		},
+		{
+			loggerLevel:  1,
+			messageLevel: WarnLevel,
+			shouldLog:    true,
+		},
+		{
+			loggerLevel:  1,
+			messageLevel: ErrorLevel,
+			shouldLog:    true,
+		},
+		// WARN level, all bug DEBUG/INFO should log
+		{
+			loggerLevel:  2,
+			messageLevel: DebugLevel,
+			shouldLog:    false,
+		},
+		{
+			loggerLevel:  2,
+			messageLevel: InfoLevel,
+			shouldLog:    false,
+		},
+		{
+			loggerLevel:  2,
+			messageLevel: WarnLevel,
+			shouldLog:    true,
+		},
+		{
+			loggerLevel:  2,
+			messageLevel: ErrorLevel,
+			shouldLog:    true,
+		},
+		// ERROR level, only ERROR should log
+		{
+			loggerLevel:  3,
+			messageLevel: DebugLevel,
+			shouldLog:    false,
+		},
+		{
+			loggerLevel:  3,
+			messageLevel: InfoLevel,
+			shouldLog:    false,
+		},
+		{
+			loggerLevel:  3,
+			messageLevel: WarnLevel,
+			shouldLog:    false,
+		},
+		{
+			loggerLevel:  3,
+			messageLevel: ErrorLevel,
+			shouldLog:    true,
+		},
+	} {
+		if got := shouldOutput(test.loggerLevel, test.messageLevel); got != test.shouldLog {
+			t.Errorf("shouldOutput(%d, %q) = %v, want %v", test.loggerLevel, test.messageLevel, got, test.shouldLog)
+		}
+	}
+}
+
+// TestFileLogger is the most simple test of the file logger.
+func TestFileLogger(t *testing.T) {
+	f := newFile()
+	defer os.Remove(f)
+	l, err := File("Main", InfoLevel, f, false, false)
+	if err != nil {
+		t.Fatalf("File(_) = %v, need nil error", err)
+	}
+	for i := 0; i < 100; i++ {
+		l.Infof("info msg nr %d", i)
+	}
+	l.Close()
+	contents, err := os.ReadFile(f)
+	if err != nil {
+		t.Fatalf("os.ReadFile(_) = %v, need nil error", err)
+	}
+	// [0..99] is 100 lines, plus one trailing \n is 101
+	if l := len(strings.Split(string(contents), "\n")); l != 101 {
+		t.Fatalf("TestFileLogger: got %d lines, need %d", l, 101)
+	}
+}
+
+// TestAtomicWritesAndLevel ensures that all writes to the log are atomic and that the output
+// level is respected.
+func TestAtomicWrites(t *testing.T) {
+	f := newFile()
+	defer os.Remove(f)
+	l, err := File("Main", InfoLevel, f, false, false)
+	if err != nil {
+		t.Fatalf("File(_) = %v, need nil error", err)
+	}
+	defer l.Close()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 1000; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			l.Infof("info")
+			l.Debugf("debug")
+		}()
+	}
+	wg.Wait()
+	if err := l.Close(); err != nil {
+		t.Fatalf("Close() = %v, need nil error", err)
+	}
+
+	contents, err := os.ReadFile(f)
+	if err != nil {
+		t.Fatalf("os.ReadFile(_) = %v, need nil error", err)
+	}
+	for _, line := range strings.Split(string(contents), "\n") {
+		if line == "" {
+			continue
+		}
+		if strings.Contains(line, "debug") {
+			t.Errorf("`line %q: unexpected DEBUG entry", line)
+		}
+		if !strings.HasSuffix(line, "[Main "+InfoLevel+"] info") {
+			t.Errorf(`line %q: suffix "[Main " + InfoLevel + "] info" expected`, line)
+		}
+	}
+}
+
+// TestSubMods tests that modules appear correctly and that atomic writes are respected across subbed
+// loggers.
+func TestSubMods(t *testing.T) {
+	f := newFile()
+	defer os.Remove(f)
+
+	l, err := File("", InfoLevel, f, false, false)
+	if err != nil {
+		t.Fatalf("File(_) = %v, need nil error", err)
+	}
+	defer l.Close()
+
+	a := l.Sub("sub_a")
+	defer a.Close()
+
+	b := a.Sub("sub_b")
+	defer a.Close()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 1000; i++ {
+		wg.Add(3)
+		go func() {
+			defer wg.Done()
+			l.Infof("info from no_module")
+		}()
+		go func() {
+			defer wg.Done()
+			a.Infof("info from sub_a")
+		}()
+		go func() {
+			defer wg.Done()
+			b.Infof("info from sub_b")
+		}()
+	}
+	wg.Wait()
+
+	// The generated output lines may now contain as the module and level one of the following keys.
+	allowed := map[string]bool{
+		"[" + InfoLevel + "]":             true,
+		"[sub_a " + InfoLevel + "]":       true,
+		"[sub_a/sub_b " + InfoLevel + "]": true,
+	}
+	var want []string
+	for k := range allowed {
+		want = append(want, k)
+	}
+	contents, err := os.ReadFile(f)
+	if err != nil {
+		t.Fatalf("os.ReadFile(_) = %v, need nil error", err)
+	}
+	for _, line := range strings.Split(string(contents), "\n") {
+		if line == "" {
+			continue
+		}
+		matched := false
+		for k := range allowed {
+			if strings.Contains(line, k) {
+				matched = true
+			}
+		}
+		if !matched {
+			t.Errorf("line %q: fails to match either of %v", line, want)
+		}
+	}
+}
+
+// TestClose verifies that a closed logger is not usable.
+func TestClose(t *testing.T) {
+	f := newFile()
+	defer os.Remove(f)
+
+	one, err := File("one", DebugLevel, f, false, false)
+	if err != nil {
+		t.Fatalf("File(...) = %v, need nil error", err)
+	}
+	one.Close()
+	if err := one.Infof("info"); err == nil {
+		t.Errorf("Infof() after closing returns nil error")
+	}
+}
+
+// TestCloseSubs checks that when (sub) loggers are closed, dependent loggers still work.
+func TestCloseSubs(t *testing.T) {
+	// Close sub logger, main must continue to work
+	f1 := newFile()
+	defer os.Remove(f1)
+	one, err := File("one", DebugLevel, f1, false, false)
+	if err != nil {
+		t.Fatalf("File(...) = %v, need nil error", err)
+	}
+	oneSub := one.Sub("sub")
+	one.Infof("one first entry")
+	oneSub.Warnf("closing oneSub")
+	oneSub.Close()
+	if err := one.Infof("one second entry"); err != nil {
+		t.Errorf("one.Infof(...) = %v, need nil error", err)
+	}
+	one.Close()
+	contents, err := os.ReadFile(f1)
+	if err != nil {
+		t.Fatalf("os.ReadFile(_) = %v, want nil error", err)
+	}
+	if !strings.Contains(string(contents), "one second entry") {
+		t.Errorf("TestCloseSubs: failed to find main log after closing sub")
+	}
+
+	// Close main logger, sub must continue to work
+	f2 := newFile()
+	defer os.Remove(f2)
+	one, err = File("one", DebugLevel, f2, false, false)
+	if err != nil {
+		t.Fatalf("File(...) = %v, need nil error", err)
+	}
+	oneSub = one.Sub("sub")
+	one.Infof("one first entry")
+	oneSub.Infof("oneSub first entry")
+	one.Warnf("closing one")
+	one.Close()
+	if err := oneSub.Infof("oneSub second entry"); err != nil {
+		t.Errorf("oneSub.Infof(...) = %v, want nil error", err)
+	}
+	oneSub.Close()
+	contents, err = os.ReadFile(f2)
+	if err != nil {
+		t.Fatalf("os.ReadFile(_) = %v, need nil error", err)
+	}
+	if !strings.Contains(string(contents), "oneSub second entry") {
+		t.Errorf("TestCloseSubs: failed to find sub log after closing sub")
+	}
+}


### PR DESCRIPTION
Noteworthy changes:

- `waLog.File()` returns a file logger using the arguments: 
  - `module` (string), just like the `Stdout()` logger
  - `filename` (string): output file
  - `reopen` (bool): should the logfile be reopened if an external script rotates it away
  - `append` (bool): overwrite or append new logs
- Literal strings like `"DEBUG"` are now constants
- The methods that a `Logger` interface must fulfill (`Errorf()`, `Debugf()` and friends) now return an error (which is non-nil if a logfile can't be reopened after disappearing)
- Common functionality between the loggers is now in helpers, like `shouldOutput()` (to prevent emitting when a log level is too low) or `timestamp()` (consistent time stamping in the `Stdout()` and `File()` loggers)
- The examples have been modified to show how logging to a file can be configured
- `util/log_test.go` is added.

Closes #244