### PR TITLE
notification: handle device list updates

### DIFF
--- a/notification.go
+++ b/notification.go
@@ -118,10 +118,6 @@ func (cli *Client) handleDeviceNotification(ctx context.Context, node *waBinary.
 	}
 	cachedParticipantHash := participantListHashV2(cached.devices)
 	for _, child := range node.GetChildren() {
-		if child.Tag != "add" && child.Tag != "remove" {
-			cli.Log.Debugf("Unknown device list change tag %s", child.Tag)
-			continue
-		}
 		cag := child.AttrGetter()
 		deviceHash := cag.String("device_hash")
 		deviceLIDHash := cag.OptionalString("device_lid_hash")
@@ -144,7 +140,13 @@ func (cli *Client) handleDeviceNotification(ctx context.Context, node *waBinary.
 				})
 			}
 		case "update":
-			// ???
+			// Exact meaning of "update" is unknown, clear device list cache to be safe
+			cli.Log.Debugf("%s's device list updated, dropping cached devices", from)
+			delete(cli.userDevicesCache, from)
+			continue
+		default:
+			cli.Log.Debugf("Unknown device list change tag %s", child.Tag)
+			continue
 		}
 		newParticipantHash := participantListHashV2(cached.devices)
 		if newParticipantHash == deviceHash {


### PR DESCRIPTION
We just drop our existing cache for the user since we need to refetch the affected device anyway. There's probably a way to re-fetch just the changed device which could be a future optimisation.