### PR TITLE
Added support to block/unblock contacts and receive block/unblock events

### DIFF
--- a/client.go
+++ b/client.go
@@ -105,6 +105,9 @@ type Client struct {
 	userDevicesCache           map[types.JID][]types.JID
 	userDevicesCacheLock       sync.Mutex
 
+	blockedContactsCache     map[types.JID]bool
+	blockedContactsCacheLock sync.Mutex
+
 	recentMessagesMap  map[recentMessageKey]*waProto.Message
 	recentMessagesList [recentMessagesSize]recentMessageKey
 	recentMessagesPtr  int
@@ -190,6 +193,8 @@ func NewClient(deviceStore *store.Device, log waLog.Logger) *Client {
 
 		groupParticipantsCache: make(map[types.JID][]types.JID),
 		userDevicesCache:       make(map[types.JID][]types.JID),
+
+		blockedContactsCache: make(map[types.JID]bool),
 
 		recentMessagesMap:      make(map[recentMessageKey]*waProto.Message, recentMessagesSize),
 		sessionRecreateHistory: make(map[types.JID]time.Time),

--- a/connectionevents.go
+++ b/connectionevents.go
@@ -138,6 +138,7 @@ func (cli *Client) handleConnectSuccess(node *waBinary.Node) {
 		if err != nil {
 			cli.Log.Warnf("Failed to send post-connect passive IQ: %v", err)
 		}
+		cli.GetAllBlockedContacts()
 		cli.dispatchEvent(&events.Connected{})
 		cli.closeSocketWaitChan()
 	}()

--- a/errors.go
+++ b/errors.go
@@ -106,6 +106,7 @@ var (
 	ErrUnknownServer            = errors.New("can't send message to unknown server")
 	ErrRecipientADJID           = errors.New("message recipient must be a user JID with no device part")
 	ErrServerReturnedError      = errors.New("server returned error")
+	ErrBlockedContact           = errors.New("contact is blocked")
 )
 
 type DownloadHTTPError struct {

--- a/mdtest/main.go
+++ b/mdtest/main.go
@@ -745,6 +745,47 @@ func handleCmd(cmd string, args []string) {
 		if err != nil {
 			log.Errorf("Error changing chat's pin state: %v", err)
 		}
+	case "listblocked":
+		blockedContacts, err := cli.GetAllBlockedContacts()
+		if err != nil {
+			log.Errorf("Failed to get blocked contacts list: %v", err)
+		} else {
+			for _, blockedContact := range blockedContacts {
+				log.Infof("%+v", blockedContact)
+			}
+		}
+	case "block":
+		if len(args) < 1 {
+			log.Errorf("Usage: block <jid>")
+			return
+		}
+		target, ok := parseJID(args[0])
+		if !ok {
+			return
+		}
+
+		blockedList, err := cli.BlockContact(target)
+		if err != nil {
+			log.Errorf("Error blocking contact: %v", err)
+		}
+
+		log.Infof("%+v", blockedList)
+	case "unblock":
+		if len(args) < 1 {
+			log.Errorf("Usage: unblock <jid>")
+			return
+		}
+		target, ok := parseJID(args[0])
+		if !ok {
+			return
+		}
+
+		blockedList, err := cli.UnblockContact(target)
+		if err != nil {
+			log.Errorf("Error unblocking contact: %v", err)
+		}
+
+		log.Infof("%+v", blockedList)
 	}
 }
 
@@ -876,5 +917,7 @@ func handler(rawEvt interface{}) {
 		log.Debugf("Keepalive timeout event: %+v", evt)
 	case *events.KeepAliveRestored:
 		log.Debugf("Keepalive restored")
+	case *events.ContactBlockedStatusChange:
+		log.Infof("ContactBlockedStatusChange event: %+v", evt)
 	}
 }

--- a/send.go
+++ b/send.go
@@ -145,6 +145,14 @@ func (cli *Client) SendMessage(ctx context.Context, to types.JID, message *waPro
 		return
 	}
 
+	cli.blockedContactsCacheLock.Lock()
+	_, isBlockedContact := cli.blockedContactsCache[to]
+	cli.blockedContactsCacheLock.Unlock()
+	if isBlockedContact {
+		err = ErrBlockedContact
+		return
+	}
+
 	if len(req.ID) == 0 {
 		req.ID = cli.GenerateMessageID()
 	}

--- a/types/events/events.go
+++ b/types/events/events.go
@@ -460,3 +460,11 @@ type MediaRetry struct {
 	SenderID  types.JID       // The user who sent the message. Only present in groups.
 	FromMe    bool            // Whether the message was sent by the current user or someone else.
 }
+
+// ContactBlockedStatusChange is emitted when the contact blocked status change is received.
+type ContactBlockedStatusChange struct {
+	// The user whose blocked state change event this is
+	From types.JID
+	// True if the user is blocked
+	Blocked bool
+}

--- a/user.go
+++ b/user.go
@@ -517,3 +517,90 @@ func (cli *Client) usync(ctx context.Context, jids []types.JID, mode, context st
 		return &list, err
 	}
 }
+
+// cacheBlockedContacts sync the cache with blocked contacts
+func (cli *Client) cacheBlockedContacts(blockedContactsResp *waBinary.Node) []types.JID {
+	blockedContacts := []types.JID{}
+	if blockedList, ok := blockedContactsResp.GetOptionalChildByTag("list"); ok {
+		cli.blockedContactsCacheLock.Lock()
+		defer cli.blockedContactsCacheLock.Unlock()
+		cli.blockedContactsCache = make(map[types.JID]bool)
+		for _, child := range blockedList.GetChildren() {
+			ag := child.AttrGetter()
+			blockedJID := ag.JID("jid")
+			if !ag.OK() {
+				cli.Log.Debugf("Ignoring contact blocked data with unexpected attributes: %v", ag.Error())
+				continue
+			}
+
+			cli.blockedContactsCache[blockedJID] = true
+			blockedContacts = append(blockedContacts, blockedJID)
+		}
+	}
+
+	return blockedContacts
+}
+
+// GetAllBlockedContacts gets all the contacts that was blocked on connected Whatsapp user phone
+func (cli *Client) GetAllBlockedContacts() ([]types.JID, error) {
+	resp, err := cli.sendIQ(infoQuery{
+		Namespace: "blocklist",
+		Type:      iqGet,
+		To:        types.ServerJID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	blockedContacts := cli.cacheBlockedContacts(resp)
+
+	return blockedContacts, nil
+}
+
+// setContactBlockedStatus updates the contact blocked status
+func (cli *Client) setContactBlockedStatus(user types.JID, block bool) ([]types.JID, error) {
+	blockAction := "unblock"
+	if block {
+		blockAction = "block"
+	}
+
+	resp, err := cli.sendIQ(infoQuery{
+		Namespace: "blocklist",
+		Type:      iqSet,
+		To:        types.ServerJID,
+		Content: []waBinary.Node{{
+			Tag: "item",
+			Attrs: waBinary.Attrs{
+				"action": blockAction,
+				"jid":    user,
+			},
+		}},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	blockedContacts := cli.cacheBlockedContacts(resp)
+
+	return blockedContacts, nil
+}
+
+// BlockContact updates the contact blocked status to true
+func (cli *Client) BlockContact(user types.JID) ([]types.JID, error) {
+	blockedList, err := cli.setContactBlockedStatus(user, true)
+	if err != nil {
+		return nil, err
+	}
+
+	return blockedList, nil
+}
+
+// UnblockContact updates the contact blocked status to false
+func (cli *Client) UnblockContact(user types.JID) ([]types.JID, error) {
+	blockedList, err := cli.setContactBlockedStatus(user, false)
+	if err != nil {
+		return nil, err
+	}
+
+	return blockedList, nil
+}


### PR DESCRIPTION
# Block/Unblock support
Added support to block/unblock contacts and receive block/unblock events

## Changes:

> connectionevents.go
- Sync at local cache the blocked list when successfully connect

> mdtest/main.go
- Included commands to test the block/unblock feature:
-- listblocked: get the blocked list from whatsapp
-- block: block contact
-- unblock: unblock contact

- Included contact blocked status changed event listener

> send.go
- Included validation at SendMessage function if the contact is blocked to not send message for a blocked contact

> notification.go
- Included function to handle the whatsapp block/unblock event changes

> types/events/events.go
- Created the contact blocked status changed event type definition

> user.go
-  Created necessary functions to allow cache, block and unblock contacts


## Notes:
> we are using this version at production environment with more than 400 whatsapps connected and all works fine

> this feature was already tested and works fine at:
- iphone business
- iphone normal
- android business
- android normal
