### PR TITLE
Add support cloudsql-postgres dialect during db upgrade

### DIFF
--- a/store/sqlstore/upgrade.go
+++ b/store/sqlstore/upgrade.go
@@ -9,6 +9,7 @@ package sqlstore
 import (
 	"database/sql"
 	"fmt"
+	"strings"
 )
 
 type upgradeFunc func(*sql.Tx, *Container) error
@@ -250,7 +251,7 @@ func upgradeV2(tx *sql.Tx, container *Container) error {
 	if err != nil {
 		return err
 	}
-	if container.dialect == "postgres" || container.dialect == "pgx" {
+	if strings.Contains(container.dialect, "postgres") || container.dialect == "pgx" {
 		_, err = tx.Exec(fillSigKeyPostgres)
 	} else {
 		_, err = tx.Exec(fillSigKeySQLite)


### PR DESCRIPTION
The container fails to upgrade database for `cloudsql-postgres` dialect. Same error as #182 