### PR TITLE
Fix panic invalid memory address or nil pointer dereference in privacysettings.go

### DIFF
--- a/privacysettings.go
+++ b/privacysettings.go
@@ -158,6 +158,7 @@ func (cli *Client) handlePrivacySettingsNotification(privacyNode *waBinary.Node)
 	settings, err := cli.TryFetchPrivacySettings(false)
 	if err != nil {
 		cli.Log.Errorf("Failed to fetch privacy settings when handling change: %v", err)
+		return
 	}
 	evt := cli.parsePrivacySettings(privacyNode, settings)
 	// The data isn't be reliable if the fetch failed, so only cache if it didn't fail


### PR DESCRIPTION
I encountered a panic

```
{"level":"error","message":"Failed to fetch privacy settings when handling change: [websocket disconnected before info query returned response]","time":"2024-04-29T14:07:33Z","wacId":"01fff71b-7938-4627-bf93-102ee3794b41"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x48 pc=0x9911fe]

goroutine 1685089 [running]:
go.mau.fi/whatsmeow.(*Client).parsePrivacySettings(0xc067f12000?, 0xc05f86ff88, 0x0)
	go.mau.fi/whatsmeow@v0.0.0-20231104103606-23bd57d939ca/privacysettings.go:140 +0x3be
go.mau.fi/whatsmeow.(*Client).handlePrivacySettingsNotification(0xc067f12000, 0xc0bd0d1f10?)
	go.mau.fi/whatsmeow@v0.0.0-20231104103606-23bd57d939ca/privacysettings.go:159 +0xfa
go.mau.fi/whatsmeow.(*Client).handleAccountSyncNotification(0xc067f12000, 0xc02a112090)
	go.mau.fi/whatsmeow@v0.0.0-20231104103606-23bd57d939ca/notification.go:199 +0x395
created by go.mau.fi/whatsmeow.(*Client).handleNotification
	go.mau.fi/whatsmeow@v0.0.0-20231104103606-23bd57d939ca/notification.go:361 +0x69d
```

We got nil and error from `cli.TryFetchPrivacySettings()`. Error is logged, but then we go to `cli.parsePrivacySettings()` and pass the arguments `*waBinary.Node` and (!!!) `nil`.

This will result in an panic in most cases.