### PR TITLE
fix: duplicate table whatsmeow_event_buffer

### DIFF
--- a/store/sqlstore/upgrades/00-latest-schema.sql
+++ b/store/sqlstore/upgrades/00-latest-schema.sql
@@ -141,13 +141,3 @@ CREATE TABLE whatsmeow_lid_map (
 	lid TEXT PRIMARY KEY,
 	pn  TEXT UNIQUE NOT NULL
 );
-
-CREATE TABLE whatsmeow_event_buffer (
-	our_jid          TEXT   NOT NULL,
-	ciphertext_hash  bytea  NOT NULL CHECK ( length(ciphertext_hash) = 32 ),
-	plaintext        bytea,
-	server_timestamp BIGINT NOT NULL,
-	insert_timestamp BIGINT NOT NULL,
-	PRIMARY KEY (our_jid, ciphertext_hash),
-	FOREIGN KEY (our_jid) REFERENCES whatsmeow_device(jid) ON DELETE CASCADE ON UPDATE CASCADE
-);


### PR DESCRIPTION
fix duplicate tabele name whatsmeow_event_buffer

`panic: failed to upgrade database: failed to run upgrade v8->v9: ERROR: relation "whatsmeow_event_buffer" already exists (SQLSTATE 42P07) [recovered]`

`panic: failed to upgrade database: failed to run upgrade v8->v9: ERROR: relation "whatsmeow_event_buffer" already exists (SQLSTATE 42P07)`

please check 
https://github.com/tulir/whatsmeow/blob/main/store/sqlstore/upgrades/00-latest-schema.sql
and
https://github.com/tulir/whatsmeow/blob/main/store/sqlstore/upgrades/09-decryption-buffer.sql

there is have same sql to create new table whatsmeow_event_buffer,