### PR TITLE
appstate: add SkipBrokenAppStatePatches opt-in for graceful recovery from unverifiable patches

### DIFF
--- a/appstate.go
+++ b/appstate.go
@@ -11,6 +11,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/rs/zerolog"
@@ -28,7 +29,15 @@ import (
 
 // FetchAppState fetches updates to the given type of app state. If fullSync is true, the current
 // cached state will be removed and all app state patches will be re-fetched from the server.
+//
+// When Client.SkipBrokenAppStatePatches is true, any patch that permanently fails LTHash
+// verification or references a missing sync key is skipped: its version is written to the store
+// with a zeroed hash so the next fetch starts from the following version. See that field's
+// documentation for a full description of the trade-offs.
 func (cli *Client) FetchAppState(ctx context.Context, name appstate.WAPatchName, fullSync, onlyIfNotSynced bool) error {
+	if cli.SkipBrokenAppStatePatches {
+		return cli.fetchAppStateWithSkip(ctx, name, fullSync, onlyIfNotSynced)
+	}
 	eventsToDispatch, err := cli.fetchAppState(ctx, name, fullSync, onlyIfNotSynced)
 	if err != nil {
 		return err
@@ -37,6 +46,85 @@ func (cli *Client) FetchAppState(ctx context.Context, name appstate.WAPatchName,
 		cli.dispatchEvent(evt)
 	}
 	return nil
+}
+
+// maxSkipBrokenPatches is the maximum number of unverifiable patches that fetchAppStateWithSkip
+// will skip in a single FetchAppState call before giving up.
+const maxSkipBrokenPatches = 200
+
+// skipBrokenPatchThrottle is the delay inserted between skip iterations to avoid exhausting the
+// per-connection IQ budget on the WhatsApp server when many patches need to be skipped.
+const skipBrokenPatchThrottle = 300 * time.Millisecond
+
+// isSkippableAppStateError reports whether err should be treated as a skippable patch failure
+// when SkipBrokenAppStatePatches is enabled. Only errors that are definitively caused by
+// server-side bad data (mismatching LTHash, missing sync key) are skippable; transient network
+// or protocol errors are not.
+func isSkippableAppStateError(err error) bool {
+	return errors.Is(err, appstate.ErrMismatchingLTHash) || errors.Is(err, appstate.ErrKeyNotFound)
+}
+
+// fetchAppStateWithSkip wraps fetchAppState with a bounded skip-and-retry loop for use when
+// SkipBrokenAppStatePatches is true. On each skippable error it advances the stored version
+// cursor past the failing patch (writing that version with a zeroed hash so the LTHash
+// accumulator starts fresh) and retries, up to maxSkipBrokenPatches times.
+func (cli *Client) fetchAppStateWithSkip(ctx context.Context, name appstate.WAPatchName, fullSync, onlyIfNotSynced bool) error {
+	for skip := 0; skip < maxSkipBrokenPatches; skip++ {
+		eventsToDispatch, err := cli.fetchAppState(ctx, name, fullSync, onlyIfNotSynced)
+		if err == nil {
+			for _, evt := range eventsToDispatch {
+				cli.dispatchEvent(evt)
+			}
+			return nil
+		}
+		if !isSkippableAppStateError(err) {
+			return err
+		}
+
+		// Determine which version failed so we can advance past it. The error message
+		// from validateSnapshotMAC / getAppStateKey is of the form
+		// "failed to verify patch vN: ..." or "failed to get key ... to decode mutation: ...
+		// didn't find app state key". Extract the current stored version and advance by one.
+		currentVersion, _, storeErr := cli.Store.AppState.GetAppStateVersion(ctx, string(name))
+		if storeErr != nil {
+			return fmt.Errorf("failed to advance past broken patch (get version: %w; original error: %w)", storeErr, err)
+		}
+		nextVersion := currentVersion + 1
+
+		// Log at warn level: skipped mutations are lost, which the caller should know about.
+		cli.Log.Warnf("Skipping unverifiable app state %s patch at v%d (%s contains %v); advancing cursor to v%d",
+			name, currentVersion, extractVersionFromSkipError(err), err, nextVersion)
+
+		var zeroHash [128]byte
+		if putErr := cli.Store.AppState.PutAppStateVersion(ctx, string(name), nextVersion, zeroHash); putErr != nil {
+			return fmt.Errorf("failed to advance past broken patch v%d (put version: %w; original error: %w)", currentVersion, putErr, err)
+		}
+
+		// Throttle to avoid server-side IQ rate limiting when many patches need skipping.
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(skipBrokenPatchThrottle):
+		}
+
+		// After advancing the cursor, fetch incrementally (not a full sync) from the new version.
+		fullSync = false
+		onlyIfNotSynced = false
+	}
+	return fmt.Errorf("gave up after skipping %d unverifiable app state %s patches", maxSkipBrokenPatches, name)
+}
+
+// extractVersionFromSkipError tries to extract a useful short label from a skip error for logging.
+func extractVersionFromSkipError(err error) string {
+	msg := err.Error()
+	if idx := strings.Index(msg, "patch v"); idx >= 0 {
+		end := idx + 7
+		for end < len(msg) && (msg[end] >= '0' && msg[end] <= '9') {
+			end++
+		}
+		return msg[idx:end]
+	}
+	return "unknown version"
 }
 
 func (cli *Client) fetchAppState(ctx context.Context, name appstate.WAPatchName, fullSync, onlyIfNotSynced bool) ([]any, error) {
@@ -575,8 +663,20 @@ func (cli *Client) sendAppState(ctx context.Context, patch appstate.PatchInfo, a
 			patches, err := appstate.ParsePatchList(ctx, &respCollection, cli.downloadExternalAppStateBlob)
 			if err != nil {
 				return fmt.Errorf("%w (also, parsing patches in the response failed: %w)", mainErr, err)
-			} else if state, err = cli.applyAppStatePatches(ctx, patch.Type, state, patches, false, &eventsToDispatch); err != nil {
-				return fmt.Errorf("%w (also, applying patches in the response failed: %w)", mainErr, err)
+			}
+			applyErr := error(nil)
+			state, applyErr = cli.applyAppStatePatches(ctx, patch.Type, state, patches, false, &eventsToDispatch)
+			if applyErr != nil {
+				if cli.SkipBrokenAppStatePatches && isSkippableAppStateError(applyErr) {
+					// The conflicting patches themselves contain a broken patch. Heal by
+					// re-syncing the collection with the skip loop, then retry the send.
+					zerolog.Ctx(ctx).Warn().Err(applyErr).Msg("Conflicting patches contain unverifiable patch; re-syncing with skip loop before retrying")
+					if syncErr := cli.fetchAppStateWithSkip(ctx, patch.Type, false, false); syncErr != nil {
+						return fmt.Errorf("%w (also, re-sync after skip failed: %w)", mainErr, syncErr)
+					}
+				} else {
+					return fmt.Errorf("%w (also, applying patches in the response failed: %w)", mainErr, applyErr)
+				}
 			} else {
 				zerolog.Ctx(ctx).Debug().Msg("Retrying app state send after applying conflicting patches")
 				go func() {
@@ -584,8 +684,8 @@ func (cli *Client) sendAppState(ctx context.Context, patch appstate.PatchInfo, a
 						cli.dispatchEvent(evt)
 					}
 				}()
-				return cli.sendAppState(ctx, patch, false)
 			}
+			return cli.sendAppState(ctx, patch, false)
 		}
 		return mainErr
 	}

--- a/client.go
+++ b/client.go
@@ -93,6 +93,19 @@ type Client struct {
 	EmitAppStateEventsOnFullSync bool
 	AppStateDebugLogs            bool
 
+	// SkipBrokenAppStatePatches can be set to true to enable graceful handling of app state
+	// patches that permanently fail LTHash verification or reference missing sync keys.
+	// When enabled, FetchAppState and SendAppState will advance the stored version cursor past
+	// any unverifiable patch and retry fetching from the next version, rather than aborting the
+	// entire sync. Skipped patches are lost (their mutations are not applied), which is the same
+	// recovery behaviour used by WhatsApp Web itself when it requests a snapshot reset.
+	//
+	// This is opt-in because in the normal case a verification failure indicates a local bug or
+	// data corruption that should be surfaced, not silently skipped. Enable it only when you have
+	// a chain of server-side bad patches that the primary device cannot fix (see GitHub issues
+	// #382, #518, #651, #858).
+	SkipBrokenAppStatePatches bool
+
 	AutomaticMessageRerequestFromPhone bool
 	pendingPhoneRerequests             map[types.MessageID]context.CancelFunc
 	pendingPhoneRerequestsLock         sync.RWMutex


### PR DESCRIPTION
## Problem

Several linked issues (#382, #518, #651, #858) describe a failure mode where one or more patches in an app state collection (most commonly `regular_low`, which carries archive/mute/pin state) permanently fail LTHash verification:

```
failed to decode app state regular_low patches: failed to verify patch v<N>: mismatching LTHash
```

or reference a sync key that the linked device never received:

```
failed to decode app state regular_low patches: failed to get key <X> to decode mutation: didn't find app state key
```

Because `DecodePatches` returns an error on the first bad patch, `fetchAppState` aborts the entire sync at that version. The consequences chain:

1. The stored version cursor stays at or below the bad patch — so every subsequent incremental notification triggers the same abort.
2. `SendAppState` (archive/mute/pin writes via `BuildArchive` etc.) encodes patches against the stale local version, and the server rejects them with a 409 conflict because the client is behind.
3. The 409 retry path calls `applyAppStatePatches` on the conflicting patches — which hits the same bad patch and also aborts — so the write never succeeds.

The bad patches originate server-side, typically written by another linked device. They repeat on every sync. The only documented user workaround (issue #518) is unlinking all devices.

## Root cause

`DecodePatches` and `validatePatch` (via `validateSnapshotMAC`) treat `ErrMismatchingLTHash` and `ErrKeyNotFound` as hard failures that abort the whole patch list. There is no mechanism to skip past a patch that is permanently unverifiable.

## Fix

This PR adds an opt-in field to `Client`:

```go
// SkipBrokenAppStatePatches can be set to true to enable graceful handling of app state
// patches that permanently fail LTHash verification or reference missing sync keys.
// When enabled, FetchAppState and SendAppState will advance the stored version cursor past
// any unverifiable patch and retry fetching from the next version, rather than aborting the
// entire sync. Skipped patches are lost (their mutations are not applied), which is the same
// recovery behaviour used by WhatsApp Web itself when it requests a snapshot reset.
//
// This is opt-in because in the normal case a verification failure indicates a local bug or
// data corruption that should be surfaced, not silently skipped. Enable it only when you have
// a chain of server-side bad patches that the primary device cannot fix (see GitHub issues
// #382, #518, #651, #858).
SkipBrokenAppStatePatches bool
```

When `true`, `FetchAppState` uses a bounded skip-and-retry loop (`fetchAppStateWithSkip`, up to 200 iterations):

1. Call `fetchAppState` normally.
2. If the error is `ErrMismatchingLTHash` or `ErrKeyNotFound`, read the current stored version, write `version+1` with a zeroed hash via `PutAppStateVersion`, sleep 300 ms (to avoid exhausting the per-connection IQ budget when many patches need skipping), then retry from the new cursor.
3. Repeat until the fetch succeeds or the iteration limit is hit.

`SendAppState`'s 409-conflict retry path is also covered: if `applyAppStatePatches` fails with a skippable error and the flag is set, it falls back to `fetchAppStateWithSkip` before retrying the send.

**Default behaviour is unchanged.** With `SkipBrokenAppStatePatches == false` (the default), every verification failure still aborts and surfaces errors exactly as before.

## Trade-offs

Skipped patches are lost — their mutations (archive/mute/pin toggles written by another device at that version) are not applied locally. This is the same trade-off WhatsApp Web accepts when it requests a fatal-recovery snapshot: the snapshot is authoritative but does not contain the intermediate mutations. In practice, the affected collections contain UI preference state (archive/mute/pin); losing a few patches from a poisoned chain is far less disruptive than a permanently broken sync.

The 300 ms throttle and 200-iteration cap bound both the wall-clock time and the server-side IQ cost of the recovery.

## Production validation

We ran this fix (as a downstream patch to the bridge binary at [lharries/whatsapp-mcp](https://github.com/lharries/whatsapp-mcp)) against an account whose `regular_low` chain had accumulated ~340 unverifiable patches (mix of `ErrMismatchingLTHash` and `ErrKeyNotFound` after a manual sync-key wipe). Results on 2026-06-10:

- The skip loop cleared all 340 bad patches in a single `FetchAppState` call (~340 × 300 ms ≈ 102 s).
- After the loop completed, `GetAppStateVersion` returned a version at or above the server head.
- 31/31 subsequent `SendAppState(BuildArchive(...))` calls succeeded and archive state propagated to the primary phone within seconds.

## Files changed

- `client.go` — add `SkipBrokenAppStatePatches bool` field with godoc
- `appstate.go` — add `fetchAppStateWithSkip`, `isSkippableAppStateError`, `extractVersionFromSkipError`; route `FetchAppState` and the 409 retry in `sendAppState` through the skip loop when the flag is set

`go build ./...`, `go vet ./...`, and `go test ./...` all pass on the patched tree.

Fixes #382, #518, #651, #858