### PR TITLE
socket: fix data race on FrameSocket.closed

### DIFF
--- a/socket/framesocket.go
+++ b/socket/framesocket.go
@@ -97,7 +97,7 @@ func (fs *FrameSocket) Connect(ctx context.Context) error {
 
 	// Reset the closed state when opening a new connection.
 	fs.closed.Store(false)
-	
+
 	fs.parentCtx = ctx
 	fs.cancelCtx, fs.cancel = context.WithCancel(ctx)
 


### PR DESCRIPTION
Fixes #1085

This changes FrameSocket.closed from bool to atomic.Bool.

Reason:
FrameSocket.Close() writes to closed, while readPump() reads it concurrently without synchronized access, which triggers a data race under the race detector.

Changes:
- replace closed bool with atomic.Bool
- use closed.Store(true) in Close()
- use closed.Load() in readPump()
- reset the flag with closed.Store(false) in Connect()