### PR TITLE
send: deduplicate own devices across PN and LID namespaces

### DIFF
--- a/send.go
+++ b/send.go
@@ -1176,6 +1176,33 @@ func (cli *Client) prepareMessageNode(
 		})
 	}
 
+	if dsmPlaintext != nil {
+		// usync can return own devices in both the PN and LID namespaces.
+		// WA Web only fans out own devices in the chat's namespace; without
+		// the dedupe each own device is encrypted to twice and the stanza
+		// mixes addressing namespaces. Only devices that also exist in the
+		// kept namespace are dropped, so none can be lost.
+		ownPN := cli.getOwnID().ToNonAD()
+		ownLID := cli.getOwnLID().ToNonAD()
+		if !ownPN.IsEmpty() && !ownLID.IsEmpty() {
+			keep, drop := ownPN, ownLID
+			if to.Server == types.HiddenUserServer {
+				keep, drop = ownLID, ownPN
+			}
+			keptDevices := make(map[uint16]bool)
+			for _, jid := range allDevices {
+				if jid.Server == keep.Server && jid.User == keep.User {
+					keptDevices[jid.Device] = true
+				}
+			}
+			if len(keptDevices) > 0 {
+				allDevices = slices.DeleteFunc(allDevices, func(jid types.JID) bool {
+					return jid.Server == drop.Server && jid.User == drop.User && keptDevices[jid.Device]
+				})
+			}
+		}
+	}
+
 	msgType := getTypeFromMessage(message)
 	encAttrs := waBinary.Attrs{}
 	// Only include encMediaType for 1:1 messages (groups don't have a device-sent message plaintext)


### PR DESCRIPTION
usync returns the own user's device list in both the PN and LID namespaces, and `prepareMessageNode` keeps both, so on every DM each own device is encrypted to twice (two sessions, two encrypts, two store writes) and the stanza mixes addressing namespaces in its participant list. A text message to a PN chat currently looks like this, where the second and third `<to>` are the same physical device:

```xml
<message to="551911030911130@s.whatsapp.net" type="text">
  <participants>
    <to jid="551911030911130@s.whatsapp.net"><enc type="msg" v="2"/></to>
    <to jid="100000012345678@lid"><enc type="msg" v="2"/></to>
    <to jid="559980000001@s.whatsapp.net"><enc type="msg" v="2"/></to>
  </participants>
</message>
```

WA Web never produces this because it only requests the own device list in a single namespace, picked from the chat's namespace (WAWebSendUserMsgJob):

```javascript
var R = S.isRegularUserPn()
    ? o("WAWebUserPrefsMeUser").getMeDevicePnOrThrow_DO_NOT_USE()
    : (p = o("WAWebUserPrefsMeUser").getMaybeMeDeviceLid()) != null
      ? p
      : o("WAWebUserPrefsMeUser").getMeDevicePnOrThrow_DO_NOT_USE(),
  L = { wids: [S, R] };
var E = yield o("WAWebDBDeviceListFanout").getFanOutList(L);
```

This applies the same rule after GetUserDevices: keep own devices in the chat's namespace (LID for `@lid` chats, PN otherwise, matching how SendMessage already picks ownID) and drop the mirror from the other namespace. A device is only dropped when the same device number exists in the kept namespace, so nothing can be lost if usync returns asymmetric lists. The phash is then computed over the deduplicated list, which also matches what WA Web hashes.
