### PR TITLE
client: recover from panics in node handler goroutine

### DIFF
--- a/client.go
+++ b/client.go
@@ -864,6 +864,15 @@ Loop:
 			doneChan := make(chan struct{}, 1)
 			start := time.Now()
 			go func() {
+				defer func() {
+					if err := recover(); err != nil {
+						cli.Log.Errorf("Node handler for %s panicked: %v\n%s", node.Tag, err, debug.Stack())
+						select {
+						case doneChan <- struct{}{}:
+						default:
+						}
+					}
+				}()
 				cli.nodeHandlers[node.Tag](evtCtx, node)
 				duration := time.Since(start)
 				doneChan <- struct{}{}


### PR DESCRIPTION
## Summary

`handlerQueueLoop` spawns a goroutine per incoming node that invokes the registered `nodeHandlers[node.Tag]`. If that handler panics, the panic propagates up and kills the entire process.

This adds a `defer recover()` around the handler invocation, matching the existing pattern used in `dispatchEvent` (client.go), `tryHandleRetryReceipt` (retry.go), and `handleHistorySyncNotificationLoop` (message.go).

## Motivation

The panic originates in `libsignal` deserialization of a `SenderKeyDistributionMessage` with empty bytes:

```
panic: runtime error: index out of range [0] with length 0

goroutine N [running]:
go.mau.fi/libsignal/serialize.(*ProtoBufSenderKeyDistributionMessageSerializer).Deserialize(...)
	go.mau.fi/libsignal@v0.2.1/serialize/ProtoBufferSerializer.go:185
go.mau.fi/libsignal/protocol.NewSenderKeyDistributionMessageFromBytes(...)
	go.mau.fi/libsignal@v0.2.1/protocol/SenderKeyDistributionMessage.go:24
go.mau.fi/whatsmeow.(*Client).handleSenderKeyDistributionMessage(...)
	whatsmeow/message.go:656
go.mau.fi/whatsmeow.(*Client).processProtocolParts(...)
	whatsmeow/message.go:907
go.mau.fi/whatsmeow.(*Client).handleDecryptedMessage(...)
	whatsmeow/message.go:1089
go.mau.fi/whatsmeow.(*Client).decryptMessages(...)
	whatsmeow/message.go:424
go.mau.fi/whatsmeow.(*Client).handleEncryptedMessage(...)
	whatsmeow/message.go:64
go.mau.fi/whatsmeow.(*Client).handlerQueueLoop.func1()
	whatsmeow/client.go:867
```

Issue: #1155

The root cause is in `libsignal` (missing length guard before `serialized[0]`). But even once that is fixed, defensive `recover` here is consistent with the rest of the codebase and protects against any future panic that bubbles up through a node handler — which is otherwise a single message away from killing the process.

## Behavior

- Panic in `nodeHandlers[node.Tag]` → logged with `node.Tag` (a string, panic-safe) and `debug.Stack()`.
- Non-blocking send to `doneChan` so the outer loop continues immediately instead of waiting up to ~5 minutes for the existing timeout to fire.
- No behavior change in the non-panic path.

## Testing

`go build ./...` and `go vet ./...` pass.