### PR TITLE
Improving the way app.js script is searched

### DIFF
--- a/binary/proto/extract/index.js
+++ b/binary/proto/extract/index.js
@@ -18,9 +18,23 @@ async function findAppModules(mods) {
         }
     }
     const baseURL = "https://web.whatsapp.com"
-    const index = await request.get(baseURL, ua)
-    const appID = index.match(/src="\/app.([0-9a-z]{10,}).js"/)[1]
-    const appURL = baseURL + "/app." + appID + ".js"
+    const serviceworker = await request.get(`${baseURL}/serviceworker.js`, ua)
+    const versions = [...serviceworker.matchAll(/assets-manifest-([\d\.]+).json/g)].map(r => r[1])
+    const version = versions[0]
+
+    let appURL = ''
+    if(version) {
+        const asset = await request.get(`${baseURL}/assets-manifest-${version}.json`, ua)
+        const hashFiles = JSON.parse(asset)
+        const files = Object.keys(hashFiles)
+        const app = files.find(f => /^app\./.test(f))
+        appURL = `${baseURL}/${app}`
+    } else {
+        const index = await request.get(baseURL, ua)
+        const appID = index.match(/src="\/app.([0-9a-z]{10,}).js"/)[1]
+        appURL = baseURL + '/app.' + appID + '.js'
+    }
+
     console.error("Found app.js URL:", appURL)
     const qrData = await request.get(appURL, ua)
     const waVersion = qrData.match(/VERSION_BASE="(\d\.\d+\.\d+)"/)[1]


### PR DESCRIPTION
The last script failed to find app.js because app.js is not directly loaded in the main page.

```log
/~/Dev/whatsmeow/binary/proto/extract/index.js:22
    const appID = index.match(/src="\/app.([0-9a-z]{10,}).js"/)[1]
                                                               ^

TypeError: Cannot read properties of null (reading '1')
    at findAppModules (/~/Dev/whatsmeow/binary/proto/extract/index.js:22:64)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async /~/Dev/whatsmeow/binary/proto/extract/index.js:74:29

Node.js v18.19.0
```