### PR TITLE
client: lock signal sessions between encrypt and decrypt

### DIFF
--- a/message.go
+++ b/message.go
@@ -557,6 +557,11 @@ func (cli *Client) decryptDM(ctx context.Context, child *waBinary.Node, from typ
 		return nil, nil, fmt.Errorf("message content is not a byte slice")
 	}
 
+	// Without the lock, concurrent sends to the same address could overwrite
+	// this decrypt's ratchet advance (and vice versa).
+	unlockSession := cli.Store.LockSession(from.SignalAddress().String())
+	defer unlockSession()
+
 	builder := session.NewBuilderFromSignal(cli.Store, from.SignalAddress(), pbSerializer)
 	cipher := session.NewCipher(builder, from.SignalAddress())
 	var plaintext []byte

--- a/retry.go
+++ b/retry.go
@@ -342,8 +342,11 @@ func (cli *Client) handleRetryReceipt(ctx context.Context, receipt *events.Recei
 				encryptionIdentity = lidForPN
 			}
 		}
+		unlockSession := cli.Store.LockSession(encryptionIdentity.SignalAddress().String())
 		encrypted, includeDeviceIdentity, err = cli.encryptMessageForDevice(ctx, plaintext, encryptionIdentity, bundle, encAttrs, nil)
+		unlockSession()
 	} else {
+		unlockSession := cli.Store.LockSession(receipt.Sender.SignalAddress().String())
 		encrypted, err = cli.encryptMessageForDeviceV3(ctx, &waMsgTransport.MessageTransport_Payload{
 			ApplicationPayload: &waCommon.SubProtocol{
 				Payload: plaintext,
@@ -351,6 +354,7 @@ func (cli *Client) handleRetryReceipt(ctx context.Context, receipt *events.Recei
 			},
 			FutureProof: waCommon.FutureProofBehavior_PLACEHOLDER.Enum(),
 		}, fbSKDM, fbDSM, receipt.Sender, bundle, encAttrs)
+		unlockSession()
 	}
 	if err != nil {
 		return fmt.Errorf("failed to encrypt message for retry: %w", err)

--- a/send.go
+++ b/send.go
@@ -1086,7 +1086,9 @@ func (cli *Client) preparePeerMessageNode(
 		}
 	}
 	start = time.Now()
+	unlockSession := cli.Store.LockSession(encryptionIdentity.SignalAddress().String())
 	encrypted, isPreKey, err := cli.encryptMessageForDevice(ctx, plaintext, encryptionIdentity, nil, nil, nil)
+	unlockSession()
 	timings.PeerEncrypt = time.Since(start)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encrypt peer message for %s: %v", to, err)
@@ -1299,6 +1301,11 @@ func (cli *Client) encryptMessageForDevices(
 		sessionAddressToJID[addr] = jid
 	}
 
+	// The decrypt path does its own read-modify-write of the same session
+	// rows; without the lock, either side's ratchet advance can be lost.
+	unlockSessions := cli.Store.LockSessions(sessionAddresses)
+	defer func() { unlockSessions() }()
+	baseCtx := ctx
 	existingSessions, ctx, err := cli.Store.WithCachedSessions(ctx, sessionAddresses)
 	if err != nil {
 		return nil, false, fmt.Errorf("failed to prefetch sessions: %w", err)
@@ -1309,7 +1316,21 @@ func (cli *Client) encryptMessageForDevices(
 			retryDevices = append(retryDevices, sessionAddressToJID[addr])
 		}
 	}
-	bundles := cli.fetchPreKeysNoError(ctx, retryDevices)
+	var bundles map[types.JID]*prekey.Bundle
+	if len(retryDevices) > 0 {
+		// Don't hold the session locks across the network round trip. The
+		// sessions may change while unlocked, so re-read them after
+		// re-locking, otherwise PutCachedSessions would overwrite concurrent
+		// ratchet advances.
+		unlockSessions()
+		unlockSessions = func() {}
+		bundles = cli.fetchPreKeysNoError(ctx, retryDevices)
+		unlockSessions = cli.Store.LockSessions(sessionAddresses)
+		existingSessions, ctx, err = cli.Store.WithCachedSessions(baseCtx, sessionAddresses)
+		if err != nil {
+			return nil, false, fmt.Errorf("failed to prefetch sessions: %w", err)
+		}
+	}
 
 	for _, jid := range allDevices {
 		plaintext := msgPlaintext

--- a/sendfb.go
+++ b/sendfb.go
@@ -534,6 +534,10 @@ func (cli *Client) encryptMessageForDevicesV3(
 		sessionAddresses = append(sessionAddresses, addr)
 		sessionAddressToJID[addr] = jid
 	}
+	// See encryptMessageForDevices for the locking rationale.
+	unlockSessions := cli.Store.LockSessions(sessionAddresses)
+	defer func() { unlockSessions() }()
+	baseCtx := ctx
 	existingSessions, ctx, err := cli.Store.WithCachedSessions(ctx, sessionAddresses)
 	if err != nil {
 		return nil, fmt.Errorf("failed to prefetch sessions: %w", err)
@@ -544,7 +548,18 @@ func (cli *Client) encryptMessageForDevicesV3(
 			retryDevices = append(retryDevices, sessionAddressToJID[addr])
 		}
 	}
-	bundles := cli.fetchPreKeysNoError(ctx, retryDevices)
+	var bundles map[types.JID]*prekey.Bundle
+	if len(retryDevices) > 0 {
+		// See encryptMessageForDevices.
+		unlockSessions()
+		unlockSessions = func() {}
+		bundles = cli.fetchPreKeysNoError(ctx, retryDevices)
+		unlockSessions = cli.Store.LockSessions(sessionAddresses)
+		existingSessions, ctx, err = cli.Store.WithCachedSessions(baseCtx, sessionAddresses)
+		if err != nil {
+			return nil, fmt.Errorf("failed to prefetch sessions: %w", err)
+		}
+	}
 
 	for _, jid := range allDevices {
 		var dsmForDevice *waMsgTransport.MessageTransport_Protocol_Integral_DeviceSentMessage

--- a/store/sessionlock.go
+++ b/store/sessionlock.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Tulir Asokan
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package store
+
+import (
+	"slices"
+	"sync"
+)
+
+// Mutexes are never evicted; the map grows with the number of distinct
+// addresses, which is negligible next to the session data itself.
+func (device *Device) sessionLock(address string) *sync.Mutex {
+	val, _ := device.sessionLocks.LoadOrStore(address, &sync.Mutex{})
+	return val.(*sync.Mutex)
+}
+
+// LockSession acquires the lock for the session record of the given signal
+// address and returns the function that releases it. Both encrypting and
+// decrypting do a read-modify-write of the whole record, so they must hold
+// this lock to avoid losing each other's ratchet advances.
+func (device *Device) LockSession(address string) func() {
+	lock := device.sessionLock(address)
+	lock.Lock()
+	return lock.Unlock
+}
+
+// LockSessions acquires the session locks for all given addresses,
+// deduplicated and in sorted order to prevent deadlocks between concurrent
+// multi-address lockers. The returned function releases all locks.
+func (device *Device) LockSessions(addresses []string) func() {
+	if len(addresses) == 0 {
+		return func() {}
+	}
+	sorted := slices.Clone(addresses)
+	slices.Sort(sorted)
+	sorted = slices.Compact(sorted)
+	locks := make([]*sync.Mutex, len(sorted))
+	for i, addr := range sorted {
+		locks[i] = device.sessionLock(addr)
+		locks[i].Lock()
+	}
+	return func() {
+		for i := len(locks) - 1; i >= 0; i-- {
+			locks[i].Unlock()
+		}
+	}
+}

--- a/store/store.go
+++ b/store/store.go
@@ -10,6 +10,7 @@ package store
 import (
 	"context"
 	"errors"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -251,6 +252,10 @@ type Device struct {
 	EventBuffer   EventBuffer
 	LIDs          LIDStore
 	Container     DeviceContainer
+
+	// Per-address signal session locks, see LockSession.
+	// Zero value is ready to use; never copy a Device after first use.
+	sessionLocks sync.Map
 }
 
 func (device *Device) GetJID() types.JID {


### PR DESCRIPTION
`messageSendLock` only serializes sends against each other. The decrypt path does its own load-modify-store of the same session records, so when a message from a contact is decrypted while a send to them is being encrypted, one side overwrites the other's ratchet advance. Depending on which side loses, either the sender chain rolls back and the next message reuses a counter, which the recipient silently drops with "message with old counter", or the receiver chain rolls back and the next decrypt materializes skipped message keys that stay in the record forever, growing it over time. Easy to reproduce by replying to a contact while receiving a burst of messages from them.

Upstream libsignal explicitly leaves this to the caller: [`SessionCipher`](https://github.com/signalapp/libsignal/blob/main/java/shared/java/org/signal/libsignal/protocol/SessionCipher.java) is documented as "This class is not thread-safe", and Signal's own client injects a lock around every encryption and decryption for exactly this reason:

```java
/**
 * An interface to allow the injection of a lock that will be used to keep interactions with
 * ecryptions/decryptions thread-safe.
 */
public interface SignalSessionLock {
  Lock acquire();
```

([SignalSessionLock](https://github.com/signalapp/Signal-Android/blob/main/lib/libsignal-service/src/main/java/org/whispersystems/signalservice/api/SignalSessionLock.java) in Signal-Android)

This adds a per-address session lock to the Device store, held across the whole load-encrypt-store cycle in `encryptMessageForDevices` (sorted and deduplicated when locking multiple addresses) and across decryption in `decryptDM`. `preparePeerMessageNode` and the retry receipt handler take it too. The prekey fetch for missing sessions happens with the locks released since it's a network round trip, and the sessions are re-read after re-locking so the cache reflects whatever changed meanwhile. The lock is per address rather than global so unrelated chats don't block each other.


Before/after heap profiles from a ping/pong flood benchmark against a mock server, viewable in speedscope: [before](https://www.speedscope.app/#profileURL=https%3A%2F%2Fgist.githubusercontent.com%2Fjlucaso1%2F38446f6dc8971fc2820e5c25bf74cdfc%2Fraw%2Fmain3k-heap.folded.txt&title=before%20%28main%29%20heap), [after](https://www.speedscope.app/#profileURL=https%3A%2F%2Fgist.githubusercontent.com%2Fjlucaso1%2F38446f6dc8971fc2820e5c25bf74cdfc%2Fraw%2Fsession-locks3k-heap.folded.txt&title=after%20%28session-locks%29%20heap). On main the race shows up as 22.5MB of `message.NewKeys` allocations, the spurious skipped message keys being deserialized back on every session load; with the lock they disappear entirely.
