### PR TITLE
feat: expose RawUpload for streaming/custom encryption support

### DIFF
--- a/upload.go
+++ b/upload.go
@@ -249,3 +249,9 @@ func (cli *Client) rawUpload(ctx context.Context, dataToUpload io.Reader, upload
 	}
 	return err
 }
+
+// RawUpload uploads the given attachment to WhatsApp servers.
+// Mautrix exposes this to allow streaming uploads without temporary files.
+func (cli *Client) RawUpload(ctx context.Context, dataToUpload io.Reader, uploadSize uint64, fileHash []byte, appInfo MediaType, newsletter bool, resp *UploadResponse) error {
+	return cli.rawUpload(ctx, dataToUpload, uploadSize, fileHash, appInfo, newsletter, resp)
+}


### PR DESCRIPTION
### Summary
Exposes the internal [rawUpload](cci:1://file:///home/user/Downloads/Careless%20whisper/contribution/whatsmeow/upload.go:190:0-250:1) method via a new public [RawUpload](cci:1://file:///home/user/Downloads/Careless%20whisper/vendor/go.mau.fi/whatsmeow/upload.go:252:0-254:1) method. This enables advanced use cases such as streaming uploads and double-pass encryption, which are essential for memory and storage-efficient handling of large files.

### Motivation
The current `Upload*` methods enforce specific workflows that may not be suitable for all environments:
- **[Upload](cci:1://file:///home/user/Downloads/Careless%20whisper/contribution/whatsmeow/upload.go:40:0-93:1)**: Requires the entire file in memory (byte slice).
- **[UploadReader](cci:1://file:///home/user/Downloads/Careless%20whisper/vendor/go.mau.fi/whatsmeow/upload.go:95:0-130:1)**: Requires a temporary file for encryption, which effectively doubles the disk usage requirement (e.g., uploading a 1.5GB file requires 3GB of free space: 1.5GB original + 1.5GB encrypted temp).

For resource-constrained environments (e.g., low disk space VPS or containers), this "storage double-dipping" can cause uploads to fail. By exposing [RawUpload](cci:1://file:///home/user/Downloads/Careless%20whisper/vendor/go.mau.fi/whatsmeow/upload.go:252:0-254:1), developers can implement a **double-pass streaming approach**:
1.  **Pass 1:** Read stream to calculate hashes (discarding output, 0 disk usage).
2.  **Pass 2:** Read stream again, encrypt on-the-fly, and pipe directly to WhatsApp servers via [RawUpload](cci:1://file:///home/user/Downloads/Careless%20whisper/vendor/go.mau.fi/whatsmeow/upload.go:252:0-254:1).

### Changes
- Added [RawUpload](cci:1://file:///home/user/Downloads/Careless%20whisper/vendor/go.mau.fi/whatsmeow/upload.go:252:0-254:1) wrapper to [upload.go](cci:7://file:///home/user/Downloads/Careless%20whisper/contribution/whatsmeow/upload.go:0:0-0:0) that calls the internal [rawUpload](cci:1://file:///home/user/Downloads/Careless%20whisper/contribution/whatsmeow/upload.go:190:0-250:1).

### Example Use Case
This change allows implementing storage-efficient uploads for large files (e.g., >1GB) without creating any temporary files on disk:

```go
// Calculate hashes first (Pass 1)
fileSHA256, fileEncSHA256, fileLength, encLen, _ := cbcutil.EncryptStream(cipherKey, iv, macKey, fileReader, io.Discard)

// ... Reset reader ...

// Upload directly (Pass 2)
pr, pw := io.Pipe()
go func() {
    cbcutil.EncryptStream(cipherKey, iv, macKey, fileReader, pw)
    pw.Close()
}()

// Stream encrypted data directly to server
client.RawUpload(ctx, pr, encLen, fileEncSHA256, whatsmeow.MediaDocument, false, &resp)