### PR TITLE
feat: add requested at in group participants request

### DIFF
--- a/group.go
+++ b/group.go
@@ -176,7 +176,7 @@ func (cli *Client) UpdateGroupParticipants(jid types.JID, participantChanges []t
 }
 
 // GetGroupRequestParticipants gets the list of participants that have requested to join the group.
-func (cli *Client) GetGroupRequestParticipants(jid types.JID) ([]types.JID, error) {
+func (cli *Client) GetGroupRequestParticipants(jid types.JID) ([]types.GroupParticipantRequest, error) {
 	resp, err := cli.sendGroupIQ(context.TODO(), iqGet, jid, waBinary.Node{
 		Tag: "membership_approval_requests",
 	})
@@ -188,9 +188,12 @@ func (cli *Client) GetGroupRequestParticipants(jid types.JID) ([]types.JID, erro
 		return nil, &ElementMissingError{Tag: "membership_approval_requests", In: "response to group request participants query"}
 	}
 	requestParticipants := request.GetChildrenByTag("membership_approval_request")
-	participants := make([]types.JID, len(requestParticipants))
+	participants := make([]types.GroupParticipantRequest, len(requestParticipants))
 	for i, req := range requestParticipants {
-		participants[i] = req.AttrGetter().JID("jid")
+		participants[i] = types.GroupParticipantRequest{
+			JID:         req.AttrGetter().JID("jid"),
+			RequestedAt: req.AttrGetter().UnixTime("request_time"),
+		}
 	}
 	return participants, nil
 }

--- a/types/group.go
+++ b/types/group.go
@@ -148,3 +148,8 @@ type GroupLinkChange struct {
 	UnlinkReason GroupUnlinkReason
 	Group        GroupLinkTarget
 }
+
+type GroupParticipantRequest struct {
+	JID         JID
+	RequestedAt time.Time
+}


### PR DESCRIPTION
# Return new Struct in GetGroupRequestParticipants

## Summary
This pull request introduces a new struct for wrap the response of the method GetGroupRequestParticipants(), that was made because i needed to get the date when the request was sent along with the JID.

## Changes
- Added new GroupParticipantRequest
- Changed the return type of GetGroupRequestParticipants from JID to the new struct
- Parsed the filed request_time from the request to the new response struct

**That change will introduce a braking change**