### PR TITLE
add MessageID on NewsletterMessage

### DIFF
--- a/notification.go
+++ b/notification.go
@@ -274,6 +274,7 @@ func (cli *Client) parseNewsletterMessages(node *waBinary.Node) []*types.Newslet
 		}
 		msg := types.NewsletterMessage{
 			MessageServerID: child.AttrGetter().Int("server_id"),
+			MessageID:       child.AttrGetter().String("id"),
 			ViewsCount:      0,
 			ReactionCounts:  nil,
 		}

--- a/notification.go
+++ b/notification.go
@@ -9,6 +9,7 @@ package whatsmeow
 import (
 	"encoding/json"
 	"errors"
+	"time"
 
 	"google.golang.org/protobuf/proto"
 
@@ -275,6 +276,7 @@ func (cli *Client) parseNewsletterMessages(node *waBinary.Node) []*types.Newslet
 		msg := types.NewsletterMessage{
 			MessageServerID: child.AttrGetter().Int("server_id"),
 			MessageID:       child.AttrGetter().String("id"),
+			TimeStamp:       time.Unix(child.AttrGetter().Int64("t"), 0),
 			ViewsCount:      0,
 			ReactionCounts:  nil,
 		}

--- a/types/newsletter.go
+++ b/types/newsletter.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"go.mau.fi/util/jsontime"
 
@@ -149,6 +150,7 @@ type NewsletterText struct {
 type NewsletterMessage struct {
 	MessageServerID MessageServerID
 	MessageID       MessageID
+	TimeStamp       time.Time
 	ViewsCount      int
 	ReactionCounts  map[string]int
 

--- a/types/newsletter.go
+++ b/types/newsletter.go
@@ -148,6 +148,7 @@ type NewsletterText struct {
 
 type NewsletterMessage struct {
 	MessageServerID MessageServerID
+	MessageID       MessageID
 	ViewsCount      int
 	ReactionCounts  map[string]int
 


### PR DESCRIPTION
## Commit Description:

**Add `MessageID` to `NewsletterMessage` struct**

This commit introduces the addition of the `MessageID` field to the `NewsletterMessage` struct. Previously, the struct only contained `MessageServerID`, `ViewsCount`, and `ReactionCounts`, without a unique identifier for the message itself. By adding the `MessageID`, each instance of `NewsletterMessage` can now store a unique message ID for better referencing.

### Key changes:
- Added a `MessageID` field of type `MessageID` to the `NewsletterMessage` struct.
- Updated the initialization of the `NewsletterMessage` struct in the relevant code, now retrieving the `MessageID` value from the `"id"` attribute in the source data.

With this change, it's now easier to identify and manage relevant messages, both for data retrieval and live message updates.
