### PR TITLE
fix: message parsing when 'from' field uses LID format

### DIFF
--- a/message.go
+++ b/message.go
@@ -123,8 +123,15 @@ func (cli *Client) parseMessageSource(node *waBinary.Node, requireParticipant bo
 			source.Chat = from
 		}
 	} else {
-		source.Chat = from.ToNonAD()
-		source.Sender = from
+		if from.Server == types.HiddenUserServer {
+			senderPn := ag.OptionalJIDOrEmpty("sender_pn")
+			source.Chat = senderPn.ToNonAD()
+			source.Sender = senderPn
+		} else {
+			source.Chat = from.ToNonAD()
+			source.Sender = from
+		}
+
 		if source.AddressingMode == types.AddressingModeLID {
 			source.SenderAlt = ag.OptionalJIDOrEmpty("sender_pn")
 		} else {


### PR DESCRIPTION

![whatsapp-log-security](https://github.com/user-attachments/assets/89e77df2-af15-4907-91f6-8190c6851132)

I identified an issue in the mapping of some private contacts with numbers in the @lid format.

After enabling debug logs, we discovered that some numbers are arriving with a different pattern in the from, sender_pn, and sender_lid fields.

**Most of the time, as shown in LOG 01:**
```
from=number_of_contact@s.whatsapp.net
sender_lid=numberid@lid
```

**In some cases, however, the pattern is like LOG 02:**
```
from=numberid@lid
sender_pn=number_of_contact@s.whatsapp.net
```

The fix implemented in this pull request should resolve cases where the message comes in the pattern shown in LOG 02.