### PR TITLE
corrected count for writeListStart

### DIFF
--- a/binary/encoder.go
+++ b/binary/encoder.go
@@ -206,14 +206,14 @@ func (w *binaryEncoder) countAttributes(attributes Attrs) int {
 		return 0
 	}
 
-    var count = 0
+	var count = 0
 	for _, val := range attributes {
 		if val == "" || val == nil {
 			continue
 		}
-        count += 1
+		count += 1
 	}
-    return count
+	return count
 }
 
 func (w *binaryEncoder) writeListStart(listSize int) {

--- a/binary/encoder.go
+++ b/binary/encoder.go
@@ -187,10 +187,6 @@ func (w *binaryEncoder) writeJID(jid types.JID) {
 }
 
 func (w *binaryEncoder) writeAttributes(attributes Attrs) {
-	if attributes == nil {
-		return
-	}
-
 	for key, val := range attributes {
 		if val == "" || val == nil {
 			continue
@@ -201,19 +197,14 @@ func (w *binaryEncoder) writeAttributes(attributes Attrs) {
 	}
 }
 
-func (w *binaryEncoder) countAttributes(attributes Attrs) int {
-	if attributes == nil {
-		return 0
-	}
-
-	var count = 0
+func (w *binaryEncoder) countAttributes(attributes Attrs) (count int) {
 	for _, val := range attributes {
 		if val == "" || val == nil {
 			continue
 		}
 		count += 1
 	}
-	return count
+	return
 }
 
 func (w *binaryEncoder) writeListStart(listSize int) {

--- a/binary/encoder.go
+++ b/binary/encoder.go
@@ -90,7 +90,7 @@ func (w *binaryEncoder) writeNode(n Node) {
 		hasContent = 1
 	}
 
-	w.writeListStart(2*len(n.Attrs) + tagSize + hasContent)
+	w.writeListStart(2*w.countAttributes(n.Attrs) + tagSize + hasContent)
 	w.writeString(n.Tag)
 	w.writeAttributes(n.Attrs)
 	if n.Content != nil {
@@ -199,6 +199,21 @@ func (w *binaryEncoder) writeAttributes(attributes Attrs) {
 		w.writeString(key)
 		w.write(val)
 	}
+}
+
+func (w *binaryEncoder) countAttributes(attributes Attrs) int {
+	if attributes == nil {
+		return 0
+	}
+
+    var count = 0
+	for _, val := range attributes {
+		if val == "" || val == nil {
+			continue
+		}
+        count += 1
+	}
+    return count
 }
 
 func (w *binaryEncoder) writeListStart(listSize int) {


### PR DESCRIPTION
writeAttributes omits empty items,  but the list size was still set to the full length of `Attrs`.
added countAttributes  to count the non-empty Attributes.

This solves some protocol errors.
