### PR TITLE
feat: handle message participants

### DIFF
--- a/group.go
+++ b/group.go
@@ -599,7 +599,7 @@ func parseParticipantList(node *waBinary.Node) (participants []types.JID) {
 	participants = make([]types.JID, 0, len(children))
 	for _, child := range children {
 		jid, ok := child.Attrs["jid"].(types.JID)
-		if child.Tag != "participant" || !ok {
+		if (child.Tag != "participant" && child.Tag != "to") || !ok {
 			continue
 		}
 		participants = append(participants, jid)

--- a/group_test.go
+++ b/group_test.go
@@ -1,0 +1,59 @@
+package whatsmeow
+
+import (
+	"testing"
+
+	"go.mau.fi/whatsmeow/binary"
+	"go.mau.fi/whatsmeow/types"
+)
+
+func TestParseparseParticipantListFromMessage(t *testing.T) {
+	/* Example message:
+
+	<message count="2" from="0000000000@broadcast" id="00000000000000000000000000000000" notify="Name"
+		participant="000000000000@s.whatsapp.net" t="0" type="text">
+		<participants>
+			<to eph_setting="X" jid="0000000001@s.whatsapp.net" />
+			<to eph_setting="Y" jid="0000000002@s.whatsapp.net" />
+		</participants>
+		<enc type="pkmsg" v="2"><!-- 165 bytes --></enc>
+		<enc type="skmsg" v="2"><!-- 154 bytes --></enc>
+	</message>
+	*/
+
+	firstParticipant := types.NewJID("0000000001", types.DefaultUserServer)
+	secondParticipant := types.NewJID("0000000002", types.DefaultUserServer)
+
+	node := &binary.Node{
+		Tag:   "participants",
+		Attrs: map[string]any{},
+		Content: []binary.Node{{
+			Tag: "to",
+			Attrs: map[string]any{
+				"eph_setting": "X",
+				"jid":         firstParticipant,
+			},
+			Content: nil,
+		}, {
+			Tag: "to",
+			Attrs: map[string]any{
+				"eph_setting": "Y",
+				"jid":         secondParticipant,
+			},
+			Content: nil,
+		}},
+	}
+
+	participants := parseParticipantList(node)
+	if actual := len(participants); actual != 2 {
+		t.Fatalf("len(participants), Expected %d, Actual %d", 2, actual)
+	}
+
+	if actual := participants[0]; actual != firstParticipant {
+		t.Fatalf("participants[0], Expected %s, Actual %s", firstParticipant, actual)
+	}
+
+	if actual := participants[1]; actual != secondParticipant {
+		t.Fatalf("participants[1], Expected %s, Actual %s", secondParticipant, actual)
+	}
+}

--- a/message.go
+++ b/message.go
@@ -114,6 +114,8 @@ func (cli *Client) parseMessageInfo(node *waBinary.Node) (*types.MessageInfo, er
 			if err != nil {
 				cli.Log.Warnf("Failed to parse verified_name node in %s: %v", info.ID, err)
 			}
+		} else if child.Tag == "participants" {
+			info.Participants = parseParticipantList(&child)
 		} else if mediaType, ok := child.AttrGetter().GetString("mediatype", false); ok {
 			info.MediaType = mediaType
 		}

--- a/types/message.go
+++ b/types/message.go
@@ -49,6 +49,8 @@ type MessageInfo struct {
 
 	VerifiedName   *VerifiedName
 	DeviceSentMeta *DeviceSentMeta // Metadata for direct messages sent from another one of the user's own devices.
+
+	Participants []JID
 }
 
 // SourceString returns a log-friendly representation of who sent the message and where.

--- a/user.go
+++ b/user.go
@@ -20,10 +20,12 @@ import (
 	"go.mau.fi/whatsmeow/types/events"
 )
 
-const BusinessMessageLinkPrefix = "https://wa.me/message/"
-const ContactQRLinkPrefix = "https://wa.me/qr/"
-const BusinessMessageLinkDirectPrefix = "https://api.whatsapp.com/message/"
-const ContactQRLinkDirectPrefix = "https://api.whatsapp.com/qr/"
+const (
+	BusinessMessageLinkPrefix       = "https://wa.me/message/"
+	ContactQRLinkPrefix             = "https://wa.me/qr/"
+	BusinessMessageLinkDirectPrefix = "https://api.whatsapp.com/message/"
+	ContactQRLinkDirectPrefix       = "https://api.whatsapp.com/qr/"
+)
 
 // ResolveBusinessMessageLink resolves a business message short link and returns the target JID, business name and
 // text to prefill in the input field (if any).

--- a/user.go
+++ b/user.go
@@ -20,12 +20,10 @@ import (
 	"go.mau.fi/whatsmeow/types/events"
 )
 
-const (
-	BusinessMessageLinkPrefix       = "https://wa.me/message/"
-	ContactQRLinkPrefix             = "https://wa.me/qr/"
-	BusinessMessageLinkDirectPrefix = "https://api.whatsapp.com/message/"
-	ContactQRLinkDirectPrefix       = "https://api.whatsapp.com/qr/"
-)
+const BusinessMessageLinkPrefix = "https://wa.me/message/"
+const ContactQRLinkPrefix = "https://wa.me/qr/"
+const BusinessMessageLinkDirectPrefix = "https://api.whatsapp.com/message/"
+const ContactQRLinkDirectPrefix = "https://api.whatsapp.com/qr/"
 
 // ResolveBusinessMessageLink resolves a business message short link and returns the target JID, business name and
 // text to prefill in the input field (if any).


### PR DESCRIPTION
Save recipients of broadcast messages to `types.MessageInfo`.

Manual test (all ids are replaced):

```json
{
    "Info": {
        "Chat": "000000000@broadcast",
        "Sender": "000000001@s.whatsapp.net",
        "IsFromMe": true,
        "IsGroup": false,
        "BroadcastListOwner": "",
        "ID": "00000000000000000000000000000000",
        "Type": "text",
        "PushName": "Maksym",
        "Timestamp": "2023-07-20T09:57:23+01:00",
        "Category": "",
        "Multicast": false,
        "MediaType": "",
        "VerifiedName": null,
        "DeviceSentMeta": null,
        "Participants": [
            "000000003@s.whatsapp.net",
            "000000002@s.whatsapp.net"
        ]
    },
    "Message": null,
    "IsEphemeral": false,
    "IsViewOnce": false,
    "IsViewOnceV2": false,
    "IsDocumentWithCaption": false,
    "IsEdit": false,
    "RawMessage": null
}
```