### PR TITLE
Group sending optimizations

### DIFF
--- a/client.go
+++ b/client.go
@@ -130,7 +130,7 @@ type Client struct {
 	groupCache           map[types.JID]*groupMetaCache
 	groupCacheLock       sync.Mutex
 	userDevicesCache     map[types.JID]deviceCache
-	userDevicesCacheLock sync.Mutex
+	userDevicesCacheLock sync.RWMutex
 
 	recentMessagesMap  map[recentMessageKey]RecentMessage
 	recentMessagesList [recentMessagesSize]recentMessageKey

--- a/internals.go
+++ b/internals.go
@@ -660,11 +660,11 @@ func (int *DangerousInternalClient) EncryptMessageForDevices(ctx context.Context
 }
 
 func (int *DangerousInternalClient) EncryptMessageForDeviceAndWrap(ctx context.Context, plaintext []byte, wireIdentity, encryptionIdentity types.JID, bundle *prekey.Bundle, encAttrs waBinary.Attrs) (*waBinary.Node, bool, error) {
-	return int.c.encryptMessageForDeviceAndWrap(ctx, plaintext, wireIdentity, encryptionIdentity, bundle, encAttrs)
+	return int.c.encryptMessageForDeviceAndWrap(ctx, plaintext, wireIdentity, encryptionIdentity, bundle, encAttrs, nil)
 }
 
 func (int *DangerousInternalClient) EncryptMessageForDevice(ctx context.Context, plaintext []byte, to types.JID, bundle *prekey.Bundle, extraAttrs waBinary.Attrs) (*waBinary.Node, bool, error) {
-	return int.c.encryptMessageForDevice(ctx, plaintext, to, bundle, extraAttrs)
+	return int.c.encryptMessageForDevice(ctx, plaintext, to, bundle, extraAttrs, nil)
 }
 
 func (int *DangerousInternalClient) RawUpload(ctx context.Context, dataToUpload io.Reader, uploadSize uint64, fileHash []byte, appInfo MediaType, newsletter bool, resp *UploadResponse) error {

--- a/retry.go
+++ b/retry.go
@@ -251,7 +251,7 @@ func (cli *Client) handleRetryReceipt(ctx context.Context, receipt *events.Recei
 				encryptionIdentity = lidForPN
 			}
 		}
-		encrypted, includeDeviceIdentity, err = cli.encryptMessageForDevice(ctx, plaintext, encryptionIdentity, bundle, encAttrs)
+		encrypted, includeDeviceIdentity, err = cli.encryptMessageForDevice(ctx, plaintext, encryptionIdentity, bundle, encAttrs, nil)
 	} else {
 		encrypted, err = cli.encryptMessageForDeviceV3(ctx, &waMsgTransport.MessageTransport_Payload{
 			ApplicationPayload: &waCommon.SubProtocol{

--- a/store/noop.go
+++ b/store/noop.go
@@ -68,6 +68,10 @@ func (n *NoopStore) HasSession(ctx context.Context, address string) (bool, error
 	return false, n.Error
 }
 
+func (n *NoopStore) HasManySessions(ctx context.Context, addresses []string) (map[string]bool, error) {
+	return nil, n.Error
+}
+
 func (n *NoopStore) PutSession(ctx context.Context, address string, session []byte) error {
 	return n.Error
 }
@@ -246,6 +250,10 @@ func (n *NoopStore) DeleteOldBufferedHashes(ctx context.Context) error {
 
 func (n *NoopStore) GetLIDForPN(ctx context.Context, pn types.JID) (types.JID, error) {
 	return types.JID{}, n.Error
+}
+
+func (n *NoopStore) GetManyLIDsForPNs(ctx context.Context, pns []types.JID) (map[types.JID]types.JID, error) {
+	return nil, n.Error
 }
 
 func (n *NoopStore) GetPNForLID(ctx context.Context, lid types.JID) (types.JID, error) {

--- a/store/store.go
+++ b/store/store.go
@@ -29,6 +29,7 @@ type IdentityStore interface {
 type SessionStore interface {
 	GetSession(ctx context.Context, address string) ([]byte, error)
 	HasSession(ctx context.Context, address string) (bool, error)
+	HasManySessions(ctx context.Context, addresses []string) (map[string]bool, error)
 	PutSession(ctx context.Context, address string, session []byte) error
 	DeleteAllSessions(ctx context.Context, phone string) error
 	DeleteSession(ctx context.Context, address string) error
@@ -171,6 +172,7 @@ type LIDStore interface {
 	PutLIDMapping(ctx context.Context, lid, jid types.JID) error
 	GetPNForLID(ctx context.Context, lid types.JID) (types.JID, error)
 	GetLIDForPN(ctx context.Context, pn types.JID) (types.JID, error)
+	GetManyLIDsForPNs(ctx context.Context, pns []types.JID) (map[types.JID]types.JID, error)
 }
 
 type AllSessionSpecificStores interface {


### PR DESCRIPTION
# Group sending performance optimizations

I noticed that there were many bottlenecks when sending to groups, and wanted to contribute in a similar way I did to Baileys.

## Changes

- Removed the global message sending lock (it was added 3 years ago and wasn't causing issues for me when removed)
- Added `GetManyLIDsForPNs`: Instead of doing one I/O op per LID needed, it makes a batch query, saving a lot of roundtrips
- Added `HasManySessions`: Same as above, one batch query for all sessions required
- `userDevicesCacheLock` Mutex => `RWMutex`: So that we can be selective in our locking, especially in `GetUserDevicesContext`

## Performance gains

Tested with large groups (800+ people), went from an average of 20s to 3s