### PR TITLE
feat: exported error/confirmation receipt handling for manual sync

### DIFF
--- a/client.go
+++ b/client.go
@@ -99,7 +99,7 @@ type Client struct {
 	appStateProc     *appstate.Processor
 	appStateSyncLock sync.Mutex
 
-	historySyncNotifications  chan *waE2E.HistorySyncNotification
+	historySyncNotifications  chan *historySyncItem
 	historySyncHandlerStarted atomic.Bool
 	ManualHistorySyncDownload bool
 
@@ -254,7 +254,7 @@ func NewClient(deviceStore *store.Device, log waLog.Logger) *Client {
 
 		incomingRetryRequestCounter: make(map[incomingRetryKey]int),
 
-		historySyncNotifications: make(chan *waE2E.HistorySyncNotification, 32),
+		historySyncNotifications: make(chan *historySyncItem, 32),
 
 		groupCache:       make(map[types.JID]*groupMetaCache),
 		userDevicesCache: make(map[types.JID]deviceCache),

--- a/client.go
+++ b/client.go
@@ -99,9 +99,10 @@ type Client struct {
 	appStateProc     *appstate.Processor
 	appStateSyncLock sync.Mutex
 
-	historySyncNotifications  chan *historySyncItem
-	historySyncHandlerStarted atomic.Bool
-	ManualHistorySyncDownload bool
+	historySyncNotifications        chan *waE2E.HistorySyncNotification
+	historySyncHandlerStarted       atomic.Bool
+	ManualHistorySyncDownload       bool
+	DisableManualHistorySyncReceipt bool
 
 	uploadPreKeysLock sync.Mutex
 	lastPreKeyUpload  time.Time
@@ -254,7 +255,7 @@ func NewClient(deviceStore *store.Device, log waLog.Logger) *Client {
 
 		incomingRetryRequestCounter: make(map[incomingRetryKey]int),
 
-		historySyncNotifications: make(chan *historySyncItem, 32),
+		historySyncNotifications: make(chan *waE2E.HistorySyncNotification, 32),
 
 		groupCache:       make(map[types.JID]*groupMetaCache),
 		userDevicesCache: make(map[types.JID]deviceCache),

--- a/internals.go
+++ b/internals.go
@@ -392,7 +392,7 @@ func (int *DangerousInternalClient) HandleDecryptedMessage(ctx context.Context, 
 }
 
 func (int *DangerousInternalClient) SendProtocolMessageReceipt(ctx context.Context, id types.MessageID, msgType types.ReceiptType) {
-	int.c.sendProtocolMessageReceipt(ctx, id, msgType)
+	_ = int.c.SendProtocolMessageReceipt(ctx, id, msgType)
 }
 
 func (int *DangerousInternalClient) DecryptMsgSecret(ctx context.Context, msg *events.Message, useCase MsgSecretType, encrypted messageEncryptedSecret, origMsgKey *waCommon.MessageKey) ([]byte, error) {

--- a/internals.go
+++ b/internals.go
@@ -391,10 +391,6 @@ func (int *DangerousInternalClient) HandleDecryptedMessage(ctx context.Context, 
 	return int.c.handleDecryptedMessage(ctx, info, msg, retryCount)
 }
 
-func (int *DangerousInternalClient) SendProtocolMessageReceipt(ctx context.Context, id types.MessageID, msgType types.ReceiptType) {
-	_ = int.c.SendProtocolMessageReceipt(ctx, id, msgType)
-}
-
 func (int *DangerousInternalClient) DecryptMsgSecret(ctx context.Context, msg *events.Message, useCase MsgSecretType, encrypted messageEncryptedSecret, origMsgKey *waCommon.MessageKey) ([]byte, error) {
 	return int.c.decryptMsgSecret(ctx, msg, useCase, encrypted, origMsgKey)
 }

--- a/message.go
+++ b/message.go
@@ -658,6 +658,11 @@ func (cli *Client) handleSenderKeyDistributionMessage(ctx context.Context, chat,
 	cli.Log.Debugf("Processed sender key distribution message from %s in %s", senderKeyName.Sender().String(), senderKeyName.GroupID())
 }
 
+type historySyncItem struct {
+	Notification *waE2E.HistorySyncNotification
+	MsgID        types.MessageID
+}
+
 func (cli *Client) handleHistorySyncNotificationLoop() {
 	defer func() {
 		cli.historySyncHandlerStarted.Store(false)
@@ -676,16 +681,59 @@ func (cli *Client) handleHistorySyncNotificationLoop() {
 	ctx := cli.BackgroundEventCtx
 	for {
 		select {
-		case notif := <-cli.historySyncNotifications:
-			blob, err := cli.DownloadHistorySync(ctx, notif, false)
-			if err != nil {
-				cli.Log.Errorf("Failed to download history sync: %v", err)
+		case item := <-cli.historySyncNotifications:
+			blob, err := cli.DownloadHistorySync(ctx, item.Notification, true)
+			if err == nil {
+				handlerFailed := cli.dispatchEvent(&events.HistorySync{Data: blob})
+				if handlerFailed {
+					cli.Log.Warnf("History sync chunk %d processed locally, but an event handler reported failure; leaving chunk unacknowledged",
+						item.Notification.GetChunkOrder())
+				} else {
+					go cli.sendProtocolMessageReceipt(ctx, item.MsgID, types.ReceiptTypeHistorySync)
+				}
+			} else if !errors.Is(err, context.Canceled) &&
+				!errors.Is(err, context.DeadlineExceeded) &&
+				!shouldRetryMediaDownload(err) {
+				cli.Log.Errorf("History sync chunk %d failed with a non-retryable error, requesting re-upload: %v",
+					item.Notification.GetChunkOrder(), err)
+				go cli.sendHistorySyncServerErrorReceipt(ctx, item.MsgID, item.Notification.GetMediaKey())
 			} else {
-				cli.dispatchEvent(&events.HistorySync{Data: blob})
+				cli.Log.Warnf("History sync chunk %d failed with a retryable transport error; leaving chunk unacknowledged: %v",
+					item.Notification.GetChunkOrder(), err)
 			}
 		case <-time.After(1 * time.Minute):
 			return
 		}
+	}
+}
+
+func (cli *Client) sendHistorySyncServerErrorReceipt(ctx context.Context, msgID types.MessageID, mediaKey []byte) {
+	ciphertext, iv, err := encryptMediaRetryReceipt(msgID, mediaKey)
+	if err != nil {
+		cli.Log.Warnf("Failed to encrypt history sync server-error receipt for %s: %v", msgID, err)
+		return
+	}
+	ownID := cli.getOwnID().ToNonAD()
+	if ownID.IsEmpty() {
+		return
+	}
+	err = cli.sendNode(ctx, waBinary.Node{
+		Tag: "receipt",
+		Attrs: waBinary.Attrs{
+			"id":       string(msgID),
+			"type":     "server-error",
+			"to":       ownID,
+			"category": "peer",
+		},
+		Content: []waBinary.Node{
+			{Tag: "encrypt", Content: []waBinary.Node{
+				{Tag: "enc_p", Content: ciphertext},
+				{Tag: "enc_iv", Content: iv},
+			}},
+		},
+	})
+	if err != nil {
+		cli.Log.Warnf("Failed to send history sync server-error receipt for %s: %v", msgID, err)
 	}
 }
 
@@ -797,13 +845,21 @@ func (cli *Client) handleProtocolMessage(ctx context.Context, info *types.Messag
 	}
 
 	if protoMsg.GetHistorySyncNotification() != nil {
+		msgID := info.ID
+		if origID := protoMsg.GetHistorySyncNotification().GetOriginalMessageID(); origID != "" {
+			msgID = types.MessageID(origID)
+		}
 		if !cli.ManualHistorySyncDownload {
-			cli.historySyncNotifications <- protoMsg.HistorySyncNotification
+			cli.historySyncNotifications <- &historySyncItem{
+				Notification: protoMsg.HistorySyncNotification,
+				MsgID:        msgID,
+			}
 			if cli.historySyncHandlerStarted.CompareAndSwap(false, true) {
 				go cli.handleHistorySyncNotificationLoop()
 			}
+		} else {
+			go cli.sendProtocolMessageReceipt(ctx, msgID, types.ReceiptTypeHistorySync)
 		}
-		go cli.sendProtocolMessageReceipt(ctx, info.ID, types.ReceiptTypeHistorySync)
 	}
 
 	if protoMsg.GetLidMigrationMappingSyncMessage() != nil {

--- a/message.go
+++ b/message.go
@@ -683,23 +683,22 @@ func (cli *Client) handleHistorySyncNotificationLoop() {
 		select {
 		case item := <-cli.historySyncNotifications:
 			blob, err := cli.DownloadHistorySync(ctx, item.Notification, true)
-			if err == nil {
-				handlerFailed := cli.dispatchEvent(&events.HistorySync{Data: blob})
-				if handlerFailed {
-					cli.Log.Warnf("History sync chunk %d processed locally, but an event handler reported failure; leaving chunk unacknowledged",
-						item.Notification.GetChunkOrder())
+			if err != nil {
+				if !errors.Is(err, context.Canceled) &&
+					!errors.Is(err, context.DeadlineExceeded) &&
+					!shouldRetryMediaDownload(err) {
+					cli.Log.Errorf("History sync chunk %d failed with a non-retryable error, requesting re-upload: %v",
+						item.Notification.GetChunkOrder(), err)
+					go cli.sendHistorySyncServerErrorReceipt(ctx, item.MsgID, item.Notification.GetMediaKey())
 				} else {
-					go cli.sendProtocolMessageReceipt(ctx, item.MsgID, types.ReceiptTypeHistorySync)
+					cli.Log.Warnf("History sync chunk %d failed with a retryable transport error; leaving chunk unacknowledged: %v",
+						item.Notification.GetChunkOrder(), err)
 				}
-			} else if !errors.Is(err, context.Canceled) &&
-				!errors.Is(err, context.DeadlineExceeded) &&
-				!shouldRetryMediaDownload(err) {
-				cli.Log.Errorf("History sync chunk %d failed with a non-retryable error, requesting re-upload: %v",
-					item.Notification.GetChunkOrder(), err)
-				go cli.sendHistorySyncServerErrorReceipt(ctx, item.MsgID, item.Notification.GetMediaKey())
+			} else if cli.dispatchEvent(&events.HistorySync{Data: blob}) {
+				cli.Log.Warnf("History sync chunk %d processed locally, but an event handler reported failure; leaving chunk unacknowledged",
+					item.Notification.GetChunkOrder())
 			} else {
-				cli.Log.Warnf("History sync chunk %d failed with a retryable transport error; leaving chunk unacknowledged: %v",
-					item.Notification.GetChunkOrder(), err)
+				go cli.sendProtocolMessageReceipt(ctx, item.MsgID, types.ReceiptTypeHistorySync)
 			}
 		case <-time.After(1 * time.Minute):
 			return

--- a/message.go
+++ b/message.go
@@ -658,11 +658,6 @@ func (cli *Client) handleSenderKeyDistributionMessage(ctx context.Context, chat,
 	cli.Log.Debugf("Processed sender key distribution message from %s in %s", senderKeyName.Sender().String(), senderKeyName.GroupID())
 }
 
-type historySyncItem struct {
-	Notification *waE2E.HistorySyncNotification
-	MsgID        types.MessageID
-}
-
 func (cli *Client) handleHistorySyncNotificationLoop() {
 	defer func() {
 		cli.historySyncHandlerStarted.Store(false)
@@ -681,24 +676,12 @@ func (cli *Client) handleHistorySyncNotificationLoop() {
 	ctx := cli.BackgroundEventCtx
 	for {
 		select {
-		case item := <-cli.historySyncNotifications:
-			blob, err := cli.DownloadHistorySync(ctx, item.Notification, true)
+		case notif := <-cli.historySyncNotifications:
+			blob, err := cli.DownloadHistorySync(ctx, notif, false)
 			if err != nil {
-				if !errors.Is(err, context.Canceled) &&
-					!errors.Is(err, context.DeadlineExceeded) &&
-					!shouldRetryMediaDownload(err) {
-					cli.Log.Errorf("History sync chunk %d failed with a non-retryable error, requesting re-upload: %v",
-						item.Notification.GetChunkOrder(), err)
-					go cli.sendHistorySyncServerErrorReceipt(ctx, item.MsgID, item.Notification.GetMediaKey())
-				} else {
-					cli.Log.Warnf("History sync chunk %d failed with a retryable transport error; leaving chunk unacknowledged: %v",
-						item.Notification.GetChunkOrder(), err)
-				}
-			} else if cli.dispatchEvent(&events.HistorySync{Data: blob}) {
-				cli.Log.Warnf("History sync chunk %d processed locally, but an event handler reported failure; leaving chunk unacknowledged",
-					item.Notification.GetChunkOrder())
+				cli.Log.Errorf("Failed to download history sync: %v", err)
 			} else {
-				go cli.sendProtocolMessageReceipt(ctx, item.MsgID, types.ReceiptTypeHistorySync)
+				cli.dispatchEvent(&events.HistorySync{Data: blob})
 			}
 		case <-time.After(1 * time.Minute):
 			return
@@ -706,15 +689,16 @@ func (cli *Client) handleHistorySyncNotificationLoop() {
 	}
 }
 
-func (cli *Client) sendHistorySyncServerErrorReceipt(ctx context.Context, msgID types.MessageID, mediaKey []byte) {
+// SendHistorySyncServerErrorReceipt sends a history sync server-error receipt, which
+// asks the phone to re-upload the referenced history sync payload.
+func (cli *Client) SendHistorySyncServerErrorReceipt(ctx context.Context, msgID types.MessageID, mediaKey []byte) error {
 	ciphertext, iv, err := encryptMediaRetryReceipt(msgID, mediaKey)
 	if err != nil {
-		cli.Log.Warnf("Failed to encrypt history sync server-error receipt for %s: %v", msgID, err)
-		return
+		return fmt.Errorf("failed to encrypt history sync server-error receipt: %w", err)
 	}
 	ownID := cli.getOwnID().ToNonAD()
 	if ownID.IsEmpty() {
-		return
+		return ErrNotLoggedIn
 	}
 	err = cli.sendNode(ctx, waBinary.Node{
 		Tag: "receipt",
@@ -732,8 +716,9 @@ func (cli *Client) sendHistorySyncServerErrorReceipt(ctx context.Context, msgID 
 		},
 	})
 	if err != nil {
-		cli.Log.Warnf("Failed to send history sync server-error receipt for %s: %v", msgID, err)
+		return fmt.Errorf("Failed to send history sync server-error receipt: %w", err)
 	}
+	return nil
 }
 
 // DownloadHistorySync will download and parse the history sync blob from the given history sync notification.
@@ -844,20 +829,19 @@ func (cli *Client) handleProtocolMessage(ctx context.Context, info *types.Messag
 	}
 
 	if protoMsg.GetHistorySyncNotification() != nil {
-		msgID := info.ID
-		if origID := protoMsg.GetHistorySyncNotification().GetOriginalMessageID(); origID != "" {
-			msgID = types.MessageID(origID)
-		}
 		if !cli.ManualHistorySyncDownload {
-			cli.historySyncNotifications <- &historySyncItem{
-				Notification: protoMsg.HistorySyncNotification,
-				MsgID:        msgID,
-			}
+			cli.historySyncNotifications <- protoMsg.HistorySyncNotification
 			if cli.historySyncHandlerStarted.CompareAndSwap(false, true) {
 				go cli.handleHistorySyncNotificationLoop()
 			}
-		} else {
-			go cli.sendProtocolMessageReceipt(ctx, msgID, types.ReceiptTypeHistorySync)
+		}
+		if !(cli.ManualHistorySyncDownload && cli.DisableManualHistorySyncReceipt) {
+			go func() {
+				err := cli.SendProtocolMessageReceipt(ctx, info.ID, types.ReceiptTypeHistorySync)
+				if err != nil {
+					cli.Log.Warnf("Failed to send acknowledgement for protocol message %s: %v", info.ID, err)
+				}
+			}()
 		}
 	}
 
@@ -880,7 +864,12 @@ func (cli *Client) handleProtocolMessage(ctx context.Context, info *types.Messag
 	}
 
 	if info.Category == "peer" {
-		go cli.sendProtocolMessageReceipt(ctx, info.ID, types.ReceiptTypePeerMsg)
+		go func() {
+			err := cli.SendProtocolMessageReceipt(ctx, info.ID, types.ReceiptTypePeerMsg)
+			if err != nil {
+				cli.Log.Warnf("Failed to send acknowledgement for protocol message %s: %v", info.ID, err)
+			}
+		}()
 	}
 	return
 }
@@ -1093,9 +1082,10 @@ func (cli *Client) handleDecryptedMessage(ctx context.Context, info *types.Messa
 	return cli.dispatchEvent(evt.UnwrapRaw())
 }
 
-func (cli *Client) sendProtocolMessageReceipt(ctx context.Context, id types.MessageID, msgType types.ReceiptType) {
+// SendProtocolMessageReceipt sends a receipt for a protocol message back to the phone.
+func (cli *Client) SendProtocolMessageReceipt(ctx context.Context, id types.MessageID, msgType types.ReceiptType) error {
 	if len(id) == 0 {
-		return
+		return nil
 	}
 	err := cli.sendNode(ctx, waBinary.Node{
 		Tag: "receipt",
@@ -1107,6 +1097,7 @@ func (cli *Client) sendProtocolMessageReceipt(ctx context.Context, id types.Mess
 		Content: nil,
 	})
 	if err != nil {
-		cli.Log.Warnf("Failed to send acknowledgement for protocol message %s: %v", id, err)
+		return err
 	}
+	return nil
 }


### PR DESCRIPTION
Add the capability to send server-error receipts manually (not supported before) and export the confirmation receipt to be able to send it manually too later with the DisableManualHistorySyncReceipt true (new flag added to disable automatic confirmation receipts in manual sync mode)