### PR TITLE
Fix: revoke newsletter message

### DIFF
--- a/send.go
+++ b/send.go
@@ -588,8 +588,10 @@ func (cli *Client) sendNewsletter(to types.JID, id types.MessageID, message *waE
 		Content: plaintext,
 		Attrs:   waBinary.Attrs{},
 	}
-	if mediaType := getMediaTypeFromMessage(message); mediaType != "" {
-		plaintextNode.Attrs["mediatype"] = mediaType
+	if message != nil {
+		if mediaType := getMediaTypeFromMessage(message); mediaType != "" {
+			plaintextNode.Attrs["mediatype"] = mediaType
+		}
 	}
 	node := waBinary.Node{
 		Tag:     "message",


### PR DESCRIPTION
Fixes #760
caused by calling `getMediaTypeFromMessage` after setting `message` to `nil` for sending to WhatsApp.

