### PR TITLE
socket: fix data race on FrameSocket.closed

### DIFF
--- a/socket/framesocket.go
+++ b/socket/framesocket.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
+	"sync/atomic"
 
 	"github.com/coder/websocket"
 
@@ -35,7 +36,7 @@ type FrameSocket struct {
 
 	Header []byte
 
-	closed bool
+	closed atomic.Bool
 
 	incomingLength int
 	receivedLength int
@@ -67,7 +68,7 @@ func (fs *FrameSocket) Close(code websocket.StatusCode) {
 		return
 	}
 
-	fs.closed = true
+	fs.closed.Store(true)
 	if code > 0 {
 		err := fs.conn.Close(code, "")
 		if err != nil {
@@ -209,7 +210,7 @@ func (fs *FrameSocket) readPump(conn *websocket.Conn, ctx context.Context) {
 		msgType, data, err := conn.Read(ctx)
 		if err != nil {
 			// Ignore the error if the context has been closed
-			if !fs.closed && !errors.Is(ctx.Err(), context.Canceled) {
+			if !fs.closed.Load() && !errors.Is(ctx.Err(), context.Canceled) {
 				fs.log.Errorf("Error reading from websocket: %v", err)
 			}
 			return


### PR DESCRIPTION
### Summary

Fixes #1085.

`FrameSocket.closed` was a plain `bool`. It is written under `fs.lock` in `Close()`, but read **without any synchronization** in `readPump()`:

- write: `Close()` -> `fs.closed = true` (`socket/framesocket.go:70`)
- read: `readPump()` -> `if !fs.closed && ...` (`socket/framesocket.go:212`)

When the keepalive loop tears down the connection (`keepAliveLoop` -> `Client.Disconnect` -> `NoiseSocket.Stop` -> `FrameSocket.Close`) while the `readPump` goroutine is still running, the write and the read touch the same field concurrently. The Go race detector flags this, as reported in #1085.

### Change

Convert `closed` from `bool` to `sync/atomic.Bool`:

- `closed atomic.Bool` in the struct
- `fs.closed.Store(true)` in `Close()`
- `fs.closed.Load()` in `readPump()`

The `fs.lock` in `Close()` is kept for the rest of the connection teardown. No behavior change: the zero value of `atomic.Bool` is `false`, and the client creates a fresh `FrameSocket` on every `Connect()` (`client.go:543`), so the flag always starts unset just like before.

### Testing

- `go build ./...`
- `go vet ./socket/`
- `gofmt -l socket/framesocket.go` (no diff)
- `go test -race ./socket/`

### Note (out of scope)

`fs.conn` is also read without the lock in `SendFrame()` and `IsConnected()` while being written under `fs.lock` in `Connect()`/`Close()`. This PR is intentionally limited to the field reported in #1085; the `conn` access can be addressed separately.

### Checklist

* [x] I have read and followed the contributing guidelines at <https://docs.mau.fi/bridges/general/contributing.html>
