### PR TITLE
Fix poll vote for @lid

### DIFF
--- a/msgsecret.go
+++ b/msgsecret.go
@@ -94,23 +94,27 @@ func (cli *Client) decryptMsgSecret(ctx context.Context, msg *events.Message, us
 	if cli == nil {
 		return nil, ErrClientIsNil
 	}
-	origSender, err := getOrigSenderFromKey(msg, origMsgKey)
+	origSenderFromKey, err := getOrigSenderFromKey(msg, origMsgKey)
 	if err != nil {
 		return nil, err
 	}
-	baseEncKey, origSender, err := cli.Store.MsgSecrets.GetMessageSecret(ctx, msg.Info.Chat, origSender, origMsgKey.GetID())
+	baseEncKey, origSenderStored, err := cli.Store.MsgSecrets.GetMessageSecret(ctx, msg.Info.Chat, origSenderFromKey, origMsgKey.GetID())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get original message secret key: %w", err)
 	}
 	if baseEncKey == nil {
 		return nil, ErrOriginalMessageSecretNotFound
 	}
-	secretKey, additionalData := generateMsgSecretKey(useCase, msg.Info.Sender, origMsgKey.GetID(), origSender, baseEncKey)
-	plaintext, err := gcmutil.Decrypt(secretKey, encrypted.GetEncIV(), encrypted.GetEncPayload(), additionalData)
-	if err != nil {
-		return nil, fmt.Errorf("failed to decrypt secret message: %w", err)
+	for _, origSender := range []types.JID{origSenderFromKey, origSenderStored} {
+		secretKey, additionalData := generateMsgSecretKey(useCase, msg.Info.Sender, origMsgKey.GetID(), origSender, baseEncKey)
+		var plaintext []byte
+		plaintext, err = gcmutil.Decrypt(secretKey, encrypted.GetEncIV(), encrypted.GetEncPayload(), additionalData)
+		if err != nil {
+			cli.Log.Warnf("failed to decrypt encrypted message secret key with orig sender %s: %v", origSender.ToNonAD().String(), err)
+		}
+		return plaintext, nil
 	}
-	return plaintext, nil
+	return nil, fmt.Errorf("failed to decrypt secret message usign all senders: %w", err)
 }
 
 func (cli *Client) encryptMsgSecret(ctx context.Context, ownID, chat, origSender types.JID, origMsgID types.MessageID, useCase MsgSecretType, plaintext []byte) (ciphertext, iv []byte, err error) {

--- a/store/sqlstore/store.go
+++ b/store/sqlstore/store.go
@@ -864,14 +864,14 @@ const (
 				WHEN $2 LIKE '%@lid'
 					THEN (SELECT pn || '@s.whatsapp.net' FROM whatsmeow_lid_map WHERE lid=replace($2, '@lid', ''))
 				WHEN $2 LIKE '%@s.whatsapp.net'
-					THEN (SELECT lid || '@lid' FROM whatsmeow_lid_map WHERE lid=replace($2, '@s.whatsapp.net', ''))
+					THEN (SELECT lid || '@lid' FROM whatsmeow_lid_map WHERE pn=replace($2, '@s.whatsapp.net', ''))
 			END
 		)) AND message_id=$4 AND (sender_jid=$3 OR sender_jid=(
 			CASE
 				WHEN $3 LIKE '%@lid'
 					THEN (SELECT pn || '@s.whatsapp.net' FROM whatsmeow_lid_map WHERE lid=replace($3, '@lid', ''))
 				WHEN $3 LIKE '%@s.whatsapp.net'
-					THEN (SELECT lid || '@lid' FROM whatsmeow_lid_map WHERE lid=replace($3, '@s.whatsapp.net', ''))
+					THEN (SELECT lid || '@lid' FROM whatsmeow_lid_map WHERE pn=replace($3, '@s.whatsapp.net', ''))
 			END
 		))
 	`


### PR DESCRIPTION
Fixed a poll voting issue where you send a poll to `@lid` but receive a reply in the `@s..` chat.

Thanks to these two fixes, **poll voting** now works again:
1. Fixed the SQL query for the `pn` case - previously, it was filtering by `lid`, but should be by `pn`.
2. When decrypting a message, iterate over all senders - from the message key and the saved one.

We probably should use `origSenderFromKey` in `generateMsgSecretKey`, but for security added a loop iterating over both