### PR TITLE
Add missing call event types

### DIFF
--- a/call.go
+++ b/call.go
@@ -59,6 +59,24 @@ func (cli *Client) handleCallEvent(node *waBinary.Node) {
 			},
 			Data: &child,
 		})
+	case "preaccept":
+		cli.dispatchEvent(&events.CallPreAccept{
+			BasicCallMeta: basicMeta,
+			CallRemoteMeta: types.CallRemoteMeta{
+				RemotePlatform: ag.String("platform"),
+				RemoteVersion:  ag.String("version"),
+			},
+			Data: &child,
+		})
+	case "transport":
+		cli.dispatchEvent(&events.CallTransport{
+			BasicCallMeta: basicMeta,
+			CallRemoteMeta: types.CallRemoteMeta{
+				RemotePlatform: ag.String("platform"),
+				RemoteVersion:  ag.String("version"),
+			},
+			Data: &child,
+		})
 	case "terminate":
 		cli.dispatchEvent(&events.CallTerminate{
 			BasicCallMeta: basicMeta,

--- a/internals.go
+++ b/internals.go
@@ -80,3 +80,7 @@ func (int *DangerousInternalClient) GetOwnID() types.JID {
 func (int *DangerousInternalClient) DecryptDM(child *waBinary.Node, from types.JID, isPreKey bool) ([]byte, error) {
 	return int.c.decryptDM(child, from, isPreKey)
 }
+
+func (int *DangerousInternalClient) MakeDeviceIdentityNode() waBinary.Node {
+	return int.c.makeDeviceIdentityNode()
+}

--- a/internals.go
+++ b/internals.go
@@ -9,6 +9,8 @@ package whatsmeow
 import (
 	"context"
 
+	"go.mau.fi/libsignal/keys/prekey"
+
 	waBinary "go.mau.fi/whatsmeow/binary"
 	"go.mau.fi/whatsmeow/types"
 )
@@ -65,4 +67,16 @@ func (int *DangerousInternalClient) RequestAppStateKeys(ctx context.Context, key
 
 func (int *DangerousInternalClient) SendRetryReceipt(node *waBinary.Node, info *types.MessageInfo, forceIncludeIdentity bool) {
 	int.c.sendRetryReceipt(node, info, forceIncludeIdentity)
+}
+
+func (int *DangerousInternalClient) EncryptMessageForDevice(plaintext []byte, to types.JID, bundle *prekey.Bundle, extraAttrs waBinary.Attrs) (*waBinary.Node, bool, error) {
+	return int.c.encryptMessageForDevice(plaintext, to, bundle, extraAttrs)
+}
+
+func (int *DangerousInternalClient) GetOwnID() types.JID {
+	return int.c.getOwnID()
+}
+
+func (int *DangerousInternalClient) DecryptDM(child *waBinary.Node, from types.JID, isPreKey bool) ([]byte, error) {
+	return int.c.decryptDM(child, from, isPreKey)
 }

--- a/types/events/call.go
+++ b/types/events/call.go
@@ -27,6 +27,20 @@ type CallAccept struct {
 	Data *waBinary.Node
 }
 
+type CallPreAccept struct {
+	types.BasicCallMeta
+	types.CallRemoteMeta
+
+	Data *waBinary.Node
+}
+
+type CallTransport struct {
+	types.BasicCallMeta
+	types.CallRemoteMeta
+
+	Data *waBinary.Node
+}
+
 // CallOfferNotice is emitted when the user receives a notice of a call on WhatsApp.
 // This seems to be primarily for group calls (whereas CallOffer is for 1:1 calls).
 type CallOfferNotice struct {


### PR DESCRIPTION
This PR adds two call event types (`CallPreAccept`, `CallTransport`) that wasn't handled previously.

Also exposed some extra internal methods through `DangerousInternalClient`.