### PR TITLE
Add public access to the underlying database

### DIFF
--- a/store/sqlstore/container.go
+++ b/store/sqlstore/container.go
@@ -290,3 +290,8 @@ func (c *Container) DeleteDevice(store *store.Device) error {
 	_, err := c.db.Exec(context.TODO(), deleteDeviceQuery, store.ID)
 	return err
 }
+
+// GetDB returns the underlying *sql.DB instance used by the Container
+func (c *Container) GetDB() *sql.DB {
+	return c.db
+}


### PR DESCRIPTION
This PR adds a **GetDB()** method to store.Container, allowing external access to the underlying ***sql.DB**. This is useful for developers who need to perform advanced operations like custom queries, migrations.