### PR TITLE
Fixed 405 error when send list message

### DIFF
--- a/mdtest/main.go
+++ b/mdtest/main.go
@@ -745,6 +745,43 @@ func handleCmd(cmd string, args []string) {
 		if err != nil {
 			log.Errorf("Error changing chat's pin state: %v", err)
 		}
+	case "sendlist":
+		if len(args) < 1 {
+			log.Errorf("Usage: sendlist <jid>")
+			return
+		}
+		recipient, ok := parseJID(args[0])
+		if !ok {
+			return
+		}
+		msg := &waProto.Message{
+			ListMessage: &waProto.ListMessage{
+				Description: proto.String("Description"),
+				ButtonText:  proto.String("ButtonText"),
+				ListType:    waProto.ListMessage_SINGLE_SELECT.Enum(),
+				Sections: []*waProto.ListMessage_Section{
+					{
+						Title: proto.String(""),
+						Rows: []*waProto.ListMessage_Row{
+							{
+								Title: proto.String("Row 1 title"),
+								RowId: proto.String("Row1"),
+							},
+							{
+								Title: proto.String("Row 2 title"),
+								RowId: proto.String("Row2"),
+							},
+						},
+					},
+				},
+			},
+		}
+		resp, err := cli.SendMessage(context.Background(), recipient, msg)
+		if err != nil {
+			log.Errorf("Error sending message: %v", err)
+		} else {
+			log.Infof("Message sent (server timestamp: %s)", resp.Timestamp)
+		}
 	}
 }
 

--- a/send.go
+++ b/send.go
@@ -644,8 +644,9 @@ func getButtonAttributes(msg *waProto.Message) waBinary.Attrs {
 		return waBinary.Attrs{}
 	case msg.ListMessage != nil:
 		return waBinary.Attrs{
-			"v":    "2",
-			"type": strings.ToLower(waProto.ListMessage_ListType_name[int32(msg.ListMessage.GetListType())]),
+			"v": "2",
+			// Force list message sent as product_list instead of single_select
+			"type": strings.ToLower(waProto.ListMessage_ListType_name[int32(*waProto.ListMessage_PRODUCT_LIST.Enum())]),
 		}
 	default:
 		return waBinary.Attrs{}


### PR DESCRIPTION
# Send List Message
Fixed 405 error when send list message

## Changes:

> mdtest/main.go
- Included command (sendlist) to test the send list feature

> send.go: 
-  Changed at getButtonAttributes function the type forcing to use product_list instead of single_select for ListMessages.


## Notes:
> we are using this version at production environment with more than 400 whatsapps connected and all works fine

> this feature was already tested and works fine at:
- iphone business
- iphone normal
- android business
- android normal