### PR TITLE
chore: Add SendMexIQ to DangerousInternals

### DIFF
--- a/internals.go
+++ b/internals.go
@@ -8,6 +8,7 @@ package whatsmeow
 
 import (
 	"context"
+	"encoding/json"
 
 	"go.mau.fi/libsignal/keys/prekey"
 
@@ -35,6 +36,10 @@ func (int *DangerousInternalClient) SendIQ(query DangerousInfoQuery) (*waBinary.
 
 func (int *DangerousInternalClient) SendIQAsync(query DangerousInfoQuery) (<-chan *waBinary.Node, error) {
 	return int.c.sendIQAsync(query)
+}
+
+func (int *DangerousInternalClient) SendMexIQ(ctx context.Context, queryID string, variables any) (json.RawMessage, error) {
+	return int.c.sendMexIQ(ctx, queryID, variables)
 }
 
 func (int *DangerousInternalClient) SendNode(node waBinary.Node) error {


### PR DESCRIPTION
We can achieve it by using `SendIQ`, but `SendMexIQ` is a very useful shortcut