### PR TITLE
Optimize downloadMedia

### DIFF
--- a/download.go
+++ b/download.go
@@ -7,6 +7,7 @@
 package whatsmeow
 
 import (
+	"bytes"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
@@ -303,7 +304,9 @@ func (cli *Client) downloadMedia(url string) ([]byte, error) {
 	if resp.StatusCode != http.StatusOK {
 		return nil, DownloadHTTPError{Response: resp}
 	}
-	return io.ReadAll(resp.Body)
+	buf := &bytes.Buffer{}
+	_, err = io.Copy(buf, resp.Body)
+	return buf.Bytes(), err
 }
 
 func (cli *Client) downloadEncryptedMedia(url string, checksum []byte) (file, mac []byte, err error) {


### PR DESCRIPTION
I had the same problem as described on #384

This pull request introduces a significant optimization in a specific function of the code. I replaced the usage of io.ReadAll with io.Copy to improve memory efficiency.

In my tests, I used a document of 10Mb using the `go tool pprof` to get this.

Before this change:
![image](https://github.com/tulir/whatsmeow/assets/14109192/5aa3eec1-f5ae-4989-bbb5-d33ef604830a)

After this change:
![image](https://github.com/tulir/whatsmeow/assets/14109192/bc680f39-2320-4fb2-b88a-82c865a4897d)

This change aims to optimize memory consumption when processing large amounts of data. Additionally, I included examples of using go tool pprof to demonstrate performance improvements.

