### PR TITLE
message,receipt: Fix message <ack>s and support peer_msg receipts

### DIFF
--- a/message.go
+++ b/message.go
@@ -441,6 +441,8 @@ func (cli *Client) decryptMessages(ctx context.Context, info *types.MessageInfo,
 	}
 	if handled {
 		go cli.sendMessageReceipt(info)
+		// cancel ack since we have a receipt
+		handlerFailed = true
 	}
 	return
 }

--- a/receipt.go
+++ b/receipt.go
@@ -239,6 +239,8 @@ func (cli *Client) sendMessageReceipt(info *types.MessageInfo) {
 	}
 	if info.IsFromMe {
 		attrs["type"] = string(types.ReceiptTypeSender)
+	} else if info.Type == "peer_msg" {
+		attrs["type"] = string(types.ReceiptTypePeerMsg)
 	} else if cli.sendActiveReceipts.Load() == 0 {
 		attrs["type"] = string(types.ReceiptTypeInactive)
 	}


### PR DESCRIPTION
WhatsApp Web is no longer sending <ack>s for successfully received messages. The existence of this node is a valid fingerprinting vector.


I ask people to test the PR to see if there would be any kind of accumulation of messages or issues in socket stability after the changes in the PR. 