### PR TITLE
Fix poll creation channels (newsletters)

### DIFF
--- a/send.go
+++ b/send.go
@@ -833,7 +833,7 @@ func getTypeFromMessage(msg *waE2E.Message) string {
 		return getTypeFromMessage(msg.DocumentWithCaptionMessage.Message)
 	case msg.ReactionMessage != nil, msg.EncReactionMessage != nil:
 		return "reaction"
-	case msg.PollCreationMessage != nil, msg.PollUpdateMessage != nil:
+	case msg.PollCreationMessage != nil, msg.PollUpdateMessage != nil, msg.PollCreationMessageV3 != nil:
 		return "poll"
 	case getMediaTypeFromMessage(msg) != "":
 		return "media"

--- a/send.go
+++ b/send.go
@@ -657,10 +657,32 @@ func (cli *Client) sendNewsletter(
 			plaintextNode.Attrs["mediatype"] = mediaType
 		}
 	}
+	content := []waBinary.Node{}
+	if attrs["type"] == "poll" {
+		var node waBinary.Node
+		if message.PollUpdateMessage == nil {
+			node = waBinary.Node{
+				Tag: "meta",
+				Attrs: waBinary.Attrs{
+					"polltype":    "creation",
+					"contenttype": "text",
+				},
+			}
+		} else {
+			node = waBinary.Node{
+				Tag: "meta",
+				Attrs: waBinary.Attrs{
+					"polltype": "vote",
+				},
+			}
+		}
+		content = append(content, node)
+	}
+	content = append(content, plaintextNode)
 	node := waBinary.Node{
 		Tag:     "message",
 		Attrs:   attrs,
-		Content: []waBinary.Node{plaintextNode},
+		Content: content,
 	}
 	start = time.Now()
 	data, err := cli.sendNodeAndGetData(node)


### PR DESCRIPTION
Currently, if you send a poll from meow to **Channels**, users are unable to vote.

This PR addresses the issue by:

* Adding support for `PollCreationMessageV3` as `"poll"`.
* Including the required `<meta>` attributes for poll creation.

ℹ️ Note: **Voting has not been tested yet.**
It's likely that this alone isn't sufficient, as the vote mechanism appears to involve multiple `votes` nodes. 

---
<img width="1192" height="634" alt="image" src="https://github.com/user-attachments/assets/77bd774c-4e1b-496d-a39b-54edaa9505a3" />
