### PR TITLE
group: store LID→PN mappings from GetGroupRequestParticipants response

### DIFF
--- a/group.go
+++ b/group.go
@@ -235,10 +235,23 @@ func (cli *Client) GetGroupRequestParticipants(ctx context.Context, jid types.JI
 	}
 	requestParticipants := request.GetChildrenByTag("membership_approval_request")
 	participants := make([]types.GroupParticipantRequest, len(requestParticipants))
+	var lidPairs []store.LIDMapping
 	for i, req := range requestParticipants {
+		cag := req.AttrGetter()
+		participantJID := cag.JID("jid")
 		participants[i] = types.GroupParticipantRequest{
-			JID:         req.AttrGetter().JID("jid"),
-			RequestedAt: req.AttrGetter().UnixTime("request_time"),
+			JID:         participantJID,
+			RequestedAt: cag.UnixTime("request_time"),
+		}
+		if participantJID.Server == types.HiddenUserServer {
+			if pn := cag.OptionalJID("phone_number"); pn != nil && !pn.IsEmpty() {
+				lidPairs = append(lidPairs, store.LIDMapping{LID: participantJID, PN: *pn})
+			}
+		}
+	}
+	if len(lidPairs) > 0 {
+		if err := cli.Store.LIDs.PutManyLIDMappings(ctx, lidPairs); err != nil {
+			cli.Log.Warnf("Failed to store LID mappings from group request participants: %v", err)
 		}
 	}
 	return participants, nil


### PR DESCRIPTION
## Problem

`GetGroupRequestParticipants` sends a `membership_approval_requests` IQ query and gets back `<membership_approval_request>` nodes, each carrying `jid`, `request_time`, **and `phone_number`**. The previous implementation only read `jid` and `request_time`, silently discarding `phone_number`.

Consequence: `ResolveLIDToPN` returns empty for any requester whose LID was never previously seen (e.g. participants who submitted a join request before the client first connected and received the corresponding push notification). The WhatsApp mobile app shows the full phone number for every requester because it reads `phone_number` directly from the same IQ response.

## Fix

Parse the `phone_number` attribute from each `<membership_approval_request>` node and call `PutManyLIDMappings` to populate the local store, so that `ResolveLIDToPN` resolves correctly for all pending requesters on the very first query — no prior notification required.

The pattern mirrors `parseParticipantList` (line ~799) and the `parseMembershipRequestParticipants` helper introduced in #998, which handle `phone_number` identically for other group event paths.

## Verified

Tested against a real group: before the fix, 2 of 25 pending requesters had no LID→PN mapping in the local store; after the fix all 25 (now 19, some were handled in the interim) resolve correctly on the first `GetGroupRequestParticipants` call.

## Relation to #998

PR #998 adds `phone_number` parsing for **push notifications** (`created_membership_requests` group change events). This PR fixes the same gap in the **IQ query** path. The two are complementary: #998 covers new requests arriving while connected; this PR covers the initial load of already-pending requests.