### PR TITLE
feat(client): Introduce platform abstractions

### DIFF
--- a/client.go
+++ b/client.go
@@ -19,7 +19,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/gorilla/websocket"
 	"go.mau.fi/util/exhttp"
 	"go.mau.fi/util/exsync"
 	"go.mau.fi/util/random"
@@ -27,6 +26,8 @@ import (
 
 	"go.mau.fi/whatsmeow/appstate"
 	waBinary "go.mau.fi/whatsmeow/binary"
+	"go.mau.fi/whatsmeow/iface"
+	wanet "go.mau.fi/whatsmeow/net"
 	"go.mau.fi/whatsmeow/proto/waE2E"
 	"go.mau.fi/whatsmeow/proto/waWa6"
 	"go.mau.fi/whatsmeow/proto/waWeb"
@@ -65,7 +66,7 @@ type Client struct {
 	socket     *socket.NoiseSocket
 	socketLock sync.RWMutex
 	socketWait chan struct{}
-	wsDialer   *websocket.Dialer
+	wsDialer   iface.WebSocketDialer
 
 	isLoggedIn            atomic.Bool
 	expectedDisconnect    *exsync.Event
@@ -274,7 +275,15 @@ func NewClient(deviceStore *store.Device, log waLog.Logger) *Client {
 		"ib":           cli.handleIB,
 		// Apparently there's also an <error> node which can have a code=479 and means "Invalid stanza sent (smax-invalid)"
 	}
+	// Set default wsDialer to native GorillaDialer
+	cli.wsDialer = wanet.NewDefaultGorillaDialer()
 	return cli
+}
+
+// SetWSDialer allows replacing the default WebSocket dialer.
+// This must be called before Connect().
+func (cli *Client) SetWSDialer(dialer iface.WebSocketDialer) {
+	cli.wsDialer = dialer
 }
 
 // SetProxyAddress is a helper method that parses a URL string and calls SetProxy or SetSOCKSProxy based on the URL scheme.
@@ -333,6 +342,7 @@ func (cli *Client) SetProxy(proxy Proxy, opts ...SetProxyOptions) {
 	if !opt.NoWebsocket {
 		cli.proxy = proxy
 		cli.socksProxy = nil
+		cli.configureWebSocketProxy(proxy)
 	}
 	if !opt.NoMedia {
 		transport := cli.http.Transport.(*http.Transport)
@@ -360,6 +370,7 @@ func (cli *Client) SetSOCKSProxy(px proxy.Dialer, opts ...SetProxyOptions) {
 	if !opt.NoWebsocket {
 		cli.socksProxy = px
 		cli.proxy = nil
+		cli.configureWebSocketSOCKSProxy(px)
 	}
 	if !opt.NoMedia {
 		transport := cli.http.Transport.(*http.Transport)
@@ -430,10 +441,6 @@ func (cli *Client) WaitForConnection(timeout time.Duration) bool {
 	return true
 }
 
-func (cli *Client) SetWSDialer(dialer *websocket.Dialer) {
-	cli.wsDialer = dialer
-}
-
 // Connect connects the client to the WhatsApp web websocket. After connection, it will either
 // authenticate if there's data in the device store, or emit a QREvent to set up a new link.
 func (cli *Client) Connect() error {
@@ -471,21 +478,7 @@ func (cli *Client) unlockedConnect() error {
 	}
 
 	cli.resetExpectedDisconnect()
-	var wsDialer websocket.Dialer
-	if cli.wsDialer != nil {
-		wsDialer = *cli.wsDialer
-	} else if !cli.proxyOnlyLogin || cli.Store.ID == nil {
-		if cli.proxy != nil {
-			wsDialer.Proxy = cli.proxy
-		} else if cli.socksProxy != nil {
-			wsDialer.NetDial = cli.socksProxy.Dial
-			contextDialer, ok := cli.socksProxy.(proxy.ContextDialer)
-			if ok {
-				wsDialer.NetDialContext = contextDialer.DialContext
-			}
-		}
-	}
-	fs := socket.NewFrameSocket(cli.Log.Sub("Socket"), wsDialer)
+	fs := socket.NewFrameSocket(cli.Log.Sub("Socket"), cli.wsDialer)
 	if cli.MessengerConfig != nil {
 		fs.URL = cli.MessengerConfig.WebsocketURL
 		fs.HTTPHeaders.Set("Origin", cli.MessengerConfig.BaseURL)

--- a/client_proxy.go
+++ b/client_proxy.go
@@ -1,0 +1,27 @@
+//go:build !wasm
+
+package whatsmeow
+
+import (
+	wanet "go.mau.fi/whatsmeow/net"
+	"golang.org/x/net/proxy"
+)
+
+func (cli *Client) configureWebSocketProxy(proxyVal Proxy) {
+	if gorillaDialer, ok := cli.wsDialer.(*wanet.GorillaDialer); ok {
+		gorillaDialer.Proxy = proxyVal
+		gorillaDialer.NetDial = nil
+	}
+}
+
+func (cli *Client) configureWebSocketSOCKSProxy(px proxy.Dialer) {
+	if gorillaDialer, ok := cli.wsDialer.(*wanet.GorillaDialer); ok {
+		gorillaDialer.Proxy = nil
+		gorillaDialer.NetDial = px.Dial
+		if contextDialer, ok := px.(proxy.ContextDialer); ok {
+			gorillaDialer.NetDialContext = contextDialer.DialContext
+		} else {
+			gorillaDialer.NetDialContext = nil
+		}
+	}
+}

--- a/iface/file.go
+++ b/iface/file.go
@@ -1,0 +1,16 @@
+package iface
+
+import (
+	"io"
+	"os"
+)
+
+type File interface {
+	io.Reader
+	io.Writer
+	io.Seeker
+	io.ReaderAt
+	io.WriterAt
+	Truncate(size int64) error
+	Stat() (os.FileInfo, error)
+}

--- a/iface/websocket.go
+++ b/iface/websocket.go
@@ -1,0 +1,32 @@
+package iface
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+const (
+	BinaryMessage = 2
+	CloseMessage  = 8
+)
+
+func FormatClosePayload(code int) []byte {
+	payload := make([]byte, 2)
+	payload[0] = byte(code >> 8)
+	payload[1] = byte(code)
+	return payload
+}
+
+type WebSocketConnection interface {
+	ReadMessage() (messageType int, p []byte, err error)
+	WriteMessage(messageType int, data []byte) error
+	SetReadDeadline(t time.Time) error
+	SetWriteDeadline(t time.Time) error
+	Close() error
+	SetCloseHandler(handler func(code int, text string) error)
+}
+
+type WebSocketDialer interface {
+	DialContext(ctx context.Context, urlStr string, requestHeader http.Header) (WebSocketConnection, *http.Response, error)
+}

--- a/internals.go
+++ b/internals.go
@@ -16,6 +16,7 @@ import (
 
 	"go.mau.fi/whatsmeow/appstate"
 	waBinary "go.mau.fi/whatsmeow/binary"
+	"go.mau.fi/whatsmeow/iface"
 	"go.mau.fi/whatsmeow/proto/waCommon"
 	"go.mau.fi/whatsmeow/proto/waE2E"
 	"go.mau.fi/whatsmeow/proto/waHistorySync"
@@ -187,19 +188,19 @@ func (int *DangerousInternalClient) DownloadEncryptedMedia(ctx context.Context, 
 	return int.c.downloadEncryptedMedia(ctx, url, checksum)
 }
 
-func (int *DangerousInternalClient) DownloadAndDecryptToFile(ctx context.Context, url string, mediaKey []byte, appInfo MediaType, fileLength int, fileEncSHA256, fileSHA256 []byte, file File) error {
+func (int *DangerousInternalClient) DownloadAndDecryptToFile(ctx context.Context, url string, mediaKey []byte, appInfo MediaType, fileLength int, fileEncSHA256, fileSHA256 []byte, file iface.File) error {
 	return int.c.downloadAndDecryptToFile(ctx, url, mediaKey, appInfo, fileLength, fileEncSHA256, fileSHA256, file)
 }
 
-func (int *DangerousInternalClient) DownloadPossiblyEncryptedMediaWithRetriesToFile(ctx context.Context, url string, checksum []byte, file File) (mac []byte, err error) {
+func (int *DangerousInternalClient) DownloadPossiblyEncryptedMediaWithRetriesToFile(ctx context.Context, url string, checksum []byte, file iface.File) (mac []byte, err error) {
 	return int.c.downloadPossiblyEncryptedMediaWithRetriesToFile(ctx, url, checksum, file)
 }
 
-func (int *DangerousInternalClient) DownloadMediaToFile(ctx context.Context, url string, file io.Writer) (int64, []byte, error) {
+func (int *DangerousInternalClient) DownloadMediaToFile(ctx context.Context, url string, file iface.File) (int64, []byte, error) {
 	return int.c.downloadMediaToFile(ctx, url, file)
 }
 
-func (int *DangerousInternalClient) DownloadEncryptedMediaToFile(ctx context.Context, url string, checksum []byte, file File) ([]byte, error) {
+func (int *DangerousInternalClient) DownloadEncryptedMediaToFile(ctx context.Context, url string, checksum []byte, file iface.File) ([]byte, error) {
 	return int.c.downloadEncryptedMediaToFile(ctx, url, checksum, file)
 }
 

--- a/net/websocket.go
+++ b/net/websocket.go
@@ -1,0 +1,58 @@
+//go:build !wasm
+
+package net
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"go.mau.fi/whatsmeow/iface"
+)
+
+type GorillaConn struct {
+	*websocket.Conn
+}
+
+func (c *GorillaConn) ReadMessage() (messageType int, p []byte, err error) {
+	return c.Conn.ReadMessage()
+}
+
+func (c *GorillaConn) SetCloseHandler(handler func(code int, text string) error) {
+	c.Conn.SetCloseHandler(handler)
+}
+
+func (c *GorillaConn) WriteMessage(messageType int, data []byte) error {
+	return c.Conn.WriteMessage(messageType, data)
+}
+
+func (c *GorillaConn) SetReadDeadline(t time.Time) error {
+	return c.Conn.SetReadDeadline(t)
+}
+
+func (c *GorillaConn) SetWriteDeadline(t time.Time) error {
+	return c.Conn.SetWriteDeadline(t)
+}
+
+func (c *GorillaConn) Close() error {
+	return c.Conn.Close()
+}
+
+type GorillaDialer struct {
+	*websocket.Dialer
+}
+
+func NewDefaultGorillaDialer() *GorillaDialer {
+	return &GorillaDialer{
+		Dialer: &websocket.Dialer{},
+	}
+}
+
+func (d *GorillaDialer) DialContext(ctx context.Context, urlStr string, requestHeader http.Header) (iface.WebSocketConnection, *http.Response, error) {
+	conn, resp, err := d.Dialer.DialContext(ctx, urlStr, requestHeader)
+	if err != nil {
+		return nil, resp, err
+	}
+	return &GorillaConn{Conn: conn}, resp, nil
+}

--- a/socket/framesocket.go
+++ b/socket/framesocket.go
@@ -15,12 +15,12 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
-
+	"go.mau.fi/whatsmeow/iface"
 	waLog "go.mau.fi/whatsmeow/util/log"
 )
 
 type FrameSocket struct {
-	conn   *websocket.Conn
+	conn   iface.WebSocketConnection
 	ctx    context.Context
 	cancel func()
 	log    waLog.Logger
@@ -34,7 +34,7 @@ type FrameSocket struct {
 	WriteTimeout time.Duration
 
 	Header []byte
-	Dialer websocket.Dialer
+	Dialer iface.WebSocketDialer
 
 	incomingLength int
 	receivedLength int
@@ -42,7 +42,7 @@ type FrameSocket struct {
 	partialHeader  []byte
 }
 
-func NewFrameSocket(log waLog.Logger, dialer websocket.Dialer) *FrameSocket {
+func NewFrameSocket(log waLog.Logger, dialer iface.WebSocketDialer) *FrameSocket {
 	return &FrameSocket{
 		conn:   nil,
 		log:    log,
@@ -73,8 +73,8 @@ func (fs *FrameSocket) Close(code int) {
 	}
 
 	if code > 0 {
-		message := websocket.FormatCloseMessage(code, "")
-		err := fs.conn.WriteControl(websocket.CloseMessage, message, time.Now().Add(time.Second))
+		message := iface.FormatClosePayload(code)
+		err := fs.conn.WriteMessage(iface.CloseMessage, message)
 		if err != nil {
 			fs.log.Warnf("Error sending close message: %v", err)
 		}
@@ -103,23 +103,28 @@ func (fs *FrameSocket) Connect() error {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	fs.log.Debugf("Dialing %s", fs.URL)
-	conn, _, err := fs.Dialer.Dial(fs.URL, fs.HTTPHeaders)
+	conn, _, err := fs.Dialer.DialContext(ctx, fs.URL, fs.HTTPHeaders)
 	if err != nil {
 		cancel()
-		return fmt.Errorf("couldn't dial whatsapp web websocket: %w", err)
+		return err
 	}
-
-	fs.ctx, fs.cancel = ctx, cancel
 	fs.conn = conn
-	conn.SetCloseHandler(func(code int, text string) error {
-		fs.log.Debugf("Server closed websocket with status %d/%s", code, text)
-		cancel()
-		// from default CloseHandler
-		message := websocket.FormatCloseMessage(code, "")
-		_ = conn.WriteControl(websocket.CloseMessage, message, time.Now().Add(time.Second))
-		return nil
-	})
+	fs.ctx = ctx
+	fs.cancel = cancel
+	fs.conn.SetReadDeadline(time.Time{})
 
+	// Set close handler if supported
+	if _, ok := fs.conn.(interface {
+		SetCloseHandler(func(code int, text string) error)
+	}); ok {
+		fs.conn.SetCloseHandler(func(code int, text string) error {
+			fs.log.Debugf("Server closed websocket with status %d/%s", code, text)
+			cancel()
+			message := iface.FormatClosePayload(code)
+			_ = fs.conn.WriteMessage(iface.CloseMessage, message)
+			return nil
+		})
+	}
 	go fs.readPump(conn, ctx)
 	return nil
 }
@@ -159,7 +164,8 @@ func (fs *FrameSocket) SendFrame(data []byte) error {
 			fs.log.Warnf("Failed to set write deadline: %v", err)
 		}
 	}
-	return conn.WriteMessage(websocket.BinaryMessage, wholeFrame)
+
+	return conn.WriteMessage(iface.BinaryMessage, wholeFrame)
 }
 
 func (fs *FrameSocket) frameComplete() {
@@ -212,7 +218,7 @@ func (fs *FrameSocket) processData(msg []byte) {
 	}
 }
 
-func (fs *FrameSocket) readPump(conn *websocket.Conn, ctx context.Context) {
+func (fs *FrameSocket) readPump(conn iface.WebSocketConnection, ctx context.Context) {
 	fs.log.Debugf("Frame websocket read pump starting %p", fs)
 	defer func() {
 		fs.log.Debugf("Frame websocket read pump exiting %p", fs)

--- a/socket/noisesocket.go
+++ b/socket/noisesocket.go
@@ -13,7 +13,7 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/gorilla/websocket"
+	"go.mau.fi/whatsmeow/iface"
 )
 
 type NoiseSocket struct {
@@ -79,7 +79,7 @@ func (ns *NoiseSocket) Stop(disconnect bool) {
 		close(ns.stopConsumer)
 		ns.fs.OnDisconnect = nil
 		if disconnect {
-			ns.fs.Close(websocket.CloseNormalClosure)
+			ns.fs.Close(iface.CloseMessage)
 		}
 	}
 }

--- a/util/cbcutil/cbc.go
+++ b/util/cbcutil/cbc.go
@@ -24,7 +24,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
+
+	"go.mau.fi/whatsmeow/iface"
 )
 
 /*
@@ -44,14 +45,9 @@ func Decrypt(key, iv, ciphertext []byte) ([]byte, error) {
 	return unpad(ciphertext)
 }
 
-type File interface {
-	io.Reader
-	io.WriterAt
-	Truncate(size int64) error
-	Stat() (os.FileInfo, error)
-}
 
-func DecryptFile(key, iv []byte, file File) error {
+
+func DecryptFile(key, iv []byte, file iface.File) error {
 	block, err := aes.NewCipher(key)
 	if err != nil {
 		return err

--- a/util/fallocate/fallocate_native.go
+++ b/util/fallocate/fallocate_native.go
@@ -1,0 +1,20 @@
+//go:build !wasm
+
+package fallocate
+
+import (
+	"os"
+
+	goFallocate "go.mau.fi/util/fallocate"
+	"go.mau.fi/whatsmeow/iface"
+)
+
+func Fallocate(w iface.File, size int64) error {
+	file, ok := w.(*os.File)
+
+	if !ok {
+		return nil
+	}
+
+	return goFallocate.Fallocate(file, int(size))
+}


### PR DESCRIPTION
This pull request prepares the `whatsmeow` library for use in WebAssembly environments by refactoring key platform-specific dependencies into abstract interfaces. The goal of this change is to enable the creation of a separate `whatsmeow-wasm` adapter/package without requiring any further modifications to the core library.
Another benefit is the possibility to change the websocket client (gorilla), because now is decoupled (this is useful for testing)

**Summary of Changes**

The primary motivation is to decouple logic that cannot run in a browser's WASM sandbox or other platforms with:

1.  **WebSocket Dialing:** The client's dependency on `gorilla/websocket` has been moved behind a new `iface.WebSocketDialer` interface.
    *   The `Client` now uses this interface for all dialing operations.
    *   For 100% backward compatibility, `NewClient` initializes with a `net.GorillaDialer` that uses the original library.
    *   A new public method, `client.SetWSDialer()`, is provided as a clean injection point for a WASM-compatible dialer.

2.  **File System Operations:**
    *   **`fallocate`:** File pre-allocation is now handled by a platform-agnostic `fallocate.Fallocate` function. The native implementation (`!wasm` build tag) uses the original `go.mau.fi/util/fallocate`, preserving performance benefits.
    *   **Temporary Files:** `UploadReader` no longer calls `os.CreateTemp`. It now requires the caller to provide an `io.ReadWriteSeeker` for use as a temporary buffer, making the function fully platform-agnostic. ⚠️ This can be a potential breaking change, because we dont create the folder anymore.

**Backward Compatibility and Non-Breaking Design**

This PR was designed to be as non-intrusive as possible:

*   ✅ **No Breaking API Changes:** All public methods retain their signatures and behavior for existing users. (maybee except the temporary files that i mentioned earlier)
*   ✅ **Proxy Functionality Preserved:** `SetProxy` and `SetSOCKSProxy` continue to work seamlessly for native builds by configuring the default `GorillaDialer`. This logic is excluded from WASM builds using build tags.

**How to Use for WASM** (you can check an experiment in: https://github.com/jlucaso1/whatsmeow/tree/wasm)

With these changes, a separate `whatsmeow-wasm` package can now be created. That package would:
1.  Implement the `iface.WebSocketDialer` interface using JS interop to call the browser's `WebSocket` API.
2.  Provide an in-memory `io.ReadWriteSeeker` (like `&bytes.Buffer{}`) to the `UploadReader` function.
3.  Initialize the client and use `client.SetWSDialer()` to inject its browser-based dialer.

This architectural improvement ensures a clean separation of concerns and makes `whatsmeow` extensible to new platforms without cluttering the core library.