### PR TITLE
send: don't fetch prekeys for own device on every message

### DIFF
--- a/send.go
+++ b/send.go
@@ -1285,6 +1285,11 @@ func (cli *Client) encryptMessageForDevices(
 	sessionAddressToJID := make(map[string]types.JID, len(allDevices))
 	sessionAddresses := make([]string, 0, len(allDevices))
 	for _, jid := range allDevices {
+		if dsmPlaintext != nil && (jid == ownJID || jid == ownLID) {
+			// There's never a session with ourselves; prefetching one would
+			// put it in retryDevices and fetch prekeys on every message.
+			continue
+		}
 		encryptionIdentity := jid
 		if jid.Server == types.DefaultUserServer {
 			// TODO query LID from server for missing entries

--- a/sendfb.go
+++ b/sendfb.go
@@ -530,6 +530,11 @@ func (cli *Client) encryptMessageForDevicesV3(
 	sessionAddressToJID := make(map[string]types.JID, len(allDevices))
 	sessionAddresses := make([]string, 0, len(allDevices))
 	for _, jid := range allDevices {
+		if jid == ownID {
+			// There's never a session with ourselves; prefetching one would
+			// trigger a prekey fetch on every message.
+			continue
+		}
 		addr := jid.SignalAddress().String()
 		sessionAddresses = append(sessionAddresses, addr)
 		sessionAddressToJID[addr] = jid


### PR DESCRIPTION
Every DM send currently triggers a prekey fetch IQ for the sender's own device. `encryptMessageForDevices` builds the session prefetch list from all devices returned by usync, but the "skip self" check only happens later in the encrypt loop. Since there's never a Signal session with yourself, the own device always ends up in `retryDevices` and the fetched bundle is never used. Easy to spot with debug logging, every send is preceded by:

```xml
<iq to="s.whatsapp.net" type="get" xmlns="encrypt">
  <key><user jid="559980000001:51@s.whatsapp.net" reason="identity"/></key>
</iq>
```

This skips ownJID/ownLID when building the prefetch list, with the same condition the encrypt loop already uses. Same fix applied to the v3 path in sendfb.go.

WA Web never hits this because `getFanOutList` (WAWebDBDeviceListFanout) drops the own device before any session check or prekey fetch:

```javascript
var i = o("WAWebWidFactory").createDeviceWidFromDeviceListPk(e.id, t.id, t.isHosted);
o("WAWebUserPrefsMeUser").isMeDevice(i) || s.set(i.toString(), i);
```
