### PR TITLE
user: Add PrivacyToken to GetProfilePictureInfo

### DIFF
--- a/user.go
+++ b/user.go
@@ -527,9 +527,18 @@ func (cli *Client) GetProfilePictureInfo(jid types.JID, params *GetProfilePictur
 	} else {
 		to = types.ServerJID
 		target = jid
+		var pictureContent []waBinary.Node
+		if token, _ := cli.Store.PrivacyTokens.GetPrivacyToken(context.TODO(), jid); token != nil {
+			pictureContent = []waBinary.Node{{
+				Tag:     "tctoken",
+				Content: token,
+			}}
+		}
+
 		content = []waBinary.Node{{
-			Tag:   "picture",
-			Attrs: attrs,
+			Tag:     "picture",
+			Attrs:   attrs,
+			Content: pictureContent,
 		}}
 	}
 	resp, err := cli.sendIQ(infoQuery{


### PR DESCRIPTION
This PR aims to fix an issue with WhatsApp, where they have started to randomly drop 401s on get profile pic url calls. It seems WhatsApp is hiding even public avatars against data mining or something of the sort. In any case, providing the tctoken would also increase whatsmeow legitimacy in the eyes of WhatsApp. 

<img width="738" height="326" alt="CleanShot 2025-10-02 at 14 13 52" src="https://github.com/user-attachments/assets/05eedc4e-6cd3-4b99-a07b-a17fcfc3b39f" />
