### PR TITLE
EncryptPollVote: use LID for HKDF (matches EncryptReaction/Comment)

### DIFF
--- a/msgsecret.go
+++ b/msgsecret.go
@@ -328,7 +328,7 @@ func (cli *Client) EncryptPollVote(ctx context.Context, pollInfo *types.MessageI
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal poll vote protobuf: %w", err)
 	}
-	ciphertext, iv, err := cli.encryptMsgSecret(ctx, cli.getOwnID(), pollInfo.Chat, pollInfo.Sender, pollInfo.ID, EncSecretPollVote, plaintext)
+	ciphertext, iv, err := cli.encryptMsgSecret(ctx, cli.getOwnLID(), pollInfo.Chat, pollInfo.Sender, pollInfo.ID, EncSecretPollVote, plaintext)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encrypt poll vote: %w", err)
 	}
@@ -347,7 +347,6 @@ func (cli *Client) EncryptComment(ctx context.Context, rootMsgInfo *types.Messag
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal comment protobuf: %w", err)
 	}
-	// TODO is hardcoding LID here correct? What about polls?
 	ciphertext, iv, err := cli.encryptMsgSecret(ctx, cli.getOwnLID(), rootMsgInfo.Chat, rootMsgInfo.Sender, rootMsgInfo.ID, EncSecretComment, plaintext)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encrypt comment: %w", err)


### PR DESCRIPTION
## Problem

`EncryptPollVote` passes `cli.getOwnID()` (phone JID, `<phone>@s.whatsapp.net`) as the sender identity when computing the HKDF key via `encryptMsgSecret`. In LID-enabled chats the **receiving** client uses the sender's LID (`<lid>@lid`) for the same derivation, so the keys don't match — the GCM decryption silently fails and the vote is dropped without any error surfacing to the sender.

## Fix

Change `getOwnID()` → `getOwnLID()` in `EncryptPollVote`. One character.

```diff
-ciphertext, iv, err := cli.encryptMsgSecret(ctx, cli.getOwnID(), pollInfo.Chat, pollInfo.Sender, pollInfo.ID, EncSecretPollVote, plaintext)
+ciphertext, iv, err := cli.encryptMsgSecret(ctx, cli.getOwnLID(), pollInfo.Chat, pollInfo.Sender, pollInfo.ID, EncSecretPollVote, plaintext)
```

## Precedent in this file

`EncryptReaction` (line 376) and `EncryptComment` (line 351) already use `getOwnLID()` for exactly this reason. `EncryptComment` even carried an explicit TODO:

```go
// TODO is hardcoding LID here correct? What about polls?
```

This PR answers that TODO (yes, LID is correct) and removes it, since `EncryptPollVote` now does the same thing.

## Reproduction

Observed on a personal-AI WhatsApp bridge (`go.mau.fi/whatsmeow v0.0.0-20260416104156-3ff20cd3462a`) in a LID-enabled DM: votes sent via `BuildPollVote` were silently discarded by the native WhatsApp client. Switching to `getOwnLID()` resolved the issue.