### PR TITLE
Add `FromFullSync` field to appstate events.

### DIFF
--- a/appstate.go
+++ b/appstate.go
@@ -74,7 +74,7 @@ func (cli *Client) FetchAppState(name appstate.WAPatchName, fullSync, onlyIfNotS
 			}
 		}
 		for _, mutation := range mutations {
-			cli.dispatchAppState(mutation, !fullSync || cli.EmitAppStateEventsOnFullSync)
+			cli.dispatchAppState(mutation, fullSync, cli.EmitAppStateEventsOnFullSync)
 		}
 	}
 	if fullSync {
@@ -105,7 +105,10 @@ func (cli *Client) filterContacts(mutations []appstate.Mutation) ([]appstate.Mut
 	return filteredMutations, contacts
 }
 
-func (cli *Client) dispatchAppState(mutation appstate.Mutation, dispatchEvts bool) {
+func (cli *Client) dispatchAppState(mutation appstate.Mutation, fullSync bool, emitOnFullSync bool) {
+
+	dispatchEvts := !fullSync || emitOnFullSync
+
 	if mutation.Operation != waProto.SyncdMutation_SET {
 		return
 	}
@@ -125,7 +128,7 @@ func (cli *Client) dispatchAppState(mutation appstate.Mutation, dispatchEvts boo
 	switch mutation.Index[0] {
 	case "mute":
 		act := mutation.Action.GetMuteAction()
-		eventToDispatch = &events.Mute{JID: jid, Timestamp: ts, Action: act}
+		eventToDispatch = &events.Mute{JID: jid, Timestamp: ts, Action: act, FromFullSync: fullSync}
 		var mutedUntil time.Time
 		if act.GetMuted() {
 			mutedUntil = time.Unix(act.GetMuteEndTimestamp(), 0)
@@ -135,35 +138,36 @@ func (cli *Client) dispatchAppState(mutation appstate.Mutation, dispatchEvts boo
 		}
 	case "pin_v1":
 		act := mutation.Action.GetPinAction()
-		eventToDispatch = &events.Pin{JID: jid, Timestamp: ts, Action: act}
+		eventToDispatch = &events.Pin{JID: jid, Timestamp: ts, Action: act, FromFullSync: fullSync}
 		if cli.Store.ChatSettings != nil {
 			storeUpdateError = cli.Store.ChatSettings.PutPinned(jid, act.GetPinned())
 		}
 	case "archive":
 		act := mutation.Action.GetArchiveChatAction()
-		eventToDispatch = &events.Archive{JID: jid, Timestamp: ts, Action: act}
+		eventToDispatch = &events.Archive{JID: jid, Timestamp: ts, Action: act, FromFullSync: fullSync}
 		if cli.Store.ChatSettings != nil {
 			storeUpdateError = cli.Store.ChatSettings.PutArchived(jid, act.GetArchived())
 		}
 	case "contact":
 		act := mutation.Action.GetContactAction()
-		eventToDispatch = &events.Contact{JID: jid, Timestamp: ts, Action: act}
+		eventToDispatch = &events.Contact{JID: jid, Timestamp: ts, Action: act, FromFullSync: fullSync}
 		if cli.Store.Contacts != nil {
 			storeUpdateError = cli.Store.Contacts.PutContactName(jid, act.GetFirstName(), act.GetFullName())
 		}
 	case "deleteChat":
 		act := mutation.Action.GetDeleteChatAction()
-		eventToDispatch = &events.DeleteChat{JID: jid, Timestamp: ts, Action: act}
+		eventToDispatch = &events.DeleteChat{JID: jid, Timestamp: ts, Action: act, FromFullSync: fullSync}
 	case "star":
 		if len(mutation.Index) < 5 {
 			return
 		}
 		evt := events.Star{
-			ChatJID:   jid,
-			MessageID: mutation.Index[2],
-			Timestamp: ts,
-			Action:    mutation.Action.GetStarAction(),
-			IsFromMe:  mutation.Index[3] == "1",
+			ChatJID:      jid,
+			MessageID:    mutation.Index[2],
+			Timestamp:    ts,
+			Action:       mutation.Action.GetStarAction(),
+			IsFromMe:     mutation.Index[3] == "1",
+			FromFullSync: fullSync,
 		}
 		if mutation.Index[4] != "0" {
 			evt.SenderJID, _ = types.ParseJID(mutation.Index[4])
@@ -174,11 +178,12 @@ func (cli *Client) dispatchAppState(mutation appstate.Mutation, dispatchEvts boo
 			return
 		}
 		evt := events.DeleteForMe{
-			ChatJID:   jid,
-			MessageID: mutation.Index[2],
-			Timestamp: ts,
-			Action:    mutation.Action.GetDeleteMessageForMeAction(),
-			IsFromMe:  mutation.Index[3] == "1",
+			ChatJID:      jid,
+			MessageID:    mutation.Index[2],
+			Timestamp:    ts,
+			Action:       mutation.Action.GetDeleteMessageForMeAction(),
+			IsFromMe:     mutation.Index[3] == "1",
+			FromFullSync: fullSync,
 		}
 		if mutation.Index[4] != "0" {
 			evt.SenderJID, _ = types.ParseJID(mutation.Index[4])
@@ -186,19 +191,28 @@ func (cli *Client) dispatchAppState(mutation appstate.Mutation, dispatchEvts boo
 		eventToDispatch = &evt
 	case "markChatAsRead":
 		eventToDispatch = &events.MarkChatAsRead{
-			JID:       jid,
-			Timestamp: ts,
-			Action:    mutation.Action.GetMarkChatAsReadAction(),
+			JID:          jid,
+			Timestamp:    ts,
+			Action:       mutation.Action.GetMarkChatAsReadAction(),
+			FromFullSync: fullSync,
 		}
 	case "setting_pushName":
-		eventToDispatch = &events.PushNameSetting{Timestamp: ts, Action: mutation.Action.GetPushNameSetting()}
+		eventToDispatch = &events.PushNameSetting{
+			Timestamp:    ts,
+			Action:       mutation.Action.GetPushNameSetting(),
+			FromFullSync: fullSync,
+		}
 		cli.Store.PushName = mutation.Action.GetPushNameSetting().GetName()
 		err := cli.Store.Save()
 		if err != nil {
 			cli.Log.Errorf("Failed to save device store after updating push name: %v", err)
 		}
 	case "setting_unarchiveChats":
-		eventToDispatch = &events.UnarchiveChatsSetting{Timestamp: ts, Action: mutation.Action.GetUnarchiveChatsSetting()}
+		eventToDispatch = &events.UnarchiveChatsSetting{
+			Timestamp:    ts,
+			Action:       mutation.Action.GetUnarchiveChatsSetting(),
+			FromFullSync: fullSync,
+		}
 	}
 	if storeUpdateError != nil {
 		cli.Log.Errorf("Failed to update device store after app state mutation: %v", storeUpdateError)

--- a/types/events/appstate.go
+++ b/types/events/appstate.go
@@ -19,7 +19,8 @@ type Contact struct {
 	JID       types.JID // The contact who was modified.
 	Timestamp time.Time // The time when the modification happened.'
 
-	Action *waProto.ContactAction // The new contact info.
+	Action       *waProto.ContactAction // The new contact info.
+	FromFullSync bool                   // Whether the action is emitted because of a fullSync
 }
 
 // PushName is emitted when a message is received with a different push name than the previous value cached for the same user.
@@ -43,7 +44,8 @@ type Pin struct {
 	JID       types.JID // The chat which was pinned or unpinned.
 	Timestamp time.Time // The time when the (un)pinning happened.
 
-	Action *waProto.PinAction // Whether the chat is now pinned or not.
+	Action       *waProto.PinAction // Whether the chat is now pinned or not.
+	FromFullSync bool               // Whether the action is emitted because of a fullSync
 }
 
 // Star is emitted when a message is starred or unstarred from another device.
@@ -54,7 +56,8 @@ type Star struct {
 	MessageID string    // The message which was starred or unstarred.
 	Timestamp time.Time // The time when the (un)starring happened.
 
-	Action *waProto.StarAction // Whether the message is now starred or not.
+	Action       *waProto.StarAction // Whether the message is now starred or not.
+	FromFullSync bool                // Whether the action is emitted because of a fullSync
 }
 
 // DeleteForMe is emitted when a message is deleted (for the current user only) from another device.
@@ -65,7 +68,8 @@ type DeleteForMe struct {
 	MessageID string    // The message which was deleted.
 	Timestamp time.Time // The time when the deletion happened.
 
-	Action *waProto.DeleteMessageForMeAction // Additional information for the deletion.
+	Action       *waProto.DeleteMessageForMeAction // Additional information for the deletion.
+	FromFullSync bool                              // Whether the action is emitted because of a fullSync
 }
 
 // Mute is emitted when a chat is muted or unmuted from another device.
@@ -73,7 +77,8 @@ type Mute struct {
 	JID       types.JID // The chat which was muted or unmuted.
 	Timestamp time.Time // The time when the (un)muting happened.
 
-	Action *waProto.MuteAction // The current mute status of the chat.
+	Action       *waProto.MuteAction // The current mute status of the chat.
+	FromFullSync bool                // Whether the action is emitted because of a fullSync
 }
 
 // Archive is emitted when a chat is archived or unarchived from another device.
@@ -81,7 +86,8 @@ type Archive struct {
 	JID       types.JID // The chat which was archived or unarchived.
 	Timestamp time.Time // The time when the (un)archiving happened.
 
-	Action *waProto.ArchiveChatAction // The current archival status of the chat.
+	Action       *waProto.ArchiveChatAction // The current archival status of the chat.
+	FromFullSync bool                       // Whether the action is emitted because of a fullSync
 }
 
 // MarkChatAsRead is emitted when a whole chat is marked as read or unread from another device.
@@ -89,7 +95,8 @@ type MarkChatAsRead struct {
 	JID       types.JID // The chat which was marked as read or unread.
 	Timestamp time.Time // The time when the marking happened.
 
-	Action *waProto.MarkChatAsReadAction // Whether the chat was marked as read or unread, and info about the most recent messages.
+	Action       *waProto.MarkChatAsReadAction // Whether the chat was marked as read or unread, and info about the most recent messages.
+	FromFullSync bool                          // Whether the action is emitted because of a fullSync
 }
 
 // DeleteChat is emitted when a chat is deleted on another device.
@@ -97,21 +104,24 @@ type DeleteChat struct {
 	JID       types.JID // The chat which was deleted.
 	Timestamp time.Time // The time when the deletion happened.
 
-	Action *waProto.DeleteChatAction // Information about the deletion.
+	Action       *waProto.DeleteChatAction // Information about the deletion.
+	FromFullSync bool                      // Whether the action is emitted because of a fullSync
 }
 
 // PushNameSetting is emitted when the user's push name is changed from another device.
 type PushNameSetting struct {
 	Timestamp time.Time // The time when the push name was changed.
 
-	Action *waProto.PushNameSetting // The new push name for the user.
+	Action       *waProto.PushNameSetting // The new push name for the user.
+	FromFullSync bool                     // Whether the action is emitted because of a fullSync
 }
 
 // UnarchiveChatsSetting is emitted when the user changes the "Keep chats archived" setting from another device.
 type UnarchiveChatsSetting struct {
 	Timestamp time.Time // The time when the setting was changed.
 
-	Action *waProto.UnarchiveChatsSetting // The new settings.
+	Action       *waProto.UnarchiveChatsSetting // The new settings.
+	FromFullSync bool                           // Whether the action is emitted because of a fullSync
 }
 
 // AppState is emitted directly for new data received from app state syncing.


### PR DESCRIPTION
We can now determine whether, when `EmitAppStateEventsOnFullSync` is enabled, an event was only dispatched because of the `EmitAppStateEventsOnFullSync` flag.

Or, in other words, whether the event was part of a `fullSync`.