### PR TITLE
Support new `ClearChatAction`

### DIFF
--- a/appstate.go
+++ b/appstate.go
@@ -154,6 +154,9 @@ func (cli *Client) dispatchAppState(mutation appstate.Mutation, fullSync bool, e
 		if cli.Store.Contacts != nil {
 			storeUpdateError = cli.Store.Contacts.PutContactName(jid, act.GetFirstName(), act.GetFullName())
 		}
+	case appstate.IndexClearChat:
+		act := mutation.Action.GetClearChatAction()
+		eventToDispatch = &events.ClearChat{JID: jid, Timestamp: ts, Action: act, FromFullSync: fullSync}
 	case appstate.IndexDeleteChat:
 		act := mutation.Action.GetDeleteChatAction()
 		eventToDispatch = &events.DeleteChat{JID: jid, Timestamp: ts, Action: act, FromFullSync: fullSync}

--- a/appstate/keys.go
+++ b/appstate/keys.go
@@ -41,6 +41,7 @@ const (
 	IndexPin                   = "pin_v1"
 	IndexArchive               = "archive"
 	IndexContact               = "contact"
+	IndexClearChat             = "clearChat"
 	IndexDeleteChat            = "deleteChat"
 	IndexStar                  = "star"
 	IndexDeleteMessageForMe    = "deleteMessageForMe"

--- a/types/events/appstate.go
+++ b/types/events/appstate.go
@@ -99,6 +99,15 @@ type MarkChatAsRead struct {
 	FromFullSync bool                          // Whether the action is emitted because of a fullSync
 }
 
+// ClearChat is emitted when a chat is cleared on another device.
+type ClearChat struct {
+	JID       types.JID // The chat which was deleted.
+	Timestamp time.Time // The time when the deletion happened.
+
+	Action       *waProto.ClearChatAction // Information about the deletion.
+	FromFullSync bool                     // Whether the action is emitted because of a fullSync
+}
+
 // DeleteChat is emitted when a chat is deleted on another device.
 type DeleteChat struct {
 	JID       types.JID // The chat which was deleted.

--- a/types/events/appstate.go
+++ b/types/events/appstate.go
@@ -99,12 +99,12 @@ type MarkChatAsRead struct {
 	FromFullSync bool                          // Whether the action is emitted because of a fullSync
 }
 
-// ClearChat is emitted when a chat is cleared on another device.
+// ClearChat is emitted when a chat is cleared on another device. This is different from DeleteChat.
 type ClearChat struct {
-	JID       types.JID // The chat which was deleted.
-	Timestamp time.Time // The time when the deletion happened.
+	JID       types.JID // The chat which was cleared.
+	Timestamp time.Time // The time when the clear happened.
 
-	Action       *waProto.ClearChatAction // Information about the deletion.
+	Action       *waProto.ClearChatAction // Information about the clear.
 	FromFullSync bool                     // Whether the action is emitted because of a fullSync
 }
 


### PR DESCRIPTION
I am 99% confident that previously `ClearChatAction` either mapped to `DeleteChat` or to `DeleteMessageForMe` but it does not do that anymore on my phone. I found that it now triggers the literal `ClearChatAction` so I have added the required functionality for that.


You can test this PR by adding

```
	case *events.ClearChat:
		fmt.Println(evt)
		fmt.Println(evt.Action)
```

to the `handler` in the `mdtest/main.go`. In a group chat, send a few messages and then `Clear Chat`.

The output will contain the same messageID repeatedly but that's probably a server-side weirdness.