### PR TITLE
Add SMaxId field to infoQuery request

### DIFF
--- a/request.go
+++ b/request.go
@@ -119,8 +119,8 @@ func (cli *Client) sendIQAsyncAndGetData(query *infoQuery) (<-chan *waBinary.Nod
 		"xmlns": query.Namespace,
 		"type":  string(query.Type),
 	}
-	if query.SMaxId != "" {
-		attrs["smax_id"] = query.SMaxId
+	if query.SMaxID != "" {
+		attrs["smax_id"] = query.SMaxID
 	}
 	if !query.To.IsEmpty() {
 		attrs["to"] = query.To

--- a/request.go
+++ b/request.go
@@ -98,7 +98,7 @@ type infoQuery struct {
 	To        types.JID
 	Target    types.JID
 	ID        string
-	SMaxId    string
+	SMaxID    string
 	Content   interface{}
 
 	Timeout time.Duration

--- a/request.go
+++ b/request.go
@@ -98,6 +98,7 @@ type infoQuery struct {
 	To        types.JID
 	Target    types.JID
 	ID        string
+	SMaxId    string
 	Content   interface{}
 
 	Timeout time.Duration
@@ -117,6 +118,9 @@ func (cli *Client) sendIQAsyncAndGetData(query *infoQuery) (<-chan *waBinary.Nod
 		"id":    query.ID,
 		"xmlns": query.Namespace,
 		"type":  string(query.Type),
+	}
+	if query.SMaxId != "" {
+		attrs["smax_id"] = query.SMaxId
 	}
 	if !query.To.IsEmpty() {
 		attrs["to"] = query.To


### PR DESCRIPTION
some infoQuery requests require the `SMaxId` field to be passed.
like `fb:thrift_iq`