### PR TITLE
appstate: trigger recovery snapshot request on LTHash/PatchMAC mismatch

### DIFF
--- a/appstate.go
+++ b/appstate.go
@@ -161,11 +161,33 @@ func (cli *Client) applyAppStatePatches(
 		if errors.Is(err, appstate.ErrKeyNotFound) {
 			go cli.requestMissingAppStateKeys(context.WithoutCancel(ctx), patches)
 		} else {
+			if errors.Is(err, appstate.ErrMismatchingLTHash) || errors.Is(err, appstate.ErrMismatchingPatchMAC) {
+				// Local hash state has diverged from the server. Request a fresh recovery
+				// snapshot from the user's primary device. The response will be handled by
+				// handleAppStateRecovery, which deletes the local version and applies the
+				// server's snapshot.
+				go cli.requestAppStateRecovery(context.WithoutCancel(ctx), name)
+			}
 			cli.dispatchEvent(&events.AppStateSyncError{Name: name, FullSync: fullSync, Error: err})
 		}
 		return state, fmt.Errorf("failed to decode app state %s patches: %w", name, err)
 	}
 	return newState, cli.collectEventsToDispatch(ctx, name, mutations, fullSync, eventsToDispatch)
+}
+
+// requestAppStateRecovery asks the primary device for a fresh snapshot of the given
+// app state collection. This is triggered automatically when DecodePatches returns
+// ErrMismatchingLTHash or ErrMismatchingPatchMAC, which indicate that the local
+// cached hash has diverged from the server's (usually after app state mutations
+// were made on another device while this one was offline, or after an upstream
+// proto version bump).
+func (cli *Client) requestAppStateRecovery(ctx context.Context, name appstate.WAPatchName) {
+	msg := BuildAppStateRecoveryRequest(name)
+	cli.Log.Infof("Requesting app state recovery snapshot for %s due to hash mismatch", name)
+	_, err := cli.SendPeerMessage(ctx, msg)
+	if err != nil {
+		cli.Log.Warnf("Failed to send app state recovery request for %s: %v", name, err)
+	}
 }
 
 func (cli *Client) collectEventsToDispatch(


### PR DESCRIPTION
## Problem

When `Client.applyAppStatePatches` calls `DecodePatches` and it returns
`ErrMismatchingLTHash` or `ErrMismatchingPatchMAC`, the error bubbles up
to the caller without any attempt to recover. Every subsequent call to
`SendAppState` then fails with an `app state update (409 conflict)` that
wraps the same decode error, because the retry path in `sendAppState`
tries to re-apply the server's conflict response through the exact same
code path that just failed.

This leaves the local hash state permanently diverged from the server —
the only remedy is to log the instance out and re-pair, which is what I
and several other users have been doing to restore label / mute / pin /
archive operations.

The recovery machinery to recover from this already exists:
`handleAppStateRecovery` consumes a `SyncdSnapshotFatalRecoveryResponse`
and rebuilds the collection from the primary device's snapshot, and
`BuildAppStateRecoveryRequest` builds the request message. However,
nothing in the client asks the primary device for that snapshot when the
local divergence is detected — the recovery path only fires when the
server proactively sends one.

## Fix

When `applyAppStatePatches` observes `ErrMismatchingLTHash` or
`ErrMismatchingPatchMAC`, kick off a goroutine that sends
`BuildAppStateRecoveryRequest(name)` via `SendPeerMessage` to the primary
device. The primary responds with a peer data operation that is already
dispatched into `handleAppStateRecovery`, which resets the collection to
a known-good state on its own.

The dispatch of `AppStateSyncError` is preserved for observers.

## Reproduction

1. Pair a device, make app state changes (e.g. create and apply labels)
   from another device while this one is offline, then reconnect.
2. Call `Client.SendAppState(ctx, appstate.BuildLabelChat(jid, "17", true))`.
3. Without this patch: returns `ErrAppStateUpdate` wrapped around
   `failed to verify patch vN: mismatching LTHash`, and keeps failing on
   every subsequent retry.
4. With this patch: first call returns the same error, but the recovery
   snapshot request is dispatched in the background; by the time the
   caller retries a few seconds later the local state has been restored
   and the operation succeeds.

## Testing

Built and ran against a real account with an app state that had been
diverged for several weeks (`mismatching LTHash v275`). The first
`SendAppState` call still failed, the log confirmed
`Requesting app state recovery snapshot for regular due to hash mismatch`,
and a retry ~8 seconds later succeeded. A follow-up batch of 10 label
operations all succeeded on the first attempt.

No existing tests regress; the new branch only fires on the two specific
errors and is gated behind the same `errors.Is` check used for
`ErrKeyNotFound`.