### PR TITLE
events: expose historical poll-vote tallies embedded in HistorySync

### DIFF
--- a/types/events/events.go
+++ b/types/events/events.go
@@ -242,8 +242,37 @@ type StreamError struct {
 type Disconnected struct{}
 
 // HistorySync is emitted when the phone has sent a blob of historical messages.
+//
+// Each [waE2E.WebMessageInfo] inside Data.Conversations[].Messages may carry
+// previously-bundled poll vote records on its PollUpdates field. Those
+// records are already decrypted (the proto field is the plaintext
+// PollVoteMessage, not the encrypted PollUpdateMessage wrapper) — the
+// primary phone assembles them when packaging the history sync so newly
+// paired companions can render existing poll tallies that they never
+// received as live PollUpdateMessage events.
+//
+// Consumers that care about poll tallies should iterate
+// WebMessageInfo.GetPollUpdates() for every poll-creation message in the
+// sync; see [HistoricalPollUpdates] for a helper that flattens this.
 type HistorySync struct {
 	Data *waHistorySync.HistorySync
+}
+
+// HistoricalPollVote is a single previously-bundled poll vote record
+// extracted from [HistorySync.Data]. SelectedOptionHashes are the
+// SHA-256(optionName) digests of the voter's selections, matching the
+// hashes emitted by live [Client.DecryptPollVote] calls so a consumer's
+// tallying path can be identical for live and historical votes.
+type HistoricalPollVote struct {
+	Chat                 types.JID
+	PollCreationID       types.MessageID
+	Voter                types.JID
+	SelectedOptionHashes [][]byte
+	Timestamp            time.Time
+	// Source poll-creation message info — useful when the consumer wants
+	// to map back to the WebMessageInfo (e.g. to verify the poll's own
+	// option list and resolve hashes back to option names).
+	PollCreationFromMe bool
 }
 
 type DecryptFailMode string

--- a/types/events/historicalpollvotes.go
+++ b/types/events/historicalpollvotes.go
@@ -1,0 +1,88 @@
+package events
+
+import (
+	"time"
+
+	"go.mau.fi/whatsmeow/types"
+)
+
+// HistoricalPollUpdates flattens every previously-bundled poll vote record
+// embedded in this history sync blob into a single slice. The primary
+// phone assembles these records on WebMessageInfo.PollUpdates for each
+// poll-creation message so newly paired companions can render existing
+// tallies they never received as live PollUpdateMessage events.
+//
+// The returned hashes are SHA-256(optionName) digests — identical in shape
+// to what [whatsmeow.Client.DecryptPollVote] yields for live votes — so a
+// consumer's tallying code path is uniform across live and historical
+// sources.
+//
+// Returns nil when the blob carries no poll-update records.
+func (h *HistorySync) HistoricalPollUpdates() []HistoricalPollVote {
+	if h == nil || h.Data == nil {
+		return nil
+	}
+	var out []HistoricalPollVote
+	for _, conv := range h.Data.GetConversations() {
+		chatJIDStr := conv.GetID()
+		if chatJIDStr == "" {
+			continue
+		}
+		chatJID, err := types.ParseJID(chatJIDStr)
+		if err != nil {
+			continue
+		}
+		for _, m := range conv.GetMessages() {
+			wm := m.GetMessage()
+			if wm == nil {
+				continue
+			}
+			updates := wm.GetPollUpdates()
+			if len(updates) == 0 {
+				continue
+			}
+			key := wm.GetKey()
+			if key == nil {
+				continue
+			}
+			pollID := types.MessageID(key.GetID())
+			pollFromMe := key.GetFromMe()
+			for _, pu := range updates {
+				vote := pu.GetVote()
+				if vote == nil {
+					continue
+				}
+				voteKey := pu.GetPollUpdateMessageKey()
+				var voter types.JID
+				if voteKey != nil {
+					if p := voteKey.GetParticipant(); p != "" {
+						if vj, perr := types.ParseJID(p); perr == nil {
+							voter = vj
+						}
+					} else if !voteKey.GetFromMe() {
+						// 1:1 polls have no Participant on the key; the
+						// voter is the chat peer (except when the vote
+						// is from us, which the caller can detect via
+						// PollUpdateMessageKey.FromMe).
+						voter = chatJID
+					}
+				}
+				var ts time.Time
+				if ms := pu.GetSenderTimestampMS(); ms > 0 {
+					ts = time.UnixMilli(ms)
+				} else {
+					ts = time.Unix(int64(wm.GetMessageTimestamp()), 0)
+				}
+				out = append(out, HistoricalPollVote{
+					Chat:                 chatJID,
+					PollCreationID:       pollID,
+					Voter:                voter,
+					SelectedOptionHashes: vote.GetSelectedOptions(),
+					Timestamp:            ts,
+					PollCreationFromMe:   pollFromMe,
+				})
+			}
+		}
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

`waWeb.WebMessageInfo.PollUpdates` (proto field 45) is the primary phone's
bundled record of prior `PollUpdateMessage` events for a poll. The field
is decoded into Go structs but nothing in whatsmeow reads it, so
companion devices that consume `events.HistorySync` see empty tallies on
every poll posted before the companion paired — even though the data is
right there in the blob.

The official WhatsApp clients show those tallies because they walk the
field themselves. Every whatsmeow-based client (mautrix-whatsapp, wuzapi,
etc.) has the same blind spot.

## Change

- `events.HistoricalPollVote` struct (already-decrypted — the proto
  carries plaintext `PollVoteMessage`, no msgsecret derivation needed)
- `(*events.HistorySync).HistoricalPollUpdates()` helper flattens every
  embedded vote across the blob into a single slice
- Doc comment on `HistorySync` pointing at the previously-undocumented
  field

Hashes match the shape `Client.DecryptPollVote` yields for live votes so
a consumer's tallying code path can be uniform across live and historical
sources.

Non-breaking — existing consumers ignore the new helper.

## Background

Discovered while building [yawac](https://github.com/vadika/yawac), a
SwiftUI macOS WhatsApp companion. Patch verified end-to-end there
(implementation initially lived in the consumer; upstreaming so other
consumers don't need to duplicate the walk).

## Test plan

- [x] `go build ./types/events/`
- [x] Verified against a real account: paired companion with multiple
      group polls that had pre-pairing votes; after the initial
      `HistorySync` arrived, `HistoricalPollUpdates()` returned the
      correct per-voter records with hashes matching the poll options'
      SHA-256(name) digests.