### PR TITLE
events: add constant for fb 418 error code

### DIFF
--- a/types/events/events.go
+++ b/types/events/events.go
@@ -174,6 +174,9 @@ const (
 	ConnectFailureCATInvalid ConnectFailureReason = 414
 	ConnectFailureNotFound   ConnectFailureReason = 415
 
+	// Status code unknown (not in WA web)
+	ConnectFailureClientUnknown ConnectFailureReason = 418
+
 	ConnectFailureInternalServerError ConnectFailureReason = 500
 	ConnectFailureExperimental        ConnectFailureReason = 501
 	ConnectFailureServiceUnavailable  ConnectFailureReason = 503


### PR DESCRIPTION
This is under the assumption that 418 is basically 401 for Meta accounts using WhatsApp (messenger, instagram).