### PR TITLE
docs: update sqlstore.New example to include context parameter

### DIFF
--- a/client.go
+++ b/client.go
@@ -226,7 +226,7 @@ const handlerQueueSize = 2048
 //
 // The device store must be set. A default SQL-backed implementation is available in the store/sqlstore package.
 //
-//	container, err := sqlstore.New("sqlite3", "file:yoursqlitefile.db?_foreign_keys=on", nil)
+//	container, err := sqlstore.New(context.Background(), "sqlite3", "file:yoursqlitefile.db?_foreign_keys=on", nil)
 //	if err != nil {
 //		panic(err)
 //	}


### PR DESCRIPTION
The example comment in client.go was using the old API signature 
without context.Context. Updated to match the current signature 
which requires context as the first parameter.

The example in store/sqlstore/container.go is already correct.


---
## Checklist
- [x] I have read and followed the contributing guidelines at https://docs.mau.fi/bridges/general/contributing.html
- [x] This is a trivial docs fix updating example to match current API. No breaking change.
- [x] Ran `go fmt./...` on changed filesfiles
---