### PR TITLE
message,send: share/request pn from business

### DIFF
--- a/message.go
+++ b/message.go
@@ -751,6 +751,11 @@ func (cli *Client) handleProtocolMessage(ctx context.Context, info *types.Messag
 		cli.storeLIDSyncMessage(ctx, protoMsg.GetLidMigrationMappingSyncMessage().GetEncodedMappingPayload())
 	}
 
+	if protoMsg.GetType() == waE2E.ProtocolMessage_SHARE_PHONE_NUMBER {
+		// user shared phone number with a business
+		cli.StoreLIDPNMapping(ctx, info.Sender, info.SenderAlt)
+	}
+
 	if protoMsg.GetPeerDataOperationRequestResponseMessage().GetPeerDataOperationRequestType() == waE2E.PeerDataOperationRequestType_PLACEHOLDER_MESSAGE_RESEND {
 		ok = cli.handlePlaceholderResendResponse(protoMsg.GetPeerDataOperationRequestResponseMessage()) && ok
 	}

--- a/send.go
+++ b/send.go
@@ -459,6 +459,25 @@ func (cli *Client) BuildRevoke(chat, sender types.JID, id types.MessageID) *waE2
 	}
 }
 
+// BuildRequestPhoneNumber builds a message that requests a user share their phone number or a business
+// This is useful when you only have an LID and not an alternate ID associated (hidden)
+func (cli *Client) BuildRequestPhoneNumber() *waE2E.Message {
+	return &waE2E.Message{
+		RequestPhoneNumberMessage: &waE2E.RequestPhoneNumberMessage{},
+	}
+}
+
+// BuildSharePhoneNumber builds a message that shares your phone number to a business
+// This is useful when you only have an LID and not an alternate ID associated (hidden)
+func (cli *Client) BuildSharePhoneNumber() *waE2E.Message {
+	// as far as I remember, nothing extra is needed here ~ rajeh
+	return &waE2E.Message{
+		ProtocolMessage: &waE2E.ProtocolMessage{
+			Type: waE2E.ProtocolMessage_SHARE_PHONE_NUMBER.Enum(),
+		},
+	}
+}
+
 // BuildReaction builds a message reaction message using the given variables.
 // The built message can be sent normally using Client.SendMessage.
 //


### PR DESCRIPTION
This PR allows whatsmeow users (mainly business running Meta Ads) to receive the phone numbers of users that are now appearing as LID. It also allows you to share your phone number with a business if needed.

This might appear later on in more normal WhatsApp uses, as WhatsApp is gearing towards username based and LID based identification, leaving phone numbers to eventually become a privacy bound identifier.