### PR TITLE
fix: Fixed the error when re-authenticating

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -237,6 +237,7 @@ func (device *Device) Delete(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	device.Initialized = false
 	device.ID = nil
 	device.LID = types.EmptyJID
 	return nil


### PR DESCRIPTION
During the first authentication, the Device is considered not initialized (Initialized = false) and after authentication, `initializeDevice` is called in the `PutDevice` method, in which an `SQLStore` is created and passed to it device.ID , `Initialized` is set to true.
```go
	if !device.Initialized {
		c.initializeDevice(device)
	}
```

```go
func (c *Container) initializeDevice(device *store.Device) {
	innerStore := NewSQLStore(c, *device.ID)
	device.Identities = innerStore
	device.Sessions = innerStore
	device.PreKeys = innerStore
	device.SenderKeys = innerStore
	device.AppStateKeys = innerStore
	device.AppState = innerStore
	device.Contacts = innerStore
	device.ChatSettings = innerStore
	device.MsgSecrets = innerStore
	device.PrivacyTokens = innerStore
	device.EventBuffer = innerStore
	device.LIDs = c.LIDMap
	device.Container = c
	device.Initialized = true
}
```

If you log out of your account and then go through the authentication process again, `PutDevice` will be called again, but `initializeDevice` will not be called, therefore SQLStore will not be created with a new one device.ID. All Device repositories will have the old JID, which will lead to errors and the inability to re-authenticate.

