### PR TITLE
Don't log 1006 error

### DIFF
--- a/socket/framesocket.go
+++ b/socket/framesocket.go
@@ -223,7 +223,9 @@ func (fs *FrameSocket) readPump(conn *websocket.Conn, ctx context.Context) {
 		if err != nil {
 			// Ignore the error if the context has been closed
 			if !errors.Is(ctx.Err(), context.Canceled) {
-				fs.log.Errorf("Error reading from websocket: %v", err)
+				if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
+					fs.log.Errorf("Error reading from websocket: %v", err)
+				}
 			}
 			return
 		} else if msgType != websocket.BinaryMessage {


### PR DESCRIPTION
I keep receiving 
Error reading from websocket: websocket: close 1006 (abnormal closure): unexpected EOF

I think logging this as an error is a mistake


https://github.com/gorilla/websocket/blob/b65e62901fc1c0d968042419e74789f6af455eb9/examples/chat/client.go#L65-L71