### PR TITLE
group: parse ParticipantsCount 

### DIFF
--- a/group.go
+++ b/group.go
@@ -711,12 +711,12 @@ func (cli *Client) parseGroupNode(groupNode *waBinary.Node) (*types.GroupInfo, e
 	group.NameSetBy = ag.OptionalJIDOrEmpty("s_o")
 	group.NameSetByPN = ag.OptionalJIDOrEmpty("s_o_pn")
 
-	group.ParticipantsCount = ag.OptionalInt("size")
 	group.GroupCreated = ag.UnixTime("creation")
 	group.CreatorCountryCode = ag.OptionalString("creator_country_code")
 
 	group.AnnounceVersionID = ag.OptionalString("a_v_id")
 	group.ParticipantVersionID = ag.OptionalString("p_v_id")
+	group.ParticipantCount = ag.OptionalInt("size")
 	group.AddressingMode = types.AddressingMode(ag.OptionalString("addressing_mode"))
 
 	for _, child := range groupNode.GetChildren() {

--- a/types/group.go
+++ b/types/group.go
@@ -36,12 +36,12 @@ type GroupInfo struct {
 	GroupMembershipApprovalMode
 
 	AddressingMode     AddressingMode
-	ParticipantsCount  int
 	GroupCreated       time.Time
 	CreatorCountryCode string
 
 	ParticipantVersionID string
 	Participants         []GroupParticipant
+	ParticipantCount     int
 
 	MemberAddMode GroupMemberAddMode
 


### PR DESCRIPTION
Find out the original number of members in a group retrieved with `GetGroupInfoFromLink` and `GetGroupInfoFromInvite`
#1028 