### PR TITLE
binary: don't panic on malformed nodes

### DIFF
--- a/binary/decoder.go
+++ b/binary/decoder.go
@@ -109,7 +109,7 @@ func (r *binaryDecoder) readPacked8(tag int) (string, error) {
 	}
 
 	ret := build.String()
-	if startByte>>7 != 0 {
+	if startByte>>7 != 0 && len(ret) > 0 {
 		ret = ret[:len(ret)-1]
 	}
 	return ret, nil
@@ -232,10 +232,19 @@ func (r *binaryDecoder) readJIDPair() (interface{}, error) {
 		return nil, err
 	} else if server == nil {
 		return nil, ErrInvalidJIDType
-	} else if user == nil {
-		return types.NewJID("", server.(string)), nil
 	}
-	return types.NewJID(user.(string), server.(string)), nil
+	serverStr, ok := server.(string)
+	if !ok {
+		return nil, ErrInvalidJIDType
+	}
+	if user == nil {
+		return types.NewJID("", serverStr), nil
+	}
+	userStr, ok := user.(string)
+	if !ok {
+		return nil, ErrInvalidJIDType
+	}
+	return types.NewJID(userStr, serverStr), nil
 }
 
 func (r *binaryDecoder) readInteropJID() (interface{}, error) {
@@ -257,8 +266,12 @@ func (r *binaryDecoder) readInteropJID() (interface{}, error) {
 	} else if server != types.InteropServer {
 		return nil, fmt.Errorf("%w: expected %q, got %q", ErrInvalidJIDType, types.InteropServer, server)
 	}
+	userStr, ok := user.(string)
+	if !ok {
+		return nil, ErrInvalidJIDType
+	}
 	return types.JID{
-		User:       user.(string),
+		User:       userStr,
 		Device:     uint16(device),
 		Integrator: uint16(integrator),
 		Server:     types.InteropServer,
@@ -280,10 +293,14 @@ func (r *binaryDecoder) readFBJID() (interface{}, error) {
 	} else if server != types.MessengerServer {
 		return nil, fmt.Errorf("%w: expected %q, got %q", ErrInvalidJIDType, types.MessengerServer, server)
 	}
+	userStr, ok := user.(string)
+	if !ok {
+		return nil, ErrInvalidJIDType
+	}
 	return types.JID{
-		User:   user.(string),
+		User:   userStr,
 		Device: uint16(device),
-		Server: server.(string),
+		Server: types.MessengerServer,
 	}, nil
 }
 
@@ -300,7 +317,11 @@ func (r *binaryDecoder) readADJID() (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	return types.NewADJID(user.(string), agent, device), nil
+	userStr, ok := user.(string)
+	if !ok {
+		return nil, ErrInvalidJIDType
+	}
+	return types.NewADJID(userStr, agent, device), nil
 }
 
 func (r *binaryDecoder) readAttributes(n int) (Attrs, error) {
@@ -365,7 +386,11 @@ func (r *binaryDecoder) readNode() (*Node, error) {
 	if err != nil {
 		return nil, err
 	}
-	ret.Tag = rawDesc.(string)
+	tag, ok := rawDesc.(string)
+	if !ok {
+		return nil, ErrInvalidNode
+	}
+	ret.Tag = tag
 	if listSize == 0 || ret.Tag == "" {
 		return nil, ErrInvalidNode
 	}

--- a/binary/decoder_test.go
+++ b/binary/decoder_test.go
@@ -1,0 +1,105 @@
+package binary_test
+
+import (
+	"reflect"
+	"testing"
+
+	"go.mau.fi/whatsmeow/binary"
+	"go.mau.fi/whatsmeow/types"
+)
+
+// TestMarshalUnmarshalRoundTrip verifies that the hardened decoder still decodes
+// valid nodes correctly: a node with attributes (including a JID, which exercises
+// the JIDPair reader) and nested content round-trips back to an equal value.
+func TestMarshalUnmarshalRoundTrip(t *testing.T) {
+	original := binary.Node{
+		Tag: "iq",
+		Attrs: binary.Attrs{
+			"id":   "abc",
+			"type": "result",
+			"from": types.NewJID("12345", types.DefaultUserServer),
+		},
+		Content: []binary.Node{
+			{Tag: "body", Content: []byte("hi")},
+		},
+	}
+	marshaled, err := binary.Marshal(original)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+	unpacked, err := binary.Unpack(marshaled)
+	if err != nil {
+		t.Fatalf("Unpack failed: %v", err)
+	}
+	decoded, err := binary.Unmarshal(unpacked)
+	if err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if !reflect.DeepEqual(*decoded, original) {
+		t.Errorf("round trip mismatch:\n original = %+v\n decoded  = %+v", original, *decoded)
+	}
+}
+
+// TestUnmarshalMalformedInputDoesNotPanic feeds the decoder binary nodes that are
+// well-formed enough to start decoding but contain a token of the wrong type where
+// a string is required (e.g. a list token in the node tag or JID user position).
+//
+// A malformed or malicious frame from the server must never crash the client, so
+// Unmarshal must return an error for all of these rather than panicking.
+func TestUnmarshalMalformedInputDoesNotPanic(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []byte
+	}{
+		// List8 node, size 1, tag token = ListEmpty -> read returns nil -> tag.(string)
+		{"node tag is nil", []byte{248, 1, 0}},
+		// List8 node, size 1, tag token = Nibble8 packed string with high bit set but length 0
+		{"empty packed-string tag", []byte{248, 1, 255, 128}},
+		// node "a" whose content is a JIDPair whose user sub-token is an empty list
+		{"jidpair user is a list", []byte{248, 2, 252, 1, 97, 250, 248, 0, 252, 1, 115}},
+		// node "a" whose content is a JIDPair whose user is empty and server is a list
+		{"jidpair server is a list", []byte{248, 2, 252, 1, 97, 250, 0, 248, 0}},
+		// node "a" whose content is an ADJID whose user sub-token is an empty list
+		{"adjid user is a list", []byte{248, 2, 252, 1, 97, 247, 1, 1, 248, 0}},
+		// node "a" whose content is an FBJID (server "msgr") whose user is an empty list
+		{"fbjid user is a list", []byte{248, 2, 252, 1, 97, 246, 248, 0, 0, 0, 252, 4, 109, 115, 103, 114}},
+		// node "a" whose content is an InteropJID (server "interop") whose user is an empty list
+		{"interopjid user is a list", []byte{248, 2, 252, 1, 97, 245, 248, 0, 0, 0, 0, 0, 252, 7, 105, 110, 116, 101, 114, 111, 112}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("Unmarshal panicked on malformed input: %v", r)
+				}
+			}()
+			if _, err := binary.Unmarshal(tc.input); err == nil {
+				t.Error("expected an error for malformed input, got nil")
+			}
+		})
+	}
+}
+
+// TestUnpackEmptyInputDoesNotPanic ensures Unpack returns an error instead of
+// panicking when given an empty payload (it reads the first byte as a flags byte).
+func TestUnpackEmptyInputDoesNotPanic(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []byte
+	}{
+		{"nil", nil},
+		{"empty", []byte{}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("Unpack panicked on empty input: %v", r)
+				}
+			}()
+			if _, err := binary.Unpack(tc.input); err == nil {
+				t.Error("expected an error for empty input, got nil")
+			}
+		})
+	}
+}

--- a/binary/fuzz_test.go
+++ b/binary/fuzz_test.go
@@ -1,0 +1,37 @@
+package binary_test
+
+import (
+	"testing"
+
+	"go.mau.fi/whatsmeow/binary"
+)
+
+// FuzzUnmarshal asserts the decoder never panics on arbitrary input: a malformed
+// or malicious frame from the server must always produce an error, never a crash.
+func FuzzUnmarshal(f *testing.F) {
+	seeds := [][]byte{
+		{248, 1, 0},
+		{248, 1, 255, 128},
+		{248, 2, 252, 1, 97, 250, 248, 0, 252, 1, 115},
+		{248, 2, 252, 1, 97, 247, 1, 1, 248, 0},
+		{248, 2, 252, 1, 97, 246, 248, 0, 0, 0, 252, 4, 109, 115, 103, 114},
+		{0},
+		{},
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, data []byte) {
+		_, _ = binary.Unmarshal(data)
+	})
+}
+
+// FuzzUnpack asserts Unpack never panics on arbitrary input.
+func FuzzUnpack(f *testing.F) {
+	for _, s := range [][]byte{{}, {0}, {1}, {2, 1, 2, 3}, {3, 4, 5}} {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, data []byte) {
+		_, _ = binary.Unpack(data)
+	})
+}

--- a/binary/unpack.go
+++ b/binary/unpack.go
@@ -19,6 +19,9 @@ import (
 // (without the first byte). There's currently no corresponding Pack function because Marshal
 // already returns the data with a leading zero (i.e. not compressed).
 func Unpack(data []byte) ([]byte, error) {
+	if len(data) == 0 {
+		return nil, io.ErrUnexpectedEOF
+	}
 	dataType, data := data[0], data[1:]
 	if 2&dataType > 0 {
 		if decompressor, err := zlib.NewReader(bytes.NewReader(data)); err != nil {


### PR DESCRIPTION
`Unmarshal`/`Unpack` could panic instead of returning an error on some malformed or empty frames:

- a node tag or JID user/server token that decodes to a non-string (e.g. a list token where a string is expected)
- a packed (nibble/hex) string with the parity bit set but zero length
- `Unpack` on an empty payload

`handleFrame` already logs and drops frames that fail to decode, but these panicked in the `consumeFrames` goroutine (no recover), so a single bad frame could take down the process. Return an error in those cases instead.

Tests added: a fuzz target for the decoder (it hits these on the unpatched code in well under a second), table tests for the specific inputs, and a marshal/unmarshal round trip. `go test -race ./...` passes on 1.25 and 1.26.

* [x] I have read and followed the contributing guidelines at <https://docs.mau.fi/bridges/general/contributing.html>
