### PR TITLE
Fix for GetDevice Function to Properly Utilize 'types.JID'

### DIFF
--- a/store/sqlstore/container.go
+++ b/store/sqlstore/container.go
@@ -176,8 +176,10 @@ func (c *Container) GetFirstDevice() (*store.Device, error) {
 // If the device is not found, nil is returned instead.
 //
 // Note that the parameter usually must be an AD-JID.
+//
+// Ex.: deviceStore, err := container.GetDevice(types.JID{User: "553199999999:11@s.whatsapp.net"})
 func (c *Container) GetDevice(jid types.JID) (*store.Device, error) {
-	sess, err := c.scanDevice(c.db.QueryRow(getDeviceQuery, jid))
+	sess, err := c.scanDevice(c.db.QueryRow(getDeviceQuery, jid.User))
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}


### PR DESCRIPTION
**Description:**
This pull request addresses an issue in the `GetDevice` function of the `Container`, where it previously failed by directly accessing the `types.JID` struct. This led to the function erroneously returning `nil` due to a type mismatch in the SQL query.

**Changes:**
- The function has been corrected to use `jid.User` (a string) instead of the full `jid` struct in the `c.db.QueryRow(getDeviceQuery, jid.User)` call. 
- This change ensures that the SQL query executes correctly, avoiding the issue of incorrect type handling.

**Benefits:**
- The fix increases the robustness of the function, ensuring it behaves as expected when dealing with different data types.
- It improves code readability and maintainability, simplifying future updates or bug fixes.

**Example Usage:**
- The corrected function can be called as follows:
  ```go
  deviceStore, err := container.GetDevice(types.JID{User: "553199999999:11@s.whatsapp.net"})
  ```
- This ensures that the `GetDevice` function handles the data efficiently and correctly, respecting the expected format for the SQL query.