### PR TITLE
Get many PNs for LIDs

### DIFF
--- a/group.go
+++ b/group.go
@@ -653,11 +653,16 @@ func (cli *Client) getCachedGroupData(ctx context.Context, jid types.JID) (*grou
 	cli.groupCacheLock.Lock()
 	defer cli.groupCacheLock.Unlock()
 	if val, ok := cli.groupCache[jid]; ok {
+		cli.Log.Debugf("Group participants cache HIT for group %s (has %d members)", jid, len(val.Members))
 		return val, nil
 	}
+	cli.Log.Debugf("Group participants cache MISS for group %s, fetching from server", jid)
 	_, err := cli.getGroupInfo(ctx, jid, false)
 	if err != nil {
 		return nil, err
+	}
+	if cachedData := cli.groupCache[jid]; cachedData != nil {
+		cli.Log.Debugf("Group participants cache populated for %s with %d members", jid, len(cachedData.Members))
 	}
 	return cli.groupCache[jid], nil
 }

--- a/store/noop.go
+++ b/store/noop.go
@@ -260,6 +260,10 @@ func (n *NoopStore) GetManyLIDsForPNs(ctx context.Context, pns []types.JID) (map
 	return nil, n.Error
 }
 
+func (n *NoopStore) GetManyPNsForLIDs(ctx context.Context, lids []types.JID) (map[types.JID]types.JID, error) {
+	return nil, n.Error
+}
+
 func (n *NoopStore) GetPNForLID(ctx context.Context, lid types.JID) (types.JID, error) {
 	return types.JID{}, n.Error
 }

--- a/store/store.go
+++ b/store/store.go
@@ -174,6 +174,7 @@ type LIDStore interface {
 	GetPNForLID(ctx context.Context, lid types.JID) (types.JID, error)
 	GetLIDForPN(ctx context.Context, pn types.JID) (types.JID, error)
 	GetManyLIDsForPNs(ctx context.Context, pns []types.JID) (map[types.JID]types.JID, error)
+	GetManyPNsForLIDs(ctx context.Context, lids []types.JID) (map[types.JID]types.JID, error)
 }
 
 type AllSessionSpecificStores interface {

--- a/user.go
+++ b/user.go
@@ -455,18 +455,29 @@ func (cli *Client) GetUserDevicesContext(ctx context.Context, jids []types.JID) 
 	defer cli.userDevicesCacheLock.Unlock()
 
 	var devices, jidsToSync, fbJIDsToSync []types.JID
+	var cacheHits, cacheMisses []types.JID
 	for _, jid := range jids {
 		cached, ok := cli.userDevicesCache[jid]
 		if ok && len(cached.devices) > 0 {
 			devices = append(devices, cached.devices...)
+			cacheHits = append(cacheHits, jid)
 		} else if jid.Server == types.MessengerServer {
 			fbJIDsToSync = append(fbJIDsToSync, jid)
+			cacheMisses = append(cacheMisses, jid)
 		} else if jid.IsBot() {
 			// Bot JIDs do not have devices, the usync query is empty
 			devices = append(devices, jid)
 		} else {
 			jidsToSync = append(jidsToSync, jid)
+			cacheMisses = append(cacheMisses, jid)
 		}
+	}
+
+	if len(cacheHits) > 0 {
+		cli.Log.Debugf("User devices cache HIT for %d JIDs: %v", len(cacheHits), cacheHits)
+	}
+	if len(cacheMisses) > 0 {
+		cli.Log.Debugf("User devices cache MISS for %d JIDs: %v", len(cacheMisses), cacheMisses)
 	}
 	if len(jidsToSync) > 0 {
 		list, err := cli.usync(ctx, jidsToSync, "query", "message", []waBinary.Node{


### PR DESCRIPTION
Previously I had implemented the reverse `GetManyLIDsForPNs` in the LidMap store, now I'm adding the inverse, for utility purposes.