### PR TITLE
client, signal: Optionally disable Signal and node processing

### DIFF
--- a/client.go
+++ b/client.go
@@ -73,11 +73,10 @@ type RawNodeHandler func(ctx context.Context, node *waBinary.Node) (modified *wa
 type DisabledFeatures struct {
 	// Signal disables the library's Signal-session machinery. When set:
 	//   - Incoming `<message>` envelopes are not decrypted and not
-	//     ack'd. The actual decrypting client downstream is responsible
-	//     for ack'ing once it has processed the message.
+	//     ack'd. They are emitted as [events.UndecryptedMessage]; the
+	//     downstream system that owns the Signal session is responsible
+	//     for ack'ing once it has processed the envelope.
 	//   - The periodic prekey-upload loop is a no-op.
-	// Combine with [RawNodeHandler] to forward the raw envelopes to the
-	// system that actually owns the Signal session.
 	Signal bool
 }
 

--- a/client.go
+++ b/client.go
@@ -880,6 +880,24 @@ func (cli *Client) handleFrame(ctx context.Context, data []byte) {
 		}
 	}
 	cli.recvLog.Debugf("%s", node.XMLString())
+	// Signal-disabled handoff: parse and dispatch UndecryptedMessage
+	// synchronously from the recv goroutine, so the event interleaves
+	// with [RawNodeHandler] callbacks in wire order. Going through the
+	// regular handlerQueue path would dispatch from a different
+	// goroutine and break ordering between `<message>` envelopes and
+	// any non-message stanzas the caller is forwarding via the hook.
+	// [handleEncryptedMessage]'s own DisabledFeatures.Signal branch
+	// stays as a fallback for direct callers (DangerousInternals,
+	// `<appdata>`).
+	if node.Tag == "message" && cli.DisabledFeatures.Signal {
+		info, err := cli.parseMessageInfo(node)
+		if err != nil {
+			cli.Log.Warnf("Failed to parse message for Signal-disabled handoff: %v", err)
+			return
+		}
+		cli.dispatchEvent(&events.UndecryptedMessage{Info: *info, Raw: node})
+		return
+	}
 	if node.Tag == "xmlstreamend" {
 		if !cli.isExpectedDisconnect() {
 			cli.Log.Warnf("Received stream end frame")

--- a/client.go
+++ b/client.go
@@ -46,6 +46,41 @@ type EventHandler func(evt any)
 type EventHandlerWithSuccessStatus func(evt any) bool
 type nodeHandler func(ctx context.Context, node *waBinary.Node)
 
+// RawNodeHandler is called for every inbound stanza node after Noise
+// transport decryption and binary decoding, but before standard
+// dispatch (tag-based routing, IQ response correlation).
+//
+// If the handler returns drop=true, the node is not dispatched further
+// (no tag handler runs, no IQ response is matched). If the handler
+// returns a non-nil modified node, it replaces the original for the
+// rest of the dispatch path.
+//
+// DANGEROUS: this is a low-level hook. Returning incorrect values
+// breaks Signal session continuity, IQ response correlation, app state
+// invariants, and other stateful parts of the protocol. Intended for
+// proxy implementations where an external system owns part of the
+// protocol state machine (see also [DisabledFeatures]).
+type RawNodeHandler func(ctx context.Context, node *waBinary.Node) (modified *waBinary.Node, drop bool)
+
+// DisabledFeatures lets callers turn off built-in whatsmeow processing
+// paths. Used by proxies where an external system owns parts of the
+// protocol state, e.g. an upstream service that holds the Signal
+// session and handles its own decryption.
+//
+// DANGEROUS: each flag disables a piece of state machinery the rest of
+// the library assumes is running. Toggle deliberately; the surrounding
+// code does not paper over the resulting gaps.
+type DisabledFeatures struct {
+	// Signal disables the library's Signal-session machinery. When set:
+	//   - Incoming `<message>` envelopes are not decrypted and not
+	//     ack'd. The actual decrypting client downstream is responsible
+	//     for ack'ing once it has processed the message.
+	//   - The periodic prekey-upload loop is a no-op.
+	// Combine with [RawNodeHandler] to forward the raw envelopes to the
+	// system that actually owns the Signal session.
+	Signal bool
+}
+
 var nextHandlerID uint32
 
 type wrappedEventHandler struct {
@@ -176,6 +211,14 @@ type Client struct {
 	// sessions will be removed on untrusted identity errors, and an events.IdentityChange will be dispatched.
 	// If false, decrypting a message from untrusted devices will fail.
 	AutoTrustIdentity bool
+
+	// RawNodeHandler, if non-nil, is called for every inbound node
+	// after decoding but before standard dispatch. See [RawNodeHandler].
+	RawNodeHandler RawNodeHandler
+
+	// DisabledFeatures controls which built-in processing paths are
+	// skipped. See [DisabledFeatures].
+	DisabledFeatures DisabledFeatures
 
 	// Should SubscribePresence return an error if no privacy token is stored for the user?
 	ErrorOnSubscribePresenceWithoutToken bool
@@ -825,6 +868,16 @@ func (cli *Client) handleFrame(ctx context.Context, data []byte) {
 		cli.Log.Warnf("Failed to decode node in frame: %v", err)
 		cli.Log.Debugf("Errored frame hex: %s", hex.EncodeToString(decompressed))
 		return
+	}
+	if h := cli.RawNodeHandler; h != nil {
+		modified, drop := h(ctx, node)
+		if drop {
+			cli.recvLog.Debugf("RawNodeHandler dropped node: %s", node.XMLString())
+			return
+		}
+		if modified != nil {
+			node = modified
+		}
 	}
 	cli.recvLog.Debugf("%s", node.XMLString())
 	if node.Tag == "xmlstreamend" {

--- a/message.go
+++ b/message.go
@@ -60,6 +60,11 @@ func (cli *Client) handleEncryptedMessage(ctx context.Context, node *waBinary.No
 			var cancelled bool
 			defer cli.maybeDeferredAck(ctx, node)(&cancelled)
 			cancelled = cli.handlePlaintextMessage(ctx, info, node)
+		} else if cli.DisabledFeatures.Signal {
+			// External system owns the Signal session. We do not decrypt
+			// and we do not ack: the actual decrypting client downstream
+			// is responsible for ack'ing once it has received and
+			// processed the message.
 		} else {
 			cli.decryptMessages(ctx, info, node)
 		}

--- a/message.go
+++ b/message.go
@@ -65,6 +65,7 @@ func (cli *Client) handleEncryptedMessage(ctx context.Context, node *waBinary.No
 			// and we do not ack: the actual decrypting client downstream
 			// is responsible for ack'ing once it has received and
 			// processed the message.
+			cli.dispatchEvent(&events.UndecryptedMessage{Info: *info, Raw: node})
 		} else {
 			cli.decryptMessages(ctx, info, node)
 		}

--- a/prekeys.go
+++ b/prekeys.go
@@ -48,6 +48,10 @@ func (cli *Client) getServerPreKeyCount(ctx context.Context) (int, error) {
 }
 
 func (cli *Client) uploadPreKeys(ctx context.Context, initialUpload bool) {
+	if cli.DisabledFeatures.Signal {
+		cli.Log.Debugf("Prekey upload skipped (DisabledFeatures.Signal)")
+		return
+	}
 	cli.uploadPreKeysLock.Lock()
 	defer cli.uploadPreKeysLock.Unlock()
 	if cli.lastPreKeyUpload.Add(10 * time.Minute).After(time.Now()) {

--- a/types/events/events.go
+++ b/types/events/events.go
@@ -278,6 +278,21 @@ type UndecryptableMessage struct {
 	DecryptFailMode DecryptFailMode
 }
 
+// UndecryptedMessage is emitted instead of attempting decryption when
+// [Client.DisabledFeatures.Signal] is set. The library does not call into
+// the Signal session machinery and does not ack the stanza; the downstream
+// system that owns the Signal session is responsible for ack'ing once it
+// has processed the envelope.
+//
+// Unlike [UndecryptableMessage], this is not an error: decryption was
+// intentionally skipped.
+type UndecryptedMessage struct {
+	Info types.MessageInfo
+	// Raw is the full <message> stanza including all <enc> children.
+	// Forward it verbatim to the downstream Signal session owner.
+	Raw *waBinary.Node
+}
+
 type NewsletterMessageMeta struct {
 	// When a newsletter message is edited, the message isn't wrapped in an EditedMessage like normal messages.
 	// Instead, the message is the new content, the ID is the original message ID, and the edit timestamp is here.


### PR DESCRIPTION
Adds two opt-in extension points for proxy/intermediary use cases:

1. `Client.RawNodeHandler`: called for every inbound node after Noise decrypt + Node decode, before standard dispatch (IQ response match, tag-based routing). Handlers can drop the node, replace it with a modified copy, or pass through. Lets an external system observe or take over inbound stanza handling without forking the library.

2. `Client.DisabledFeatures.Signal`: short-circuits the library's Signal session machinery: decryptMessages becomes  a stub, uploadPreKeys becomes a no-op. Use when an external system owns the Signal session for this device.

3. `events.UndecryptedMessage`: emitted in place of decryption when `DisabledFeatures.Signal` is set. Carries the parsed `MessageInfo` and the raw `<message>` node (including all `<enc>` children) so the downstream Signal session owner can forward the envelope verbatim. This is distinct from `UndecryptableMessage`, which means decryption was attempted and failed; this one means decryption was intentionally skipped and ack ownership is downstream.
  
### Checklist

* [x] I have read and followed the contributing guidelines at <https://docs.mau.fi/bridges/general/contributing.html>
