### PR TITLE
send: expose participant list hash mismatch in SendResponse

### DIFF
--- a/send.go
+++ b/send.go
@@ -126,6 +126,13 @@ type SendResponse struct {
 	// The identity the message was sent with (LID or PN)
 	// This is currently not reliable in all cases.
 	Sender types.JID
+
+	// Whether the server responded with a different participant list hash than the one used to
+	// encrypt the message, meaning the local device list cache was stale and some of the
+	// recipient's devices likely did not receive the message. The stale cache entry is
+	// invalidated automatically, so resending the message (e.g. with the same ID via
+	// SendRequestExtra) will fetch a fresh device list and re-encrypt for the correct sessions.
+	PHashMismatch bool
 }
 
 // SendRequestExtra contains the optional parameters for SendMessage.
@@ -447,6 +454,7 @@ func (cli *Client) SendMessage(ctx context.Context, to types.JID, message *waE2E
 	}
 	expectedPHash := ag.OptionalString("phash")
 	if len(expectedPHash) > 0 && phash != expectedPHash {
+		resp.PHashMismatch = true
 		cli.Log.Warnf("Server returned different participant list hash (%s != %s) when sending to %s. Some devices may not have received the message.", phash, expectedPHash, to)
 		switch to.Server {
 		case types.GroupServer:

--- a/sendfb.go
+++ b/sendfb.go
@@ -199,6 +199,7 @@ func (cli *Client) SendFBMessage(
 	}
 	expectedPHash := ag.OptionalString("phash")
 	if len(expectedPHash) > 0 && phash != expectedPHash {
+		resp.PHashMismatch = true
 		cli.Log.Warnf("Server returned different participant list hash when sending to %s. Some devices may not have received the message.", to)
 		// TODO also invalidate device list caches
 		cli.groupCacheLock.Lock()


### PR DESCRIPTION
When the server acks a message with a different participant list hash than the one used for encryption, the local device list cache was stale and some (or all) of the recipient's devices likely never received the message. whatsmeow currently logs a warning and invalidates the stale cache entry, but the message itself is never retransmitted and the application has no programmatic way to know it happened — the send returns success, the message stays "sent" forever, and users end up resending manually.

This adds a `PHashMismatch bool` field to `SendResponse`, set in both `send.go` and `sendfb.go` when the mismatch is detected. Applications can then react at send time — e.g. immediately resend with the same message ID via `SendRequestExtra{ID: resp.ID}`, which re-encrypts against the freshly-fetched device list and lets recipient devices dedupe by ID.

Context: we run a CRM on top of whatsmeow and were seeing 1:1 messages permanently stuck in "sent" (server ack, no delivery receipt, cache self-corrects hours later). We currently detect this by intercepting the log warning, which is fragile. If you'd rather have whatsmeow retransmit automatically on mismatch (there's a `// TODO` in that area), happy to rework this PR in that direction instead — exposing the signal seemed like the least invasive first step.

No behavior change otherwise; field is additive.