### PR TITLE
call: add dispatch for the entire call packets in a generic event

### DIFF
--- a/call.go
+++ b/call.go
@@ -21,6 +21,9 @@ func (cli *Client) handleCallEvent(ctx context.Context, node *waBinary.Node) {
 		cli.dispatchEvent(&events.UnknownCallEvent{Node: node})
 		return
 	}
+
+	cli.dispatchEvent(&events.GenericCallEvent{Node: node});
+
 	ag := node.AttrGetter()
 	child := node.GetChildren()[0]
 	cag := child.AttrGetter()

--- a/types/events/call.go
+++ b/types/events/call.go
@@ -11,6 +11,10 @@ import (
 	"go.mau.fi/whatsmeow/types"
 )
 
+type GenericCallEvent struct {
+	Node *waBinary.Node
+}
+
 // CallOffer is emitted when the user receives a call on WhatsApp.
 type CallOffer struct {
 	types.BasicCallMeta


### PR DESCRIPTION
This adds an unified way to get all call packets within a single handler