### PR TITLE
add MessageID and TimeStamp on NewsletterMessage 

### DIFF
--- a/notification.go
+++ b/notification.go
@@ -274,6 +274,7 @@ func (cli *Client) parseNewsletterMessages(node *waBinary.Node) []*types.Newslet
 		}
 		msg := types.NewsletterMessage{
 			MessageServerID: child.AttrGetter().Int("server_id"),
+			MessageID:       child.AttrGetter().String("id"),
 			ViewsCount:      0,
 			ReactionCounts:  nil,
 		}

--- a/notification.go
+++ b/notification.go
@@ -9,6 +9,7 @@ package whatsmeow
 import (
 	"encoding/json"
 	"errors"
+	"time"
 
 	"google.golang.org/protobuf/proto"
 
@@ -275,6 +276,7 @@ func (cli *Client) parseNewsletterMessages(node *waBinary.Node) []*types.Newslet
 		msg := types.NewsletterMessage{
 			MessageServerID: child.AttrGetter().Int("server_id"),
 			MessageID:       child.AttrGetter().String("id"),
+			TimeStamp:       time.Unix(child.AttrGetter().Int64("t"), 0),
 			ViewsCount:      0,
 			ReactionCounts:  nil,
 		}

--- a/types/newsletter.go
+++ b/types/newsletter.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"go.mau.fi/util/jsontime"
 
@@ -149,6 +150,7 @@ type NewsletterText struct {
 type NewsletterMessage struct {
 	MessageServerID MessageServerID
 	MessageID       MessageID
+	TimeStamp       time.Time
 	ViewsCount      int
 	ReactionCounts  map[string]int
 

--- a/types/newsletter.go
+++ b/types/newsletter.go
@@ -148,6 +148,7 @@ type NewsletterText struct {
 
 type NewsletterMessage struct {
 	MessageServerID MessageServerID
+	MessageID       MessageID
 	ViewsCount      int
 	ReactionCounts  map[string]int
 


### PR DESCRIPTION
# Add `MessageID` and `TimeStamp` to `NewsletterMessage` struct

## Summary
This pull request introduces the `MessageID` and `TimeStamp` fields into the `NewsletterMessage` struct. The new fields are essential for capturing the message's unique identifier and timestamp, ensuring better tracking and management of the newsletter messages.

## Changes
- Added `MessageID` field of type `MessageID` to the `NewsletterMessage` struct.
- Added `TimeStamp` field of type `time.Time` to the `NewsletterMessage` struct.
- Updated the creation of `NewsletterMessage` instances to include these new fields, using the `id` and `t` attributes respectively.