### PR TITLE
fix(msgsecret): preserve caller origSender across @lid↔phone chat migration

### DIFF
--- a/msgsecret.go
+++ b/msgsecret.go
@@ -98,7 +98,19 @@ func (cli *Client) decryptMsgSecret(ctx context.Context, msg *events.Message, us
 	if err != nil {
 		return nil, err
 	}
-	baseEncKey, origSender, err := cli.Store.MsgSecrets.GetMessageSecret(ctx, msg.Info.Chat, origSender, origMsgKey.GetID())
+	// GetMessageSecret transparently resolves @lid↔@s.whatsapp.net via
+	// whatsmeow_lid_map and returns whichever sender form the secret was
+	// originally stored under (realSender). We intentionally *do not*
+	// override the caller's origSender with realSender here: the HKDF
+	// context used to derive the symmetric key includes the sender JID
+	// string, and the peer that encrypted the message used the JID form
+	// present on the echoed origMsgKey (i.e. the same form we have in
+	// origSender above). Overriding with a differently-represented
+	// realSender — which happens after chat migration when the secret
+	// was stored pre-migration as @s.whatsapp.net but the vote key
+	// arrives as @lid (or vice-versa) — produces a mismatched HKDF
+	// context and GCM auth fails.
+	baseEncKey, realSender, err := cli.Store.MsgSecrets.GetMessageSecret(ctx, msg.Info.Chat, origSender, origMsgKey.GetID())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get original message secret key: %w", err)
 	}
@@ -108,6 +120,16 @@ func (cli *Client) decryptMsgSecret(ctx context.Context, msg *events.Message, us
 	secretKey, additionalData := generateMsgSecretKey(useCase, msg.Info.Sender, origMsgKey.GetID(), origSender, baseEncKey)
 	plaintext, err := gcmutil.Decrypt(secretKey, encrypted.GetEncIV(), encrypted.GetEncPayload(), additionalData)
 	if err != nil {
+		// Fall back to realSender (legacy behaviour) in case the stored
+		// form actually is the one the peer used — e.g. secrets persisted
+		// by an older whatsmeow version that only ever stored the phone
+		// representation.
+		if !realSender.IsEmpty() && realSender != origSender {
+			secretKey2, additionalData2 := generateMsgSecretKey(useCase, msg.Info.Sender, origMsgKey.GetID(), realSender, baseEncKey)
+			if plaintext2, err2 := gcmutil.Decrypt(secretKey2, encrypted.GetEncIV(), encrypted.GetEncPayload(), additionalData2); err2 == nil {
+				return plaintext2, nil
+			}
+		}
 		return nil, fmt.Errorf("failed to decrypt secret message: %w", err)
 	}
 	return plaintext, nil


### PR DESCRIPTION
> Reopens #1122 (auto-closed when the head branch was deleted; PR has been rebased onto current `main` with no conflicts and the fix is unchanged).

## Bug

`DecryptPollVote` (and, by extension, any `decryptMsgSecret` caller) fails with

```
failed to decrypt secret message: cipher: message authentication failed
```

on DMs that WhatsApp has migrated to `@lid` addressing, whenever the poll's message secret was stored before the migration under the `@s.whatsapp.net` form of the sender.

## Root cause

`GetMessageSecret` intentionally resolves `@`@s.whatsapp.net` via `whatsmeow_lid_map` in its SQL query (see `store/sqlstore/store.go`), so the row is found regardless of which form is passed in. But it also returns the **stored** sender form as `realSender`, and `decryptMsgSecret` unconditionally overwrites the caller's origSender with that value:lid`

```go
origSender, err := getOrigSenderFromKey(msg, origMsgKey)
...
baseEncKey, origSender, err := cli.Store.MsgSecrets.GetMessageSecret(ctx, msg.Info.Chat, origSender, origMsgKey.GetID())
...
secretKey, additionalData := generateMsgSecretKey(useCase, msg.Info.Sender, origMsgKey.GetID(), origSender, baseEncKey)
```

The HKDF context inside `generateMsgSecretKey` is built from the sender JID string. The peer that encrypted the vote derived its key using the sender form present on the echoed ` i.e. the same form the caller originally had in `origSender`. Overriding with a differently-represented `realSender` produces a mismatched HKDF context and GCM auth fails.origMsgKey` 

## Fix

Keep the caller's `origSender` for HKDF derivation (it matches the peer's derivation). If that fails, fall back to the stored `realSender` so legacy stores whose secrets predate any LID-aware behaviour still decrypt.

## Reproduction

1. Have an active DM that WhatsApp has migrated to `@lid` addressing on the peer's side.
2. Send a poll from whatsmeow to that DM.
3. Have the peer vote.
4. Observe: `cli.DecryptPollVote(ctx, evt)` returns `cipher: message authentication failed`.

With this patch applied, decryption succeeds.

## Notes

- I've kept the fallback to `realSender` so any existing store that relied on the overwrite behaviour continues to work.
- Encryption path (`encryptMsgSecret`) has the same override  I haven't touched it because, for the sending side, the caller's origSender and the resolved realSender should coincide (we're about to encrypt to the peer whose form we used when storing). Happy to extend the change if a maintainer sees value.pattern 
