### PR TITLE
sqlstore: close rows on scan error to avoid leaking connections

### DIFF
--- a/store/sqlstore/container.go
+++ b/store/sqlstore/container.go
@@ -158,6 +158,7 @@ func (c *Container) GetAllDevices(ctx context.Context) ([]*store.Device, error) 
 	if err != nil {
 		return nil, fmt.Errorf("failed to query sessions: %w", err)
 	}
+	defer res.Close()
 	sessions := make([]*store.Device, 0)
 	for res.Next() {
 		sess, scanErr := c.scanDevice(res)

--- a/store/sqlstore/lidmap.go
+++ b/store/sqlstore/lidmap.go
@@ -72,6 +72,7 @@ func (s *CachedLIDMap) scanManyLids(rows dbutil.Rows, fn func(lid, pn string)) e
 	if fn == nil {
 		fn = func(lid, pn string) {}
 	}
+	defer rows.Close()
 	for rows.Next() {
 		var lid, pn string
 		err := rows.Scan(&lid, &pn)
@@ -81,10 +82,6 @@ func (s *CachedLIDMap) scanManyLids(rows dbutil.Rows, fn func(lid, pn string)) e
 		s.pnToLIDCache[pn] = lid
 		s.lidToPNCache[lid] = pn
 		fn(lid, pn)
-	}
-	err := rows.Close()
-	if err != nil {
-		return err
 	}
 	return rows.Err()
 }

--- a/store/sqlstore/lidmap_test.go
+++ b/store/sqlstore/lidmap_test.go
@@ -1,0 +1,42 @@
+package sqlstore
+
+import (
+	"database/sql"
+	"errors"
+	"testing"
+)
+
+// fakeRows is a minimal dbutil.Rows that yields rowsLeft rows and always fails to
+// scan them, recording whether Close was called.
+type fakeRows struct {
+	rowsLeft int
+	closed   bool
+}
+
+func (r *fakeRows) Next() bool {
+	if r.rowsLeft > 0 {
+		r.rowsLeft--
+		return true
+	}
+	return false
+}
+func (r *fakeRows) Scan(...any) error                       { return errors.New("scan failed") }
+func (r *fakeRows) Close() error                            { r.closed = true; return nil }
+func (r *fakeRows) Err() error                              { return nil }
+func (r *fakeRows) Columns() ([]string, error)              { return nil, nil }
+func (r *fakeRows) ColumnTypes() ([]*sql.ColumnType, error) { return nil, nil }
+func (r *fakeRows) NextResultSet() bool                     { return false }
+
+// TestScanManyLidsClosesRowsOnScanError ensures the rows (and the underlying pooled
+// DB connection) are closed even when scanning a row fails partway through iteration.
+// Without the fix, the early return skips Close and leaks the connection.
+func TestScanManyLidsClosesRowsOnScanError(t *testing.T) {
+	rows := &fakeRows{rowsLeft: 1}
+	s := NewCachedLIDMap(nil)
+	if err := s.scanManyLids(rows, nil); err == nil {
+		t.Fatal("expected an error from the failing scan")
+	}
+	if !rows.closed {
+		t.Error("scanManyLids leaked the rows: Close() was not called on the scan-error path")
+	}
+}

--- a/store/sqlstore/store.go
+++ b/store/sqlstore/store.go
@@ -347,6 +347,7 @@ func (s *SQLStore) GetOrGenPreKeys(ctx context.Context, count uint32) ([]*keys.P
 	if err != nil {
 		return nil, fmt.Errorf("failed to query existing prekeys: %w", err)
 	}
+	defer res.Close()
 	newKeys := make([]*keys.PreKey, count)
 	var existingCount uint32
 	for res.Next() {
@@ -457,6 +458,7 @@ func (s *SQLStore) GetAllAppStateSyncKeys(ctx context.Context) ([]*store.AppStat
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 	var out []*store.AppStateSyncKey
 	for rows.Next() {
 		var item store.AppStateSyncKey
@@ -468,7 +470,7 @@ func (s *SQLStore) GetAllAppStateSyncKeys(ctx context.Context) ([]*store.AppStat
 			out = append(out, &item)
 		}
 	}
-	return out, rows.Close()
+	return out, rows.Err()
 }
 
 func (s *SQLStore) GetAppStateSyncKey(ctx context.Context, id []byte) (*store.AppStateSyncKey, error) {
@@ -801,6 +803,7 @@ func (s *SQLStore) GetAllContacts(ctx context.Context) (map[types.JID]types.Cont
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 	output := make(map[types.JID]types.ContactInfo, len(s.contactCache))
 	for rows.Next() {
 		var jid types.JID


### PR DESCRIPTION
Several sqlstore queries iterate rows with a `for rows.Next()` loop that returns early on a scan error without closing the rows. The success path is fine (Next returning false closes the rows), but the early return leaks the `*sql.Rows` and its pooled connection, which can accumulate to connection pool exhaustion if scan errors recur.

Adds `defer rows.Close()` after the query in `GetOrGenPreKeys`, `GetAllContacts`, `GetAllDevices`, `GetAllAppStateSyncKeys` and `scanManyLids`. (`getManySession` already handles this via `dbutil.NewRowIter`.)

Tested: a new test for `scanManyLids` (via a fake `dbutil.Rows`) checks the rows are closed when a scan fails partway through iteration — it fails before the change and passes after. `go build/vet/test ./...` pass on 1.25 and 1.26.

* [x] I have read and followed the contributing guidelines at <https://docs.mau.fi/bridges/general/contributing.html>
