### PR TITLE
Group sending optimisations: GetManySessions & per-group locking

### DIFF
--- a/store/noop.go
+++ b/store/noop.go
@@ -72,6 +72,10 @@ func (n *NoopStore) HasManySessions(ctx context.Context, addresses []string) (ma
 	return nil, n.Error
 }
 
+func (n *NoopStore) GetManySessions(ctx context.Context, addresses []string) (map[string][]byte, error) {
+	return nil, n.Error
+}
+
 func (n *NoopStore) PutSession(ctx context.Context, address string, session []byte) error {
 	return n.Error
 }

--- a/store/store.go
+++ b/store/store.go
@@ -30,6 +30,7 @@ type SessionStore interface {
 	GetSession(ctx context.Context, address string) ([]byte, error)
 	HasSession(ctx context.Context, address string) (bool, error)
 	HasManySessions(ctx context.Context, addresses []string) (map[string]bool, error)
+	GetManySessions(ctx context.Context, addresses []string) (map[string][]byte, error)
 	PutSession(ctx context.Context, address string, session []byte) error
 	DeleteAllSessions(ctx context.Context, phone string) error
 	DeleteSession(ctx context.Context, address string) error


### PR DESCRIPTION
# Group sending optimisations

After my PR #954, I realised the library was still doing an individual IO operation per encryption request. So, this PR creates a tmp cache, warms it and passes it down to libsignal.

I also added a per-group lock on groups, so I can send messages in parallel, emulating WhatsApp's message forwarding.