### PR TITLE
Add paginated contact queries to ContactStore

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/beeper/argo-go v1.1.2
 	github.com/coder/websocket v1.8.15
 	github.com/google/uuid v1.6.0
+	github.com/mattn/go-sqlite3 v1.14.45
 	github.com/rs/zerolog v1.35.1
 	go.mau.fi/libsignal v0.2.2
 	go.mau.fi/util v0.9.10

--- a/store/noop.go
+++ b/store/noop.go
@@ -193,6 +193,10 @@ func (n *NoopStore) GetAllContacts(ctx context.Context) (map[types.JID]types.Con
 	return nil, n.Error
 }
 
+func (n *NoopStore) GetContactsPage(ctx context.Context, limit, offset int) (*ContactPage, error) {
+	return nil, n.Error
+}
+
 func (n *NoopStore) PutMutedUntil(ctx context.Context, chat types.JID, mutedUntil time.Time) error {
 	return n.Error
 }

--- a/store/sqlstore/contact_test.go
+++ b/store/sqlstore/contact_test.go
@@ -30,7 +30,12 @@ func newTestSQLStore(t *testing.T) (*SQLStore, func()) {
 
 	device := container.NewDevice()
 	device.ID = ptr(mustParseJID(t, "5511999999999:1@s.whatsapp.net"))
-	device.Account = &waAdv.ADVSignedDeviceIdentity{}
+	device.Account = &waAdv.ADVSignedDeviceIdentity{
+		Details:             []byte{},
+		AccountSignatureKey: make([]byte, 32),
+		AccountSignature:    make([]byte, 64),
+		DeviceSignature:     make([]byte, 64),
+	}
 	if err := device.Save(ctx); err != nil {
 		_ = container.Close()
 		t.Fatalf("failed to save test device: %v", err)

--- a/store/sqlstore/contact_test.go
+++ b/store/sqlstore/contact_test.go
@@ -1,0 +1,128 @@
+package sqlstore
+
+import (
+	"context"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+
+	"go.mau.fi/whatsmeow/proto/waAdv"
+	"go.mau.fi/whatsmeow/types"
+)
+
+func mustParseJID(t *testing.T, value string) types.JID {
+	t.Helper()
+	jid, err := types.ParseJID(value)
+	if err != nil {
+		t.Fatalf("failed to parse jid %q: %v", value, err)
+	}
+	return jid
+}
+
+func newTestSQLStore(t *testing.T) (*SQLStore, func()) {
+	t.Helper()
+
+	ctx := context.Background()
+	container, err := New(ctx, "sqlite3", "file::memory:?_foreign_keys=on", nil)
+	if err != nil {
+		t.Fatalf("failed to create sqlstore container: %v", err)
+	}
+
+	device := container.NewDevice()
+	device.ID = ptr(mustParseJID(t, "5511999999999:1@s.whatsapp.net"))
+	device.Account = &waAdv.ADVSignedDeviceIdentity{}
+	if err := device.Save(ctx); err != nil {
+		_ = container.Close()
+		t.Fatalf("failed to save test device: %v", err)
+	}
+
+	sqlStore, ok := device.Contacts.(*SQLStore)
+	if !ok {
+		_ = container.Close()
+		t.Fatalf("expected *SQLStore contacts implementation, got %T", device.Contacts)
+	}
+
+	return sqlStore, func() {
+		_ = container.Close()
+	}
+}
+
+func ptr[T any](value T) *T {
+	return &value
+}
+
+func TestGetContactsPageReturnsOrderedSliceAndTotal(t *testing.T) {
+	sqlStore, cleanup := newTestSQLStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	contact1 := mustParseJID(t, "5511999999998@s.whatsapp.net")
+	contact2 := mustParseJID(t, "5511999999997@s.whatsapp.net")
+	contact3 := mustParseJID(t, "5511999999999@s.whatsapp.net")
+
+	if err := sqlStore.PutContactName(ctx, contact1, "Zulu", "Zulu"); err != nil {
+		t.Fatalf("failed to put contact1: %v", err)
+	}
+	if _, _, err := sqlStore.PutPushName(ctx, contact1, "Zulu"); err != nil {
+		t.Fatalf("failed to put push name contact1: %v", err)
+	}
+	if err := sqlStore.PutContactName(ctx, contact2, "Alpha", "Alpha"); err != nil {
+		t.Fatalf("failed to put contact2: %v", err)
+	}
+	if _, _, err := sqlStore.PutPushName(ctx, contact2, "Alpha"); err != nil {
+		t.Fatalf("failed to put push name contact2: %v", err)
+	}
+	if err := sqlStore.PutContactName(ctx, contact3, "Mike", "Mike"); err != nil {
+		t.Fatalf("failed to put contact3: %v", err)
+	}
+	if _, _, err := sqlStore.PutPushName(ctx, contact3, "Mike"); err != nil {
+		t.Fatalf("failed to put push name contact3: %v", err)
+	}
+
+	page, err := sqlStore.GetContactsPage(ctx, 2, 1)
+	if err != nil {
+		t.Fatalf("GetContactsPage returned error: %v", err)
+	}
+
+	if page.Total != 3 {
+		t.Fatalf("expected total 3, got %d", page.Total)
+	}
+	if len(page.Items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(page.Items))
+	}
+	if page.Items[0].JID.String() != "5511999999998@s.whatsapp.net" {
+		t.Fatalf("expected first paged jid to be 5511999999998@s.whatsapp.net, got %s", page.Items[0].JID.String())
+	}
+	if page.Items[1].JID.String() != "5511999999999@s.whatsapp.net" {
+		t.Fatalf("expected second paged jid to be 5511999999999@s.whatsapp.net, got %s", page.Items[1].JID.String())
+	}
+	if page.Items[0].Info.PushName != "Zulu" {
+		t.Fatalf("expected first paged push name to be Zulu, got %q", page.Items[0].Info.PushName)
+	}
+	if page.Items[1].Info.PushName != "Mike" {
+		t.Fatalf("expected second paged push name to be Mike, got %q", page.Items[1].Info.PushName)
+	}
+}
+
+func TestGetContactsPageReturnsEmptyWhenOffsetExceedsTotal(t *testing.T) {
+	sqlStore, cleanup := newTestSQLStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	contact := mustParseJID(t, "5511999999999@s.whatsapp.net")
+	if err := sqlStore.PutContactName(ctx, contact, "Only", "Only"); err != nil {
+		t.Fatalf("failed to put contact: %v", err)
+	}
+
+	page, err := sqlStore.GetContactsPage(ctx, 10, 5)
+	if err != nil {
+		t.Fatalf("GetContactsPage returned error: %v", err)
+	}
+
+	if page.Total != 1 {
+		t.Fatalf("expected total 1, got %d", page.Total)
+	}
+	if len(page.Items) != 0 {
+		t.Fatalf("expected empty page, got %d items", len(page.Items))
+	}
+}

--- a/store/sqlstore/store.go
+++ b/store/sqlstore/store.go
@@ -604,6 +604,16 @@ const (
 	getAllContactsQuery = `
 		SELECT their_jid, first_name, full_name, push_name, business_name, redacted_phone FROM whatsmeow_contacts WHERE our_jid=$1
 	`
+	getContactsCountQuery = `
+		SELECT COUNT(*) FROM whatsmeow_contacts WHERE our_jid=$1
+	`
+	getContactsPageQuery = `
+		SELECT their_jid, first_name, full_name, push_name, business_name, redacted_phone
+		FROM whatsmeow_contacts
+		WHERE our_jid=$1
+		ORDER BY their_jid
+		LIMIT $2 OFFSET $3
+	`
 )
 
 var putContactNamesMassInsertBuilder = dbutil.NewMassInsertBuilder[store.ContactEntry, [1]any](
@@ -812,6 +822,49 @@ func (s *SQLStore) GetAllContacts(ctx context.Context) (map[types.JID]types.Cont
 		return true, nil
 	})
 	return output, err
+}
+
+func (s *SQLStore) GetContactsPage(ctx context.Context, limit, offset int) (*store.ContactPage, error) {
+	if limit < 1 {
+		return &store.ContactPage{Items: []store.ContactPageItem{}}, nil
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	var total int
+	if err := s.db.QueryRow(ctx, getContactsCountQuery, s.JID).Scan(&total); err != nil {
+		return nil, err
+	}
+
+	page := &store.ContactPage{
+		Items: make([]store.ContactPageItem, 0, min(limit, total)),
+		Total: total,
+	}
+	if total == 0 || offset >= total {
+		return page, nil
+	}
+
+	rows, err := s.db.Query(ctx, getContactsPageQuery, s.JID, limit, offset)
+	if err != nil {
+		return nil, err
+	}
+
+	s.contactCacheLock.Lock()
+	defer s.contactCacheLock.Unlock()
+	err = convertContactRow.NewRowIter(rows, nil).Iter(func(tuple *contactTuple) (bool, error) {
+		page.Items = append(page.Items, store.ContactPageItem{
+			JID:  tuple.JID,
+			Info: *tuple.Info,
+		})
+		s.contactCache[tuple.JID] = tuple.Info
+		return true, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return page, nil
 }
 
 const (

--- a/store/store.go
+++ b/store/store.go
@@ -99,6 +99,16 @@ func (rpe RedactedPhoneEntry) GetMassInsertValues() [2]any {
 	return [...]any{rpe.JID.String(), rpe.RedactedPhone}
 }
 
+type ContactPageItem struct {
+	JID  types.JID
+	Info types.ContactInfo
+}
+
+type ContactPage struct {
+	Items []ContactPageItem
+	Total int
+}
+
 type ContactStore interface {
 	PutPushName(ctx context.Context, user types.JID, pushName string) (bool, string, error)
 	PutBusinessName(ctx context.Context, user types.JID, businessName string) (bool, string, error)
@@ -107,6 +117,7 @@ type ContactStore interface {
 	PutManyRedactedPhones(ctx context.Context, entries []RedactedPhoneEntry) error
 	GetContact(ctx context.Context, user types.JID) (types.ContactInfo, error)
 	GetAllContacts(ctx context.Context) (map[types.JID]types.ContactInfo, error)
+	GetContactsPage(ctx context.Context, limit, offset int) (*ContactPage, error)
 }
 
 var MutedForever = time.Date(9999, 12, 31, 23, 59, 59, 999999999, time.UTC)


### PR DESCRIPTION
## Summary
  Adds paginated contact retrieval to ContactStore without breaking the existing GetAllContacts API.

  ## Changes
  - adds GetContactsPage(ctx, limit, offset) to ContactStore
  - implements paginated SQL queries in sqlstore
  - keeps deterministic ordering by their_jid
  - preserves GetAllContacts for backward compatibility
  - adds focused tests for pagination behavior

  ## Motivation
  This allows downstream consumers to paginate contact reads at the persistence layer instead of loading the full contact set into memory first