### PR TITLE
download: Fail faster on invalid download

### DIFF
--- a/download.go
+++ b/download.go
@@ -255,9 +255,6 @@ func (cli *Client) DownloadMediaWithPath(
 	mediaType MediaType,
 	mmsType string,
 ) (data []byte, err error) {
-	if directPath == "" {
-		return nil, fmt.Errorf("media download path missing")
-	}
 	if !strings.HasPrefix(directPath, "/") {
 		return nil, fmt.Errorf("media download path does not start with slash: %s", directPath)
 	}


### PR DESCRIPTION
If the user passes in an empty or malformed string for the path, rather than doing string concatenation with it and then trying repeatedly to resolve a nonexistent domain, just error out immediately, as it's obviously not a valid parameter.