### PR TITLE
client: render node XML lazily in debug logs

### DIFF
--- a/client.go
+++ b/client.go
@@ -814,6 +814,12 @@ func (cli *Client) RemoveEventHandlers() {
 	cli.eventHandlersLock.Unlock()
 }
 
+// lazyXMLString defers Node.XMLString until a logger actually formats the
+// message, so disabled debug logs don't pay for the XML serialization.
+type lazyXMLString struct{ node *waBinary.Node }
+
+func (l lazyXMLString) String() string { return l.node.XMLString() }
+
 func (cli *Client) handleFrame(ctx context.Context, data []byte) {
 	decompressed, err := waBinary.Unpack(data)
 	if err != nil {
@@ -827,7 +833,7 @@ func (cli *Client) handleFrame(ctx context.Context, data []byte) {
 		cli.Log.Debugf("Errored frame hex: %s", hex.EncodeToString(decompressed))
 		return
 	}
-	cli.recvLog.Debugf("%s", node.XMLString())
+	cli.recvLog.Debugf("%s", lazyXMLString{node})
 	if node.Tag == "xmlstreamend" {
 		if !cli.isExpectedDisconnect() {
 			cli.Log.Warnf("Received stream end frame")
@@ -906,7 +912,7 @@ func (cli *Client) sendNodeAndGetData(ctx context.Context, node waBinary.Node) (
 		return nil, fmt.Errorf("failed to marshal node: %w", err)
 	}
 
-	cli.sendLog.Debugf("%s", node.XMLString())
+	cli.sendLog.Debugf("%s", lazyXMLString{&node})
 	return payload, sock.SendFrame(ctx, payload)
 }
 


### PR DESCRIPTION
`handleFrame` and `sendNodeAndGetData` log every received and sent node with `Debugf("%s", node.XMLString())`. The argument is evaluated before the call, so the regexp-heavy XML serialization runs for every single node even when debug logging is disabled, which is the common case in production.

This wraps the node in a small `fmt.Stringer` instead, so the XML is only rendered when a logger actually formats the message. The bundled loggers check the level before formatting, and with debug enabled the output is identical.

Heap profiles from a ping/pong flood benchmark, viewable in speedscope: [before](https://www.speedscope.app/#profileURL=https%3A%2F%2Fgist.githubusercontent.com%2Fjlucaso1%2F38446f6dc8971fc2820e5c25bf74cdfc%2Fraw%2Fmain-heap.folded.txt&title=before%20%28main%29%20heap), [after](https://www.speedscope.app/#profileURL=https%3A%2F%2Fgist.githubusercontent.com%2Fjlucaso1%2F38446f6dc8971fc2820e5c25bf74cdfc%2Fraw%2Flazy-xml-debug-logs-heap.folded.txt&title=after%20%28lazy-xml%29%20heap). The 172MB of allocations under `Node.XMLString` on main disappear entirely (search for XMLString in the before profile).
