### PR TITLE
msgsecret: fix poll vote encryption using wrong identity 

### DIFF
--- a/msgsecret.go
+++ b/msgsecret.go
@@ -328,7 +328,7 @@ func (cli *Client) EncryptPollVote(ctx context.Context, pollInfo *types.MessageI
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal poll vote protobuf: %w", err)
 	}
-	ciphertext, iv, err := cli.encryptMsgSecret(ctx, cli.getOwnID(), pollInfo.Chat, pollInfo.Sender, pollInfo.ID, EncSecretPollVote, plaintext)
+	ciphertext, iv, err := cli.encryptMsgSecret(ctx, cli.getOwnLID(), pollInfo.Chat, pollInfo.Sender, pollInfo.ID, EncSecretPollVote, plaintext)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encrypt poll vote: %w", err)
 	}
@@ -347,7 +347,6 @@ func (cli *Client) EncryptComment(ctx context.Context, rootMsgInfo *types.Messag
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal comment protobuf: %w", err)
 	}
-	// TODO is hardcoding LID here correct? What about polls?
 	ciphertext, iv, err := cli.encryptMsgSecret(ctx, cli.getOwnLID(), rootMsgInfo.Chat, rootMsgInfo.Sender, rootMsgInfo.ID, EncSecretComment, plaintext)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encrypt comment: %w", err)


### PR DESCRIPTION
`EncryptPollVote` uses `cli.getOwnID()` (Phone Number JID) for key derivation, but `SendMessage` sends using LID    identity. WhatsApp recipients derive the decryption key using the LID, causing a mismatch and `decrypt-fail="hide"` on all encrypted poll vote payloads.                                                                                 
                                                                                                                       
`EncryptComment` and `EncryptReaction` already use `cli.getOwnLID()` correctly. This change aligns `EncryptPollVote` 
with them.
                                                                                                                     
Also removes the TODO on line 350 which questioned whether polls should use LID.                                     

Fixes #1076                                                                                                          
See also mautrix/whatsapp#681  