### PR TITLE
Fix sending pin messages by adding edit attribute

### DIFF
--- a/send.go
+++ b/send.go
@@ -1033,6 +1033,8 @@ func getEditAttribute(msg *waE2E.Message) types.EditAttribute {
 		return types.EditAttributeSenderRevoke
 	case msg.KeepInChatMessage != nil && msg.KeepInChatMessage.GetKey().GetFromMe() && msg.KeepInChatMessage.GetKeepType() == waE2E.KeepType_UNDO_KEEP_FOR_ALL:
 		return types.EditAttributeSenderRevoke
+	case msg.PinInChatMessage != nil:
+		return types.EditAttributePinInChat
 	}
 	return types.EditAttributeEmpty
 }


### PR DESCRIPTION
Adds the missing `PinInChatMessage` case to `getEditAttribute` so that `SendMessage` sets the required `edit="2"` attribute when sending pin messages. Without this, WhatsApp silently ignores outgoing pin messages.

Fixes #1105

Related: mautrix/whatsapp#905