### PR TITLE
privacysettings: add support for new privacy settings

### DIFF
--- a/privacysettings.go
+++ b/privacysettings.go
@@ -157,6 +157,9 @@ func (cli *Client) parsePrivacySettings(privacyNode *waBinary.Node, settings *ty
 		case types.PrivacySettingTypeDefense:
 			settings.Defense = value
 			evt.DefenseChanged = true
+		case types.PrivacySettingTypeStickers:
+			settings.Stickers = value
+			evt.StickersChanged = true
 		}
 	}
 	return &evt

--- a/types/events/events.go
+++ b/types/events/events.go
@@ -535,6 +535,7 @@ type PrivacySettings struct {
 	CallAddChanged      bool
 	MessagesChanged     bool
 	DefenseChanged      bool
+	StickersChanged     bool
 }
 
 // OfflineSyncPreview is emitted right after connecting if the server is going to send events that the client missed during downtime.

--- a/types/user.go
+++ b/types/user.go
@@ -118,6 +118,7 @@ const (
 	PrivacySettingUndefined        PrivacySetting = ""
 	PrivacySettingAll              PrivacySetting = "all"
 	PrivacySettingContacts         PrivacySetting = "contacts"
+	PrivacySettingContactAllowlist PrivacySetting = "contact_allowlist"
 	PrivacySettingContactBlacklist PrivacySetting = "contact_blacklist"
 	PrivacySettingMatchLastSeen    PrivacySetting = "match_last_seen"
 	PrivacySettingKnown            PrivacySetting = "known"
@@ -139,6 +140,7 @@ const (
 	PrivacySettingTypeCallAdd      PrivacySettingType = "calladd"      // Valid values: PrivacySettingAll, PrivacySettingKnown
 	PrivacySettingTypeMessages     PrivacySettingType = "messages"     // Valid values: PrivacySettingAll, PrivacySettingContacts
 	PrivacySettingTypeDefense      PrivacySettingType = "defense"      // Valid values: PrivacySettingOnStandard, PrivacySettingOff
+	PrivacySettingTypeStickers     PrivacySettingType = "stickers"     // Valid values: PrivacySettingContacts, PrivacySettingContactAllowlist, PrivacySettingNone
 )
 
 // PrivacySettings contains the user's privacy settings.
@@ -152,6 +154,7 @@ type PrivacySettings struct {
 	Online       PrivacySetting // Valid values: PrivacySettingAll, PrivacySettingMatchLastSeen
 	Messages     PrivacySetting // Valid values: PrivacySettingAll, PrivacySettingContacts
 	Defense      PrivacySetting // Valid values: PrivacySettingOnStandard, PrivacySettingOff
+	Stickers     PrivacySetting // Valid values: PrivacySettingContacts, PrivacySettingContactAllowlist, PrivacySettingNone
 }
 
 // StatusPrivacyType is the type of list in StatusPrivacy.


### PR DESCRIPTION
The following privacy categories are now observed in the <privacy> node:
```xml
<privacy>
  <category name="calladd" value="..."/>
  <category name="defense" value="..."/>
  <category name="groupadd" value="..."/>
  <category name="messages" value="..."/>
  <category name="online" value="..."/>
  <category name="last" value="..."/>
  <category name="profile" value="..."/>
  <category name="readreceipts" value="..."/>
  <category name="status" value="..."/>
  <category name="stickers" value="..."/>
</privacy>
```