### PR TITLE
perf(send): Parallelize per-device encryption for large group messages

### DIFF
--- a/client.go
+++ b/client.go
@@ -183,6 +183,14 @@ type Client struct {
 	// The library is currently embedded in mautrix-meta (https://github.com/mautrix/meta), but may be separated later.
 	MessengerConfig *MessengerConfig
 	RefreshCAT      func(context.Context) error
+
+	// EncryptConcurrency controls how many goroutines are used when encrypting a
+	// message fan-out to multiple devices (e.g. large groups). If zero or
+	// negative, the library will pick a value automatically (runtime.NumCPU()).
+	// A value of 1 disables parallelization and preserves the previous
+	// sequential behavior. Small groups automatically fall back to sequential
+	// processing for lower overhead.
+	EncryptConcurrency int
 }
 
 type groupMetaCache struct {

--- a/send.go
+++ b/send.go
@@ -14,9 +14,11 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/rs/zerolog"
@@ -1166,72 +1168,184 @@ func (cli *Client) encryptMessageForDevices(
 	ownLID := cli.getOwnLID()
 	includeIdentity := false
 	participantNodes := make([]waBinary.Node, 0, len(allDevices))
-	var retryDevices, retryEncryptionIdentities []types.JID
-	for _, jid := range allDevices {
-		plaintext := msgPlaintext
-		if (jid.User == ownJID.User || jid.User == ownLID.User) && dsmPlaintext != nil {
-			if jid == ownJID || jid == ownLID {
+
+	// Heuristic: below this size, sequential loop is cheaper than goroutine scheduling.
+	const parallelThreshold = 8
+	concurrency := cli.EncryptConcurrency
+	if concurrency <= 0 {
+		concurrency = runtime.NumCPU()
+	}
+	if concurrency < 1 {
+		concurrency = 1
+	}
+
+	if len(allDevices) < parallelThreshold || concurrency == 1 {
+		// Fall back to original sequential implementation for small batches
+		var retryDevices, retryEncryptionIdentities []types.JID
+		for _, jid := range allDevices {
+			plaintext := msgPlaintext
+			if (jid.User == ownJID.User || jid.User == ownLID.User) && dsmPlaintext != nil {
+				if jid == ownJID || jid == ownLID {
+					continue
+				}
+				plaintext = dsmPlaintext
+			}
+			encryptionIdentity := jid
+			if jid.Server == types.DefaultUserServer {
+				lidForPN, err := cli.Store.LIDs.GetLIDForPN(ctx, jid)
+				if err != nil {
+					cli.Log.Warnf("Failed to get LID for %s: %v", jid, err)
+				} else if !lidForPN.IsEmpty() {
+					cli.migrateSessionStore(ctx, jid, lidForPN)
+					encryptionIdentity = lidForPN
+				}
+			}
+			encrypted, isPreKey, err := cli.encryptMessageForDeviceAndWrap(
+				ctx, plaintext, jid, encryptionIdentity, nil, encAttrs,
+			)
+			if errors.Is(err, ErrNoSession) {
+				retryDevices = append(retryDevices, jid)
+				retryEncryptionIdentities = append(retryEncryptionIdentities, encryptionIdentity)
+				continue
+			} else if err != nil {
+				cli.Log.Warnf("Failed to encrypt %s for %s: %v", id, jid, err)
 				continue
 			}
-			plaintext = dsmPlaintext
-		}
-		encryptionIdentity := jid
-		if jid.Server == types.DefaultUserServer {
-			lidForPN, err := cli.Store.LIDs.GetLIDForPN(ctx, jid)
-			if err != nil {
-				cli.Log.Warnf("Failed to get LID for %s: %v", jid, err)
-			} else if !lidForPN.IsEmpty() {
-				cli.migrateSessionStore(ctx, jid, lidForPN)
-				encryptionIdentity = lidForPN
+			participantNodes = append(participantNodes, *encrypted)
+			if isPreKey {
+				includeIdentity = true
 			}
 		}
+		participantNodes, includeIdentity = cli.retryEncryptMissing(ctx, id, msgPlaintext, dsmPlaintext, encAttrs, ownJID, ownLID, participantNodes, includeIdentity, retryDevices, retryEncryptionIdentities)
+		return participantNodes, includeIdentity
+	}
 
-		encrypted, isPreKey, err := cli.encryptMessageForDeviceAndWrap(
-			ctx, plaintext, jid, encryptionIdentity, nil, encAttrs,
-		)
-		if errors.Is(err, ErrNoSession) {
-			retryDevices = append(retryDevices, jid)
-			retryEncryptionIdentities = append(retryEncryptionIdentities, encryptionIdentity)
-			continue
-		} else if err != nil {
-			// TODO return these errors if it's a fatal one (like context cancellation or database)
-			cli.Log.Warnf("Failed to encrypt %s for %s: %v", id, jid, err)
+	type workItem struct {
+		jid                types.JID
+		plaintext          []byte
+		encryptionIdentity types.JID
+	}
+	type resultItem struct {
+		jid      types.JID
+		node     *waBinary.Node
+		isPreKey bool
+		retry    bool
+		err      error
+		encIdent types.JID
+	}
+	jobs := make(chan workItem)
+	results := make(chan resultItem, len(allDevices))
+	var wg sync.WaitGroup
+
+	worker := func() {
+		defer wg.Done()
+		for wi := range jobs {
+			encrypted, isPreKey, err := cli.encryptMessageForDeviceAndWrap(ctx, wi.plaintext, wi.jid, wi.encryptionIdentity, nil, encAttrs)
+			if errors.Is(err, ErrNoSession) {
+				results <- resultItem{jid: wi.jid, retry: true, err: err, encIdent: wi.encryptionIdentity}
+				continue
+			} else if err != nil {
+				results <- resultItem{jid: wi.jid, err: err}
+				continue
+			}
+			results <- resultItem{jid: wi.jid, node: encrypted, isPreKey: isPreKey}
+		}
+	}
+
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go worker()
+	}
+
+	go func() {
+		for _, jid := range allDevices {
+			plaintext := msgPlaintext
+			if (jid.User == ownJID.User || jid.User == ownLID.User) && dsmPlaintext != nil {
+				if jid == ownJID || jid == ownLID {
+					continue
+				}
+				plaintext = dsmPlaintext
+			}
+			encryptionIdentity := jid
+			if jid.Server == types.DefaultUserServer {
+				lidForPN, err := cli.Store.LIDs.GetLIDForPN(ctx, jid)
+				if err != nil {
+					cli.Log.Warnf("Failed to get LID for %s: %v", jid, err)
+				} else if !lidForPN.IsEmpty() {
+					cli.migrateSessionStore(ctx, jid, lidForPN)
+					encryptionIdentity = lidForPN
+				}
+			}
+			jobs <- workItem{jid: jid, plaintext: plaintext, encryptionIdentity: encryptionIdentity}
+		}
+		close(jobs)
+	}()
+
+	var retryDevices []types.JID
+	var retryEncryptionIdentities []types.JID
+	for completed := 0; completed < len(allDevices); completed++ {
+		res := <-results
+		if res.err != nil {
+			if res.retry {
+				retryDevices = append(retryDevices, res.jid)
+				retryEncryptionIdentities = append(retryEncryptionIdentities, res.encIdent)
+			} else {
+				cli.Log.Warnf("Failed to encrypt %s for %s: %v", id, res.jid, res.err)
+			}
 			continue
 		}
+		if res.node != nil {
+			participantNodes = append(participantNodes, *res.node)
+			if res.isPreKey {
+				includeIdentity = true
+			}
+		}
+	}
 
+	go func() { wg.Wait(); close(results) }()
+
+	participantNodes, includeIdentity = cli.retryEncryptMissing(ctx, id, msgPlaintext, dsmPlaintext, encAttrs, ownJID, ownLID, participantNodes, includeIdentity, retryDevices, retryEncryptionIdentities)
+	return participantNodes, includeIdentity
+}
+
+func (cli *Client) retryEncryptMissing(
+	ctx context.Context,
+	id string,
+	msgPlaintext, dsmPlaintext []byte,
+	encAttrs waBinary.Attrs,
+	ownJID, ownLID types.JID,
+	participantNodes []waBinary.Node,
+	includeIdentity bool,
+	retryDevices, retryEncryptionIdentities []types.JID,
+) ([]waBinary.Node, bool) {
+	if len(retryDevices) == 0 {
+		return participantNodes, includeIdentity
+	}
+	bundles, err := cli.fetchPreKeys(ctx, retryDevices)
+	if err != nil {
+		cli.Log.Warnf("Failed to fetch prekeys for %v to retry encryption: %v", retryDevices, err)
+		return participantNodes, includeIdentity
+	}
+	for i, jid := range retryDevices {
+		resp := bundles[jid]
+		if resp.err != nil {
+			cli.Log.Warnf("Failed to fetch prekey for %s: %v", jid, resp.err)
+			continue
+		}
+		plaintext := msgPlaintext
+		if (jid.User == ownJID.User || jid.User == ownLID.User) && dsmPlaintext != nil {
+			plaintext = dsmPlaintext
+		}
+		encrypted, isPreKey, err := cli.encryptMessageForDeviceAndWrap(
+			ctx, plaintext, jid, retryEncryptionIdentities[i], resp.bundle, encAttrs,
+		)
+		if err != nil {
+			cli.Log.Warnf("Failed to encrypt %s for %s (retry): %v", id, jid, err)
+			continue
+		}
 		participantNodes = append(participantNodes, *encrypted)
 		if isPreKey {
 			includeIdentity = true
-		}
-	}
-	if len(retryDevices) > 0 {
-		bundles, err := cli.fetchPreKeys(ctx, retryDevices)
-		if err != nil {
-			cli.Log.Warnf("Failed to fetch prekeys for %v to retry encryption: %v", retryDevices, err)
-		} else {
-			for i, jid := range retryDevices {
-				resp := bundles[jid]
-				if resp.err != nil {
-					cli.Log.Warnf("Failed to fetch prekey for %s: %v", jid, resp.err)
-					continue
-				}
-				plaintext := msgPlaintext
-				if (jid.User == ownJID.User || jid.User == ownLID.User) && dsmPlaintext != nil {
-					plaintext = dsmPlaintext
-				}
-				encrypted, isPreKey, err := cli.encryptMessageForDeviceAndWrap(
-					ctx, plaintext, jid, retryEncryptionIdentities[i], resp.bundle, encAttrs,
-				)
-				if err != nil {
-					// TODO return these errors if it's a fatal one (like context cancellation or database)
-					cli.Log.Warnf("Failed to encrypt %s for %s (retry): %v", id, jid, err)
-					continue
-				}
-				participantNodes = append(participantNodes, *encrypted)
-				if isPreKey {
-					includeIdentity = true
-				}
-			}
 		}
 	}
 	return participantNodes, includeIdentity

--- a/store/sqlstore/container.go
+++ b/store/sqlstore/container.go
@@ -277,6 +277,7 @@ func (c *Container) initializeDevice(device *store.Device) {
 	device.PrivacyTokens = innerStore
 	device.EventBuffer = innerStore
 	device.LIDs = c.LIDMap
+	device.Cache = innerStore
 	device.Container = c
 	device.Initialized = true
 }


### PR DESCRIPTION
A simple benchmark with a group with 117 members (both are fresh sessions and are the first message sent to a group):

```bash
* **Without Goroutines (`log-go-first.txt`):**
    * [cite_start]Initial message received: `20:46:02.486` [cite: 3]
    * [cite_start]Encrypted group reply sent: `20:46:06.922` [cite: 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78]
    * **Total Time Elapsed: 4.436 seconds**
    * [cite_start]A warning in the log confirms a long processing time, stating: `Node handling took 5.317818646s`[cite: 79].

* **With Goroutines (`log-go-first-with-goroutine.txt`):**
    * [cite_start]Initial message received: `21:10:33.447` [cite: 86]
    * [cite_start]Encrypted group reply sent: `21:10:36.138` [cite: 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159]
    * **Total Time Elapsed: 2.691 seconds**
```