### PR TITLE
store: synchronize Device.Save and Device.Delete to fix crash when pairing races a logout

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -10,6 +10,7 @@ package store
 import (
 	"context"
 	"errors"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -251,6 +252,12 @@ type Device struct {
 	EventBuffer   EventBuffer
 	LIDs          LIDStore
 	Container     DeviceContainer
+
+	// saveDeleteLock synchronizes Save and Delete so that a concurrent Delete
+	// (e.g. triggered by a 401 connect failure or device_removed stream error)
+	// can't set ID to nil in the middle of a Save, which would panic in
+	// Container.PutDevice.
+	saveDeleteLock sync.Mutex
 }
 
 func (device *Device) GetJID() types.JID {
@@ -274,6 +281,8 @@ func (device *Device) GetLID() types.JID {
 var ErrDeviceDeleted = errors.New("invalid use of deleted device")
 
 func (device *Device) Save(ctx context.Context) error {
+	device.saveDeleteLock.Lock()
+	defer device.saveDeleteLock.Unlock()
 	if device.Deleted {
 		return ErrDeviceDeleted
 	}
@@ -281,6 +290,8 @@ func (device *Device) Save(ctx context.Context) error {
 }
 
 func (device *Device) Delete(ctx context.Context) error {
+	device.saveDeleteLock.Lock()
+	defer device.saveDeleteLock.Unlock()
 	if device.Deleted {
 		return nil
 	}


### PR DESCRIPTION
`Device.Save` and `Device.Delete` can run concurrently on whatsmeow's own goroutines with nothing coordinating them:

- **pairing goroutine:** `handlePairSuccess` → `handlePair` → `Store.Save` → `Container.PutDevice`, which dereferences `*device.ID` (in `sqlstore.Container.initializeDevice`)
- **connection goroutine:** a 401 connect failure or `device_removed` stream error → `Store.Delete`, which sets `device.ID = nil`

If Delete lands in the middle of a Save, `PutDevice` dereferences the now-nil `device.ID` and panics — and since the goroutine spawned by `handlePairSuccess` has no recover, the panic takes down the entire process.

**Reproduction:** re-pair a phone number whose old session is still connecting. The old session's `Got 401 connect failure, sending LoggedOut event and deleting session` races the new pairing's Save; losing the race crashes the process instead of just failing that pairing attempt.

**Fix:** add a mutex to `Device` making `Save` and `Delete` mutually exclusive. If Delete runs first, Save sees `Deleted == true` and returns the existing `ErrDeviceDeleted`, so the pairing attempt fails gracefully with a `PairError` event. This also prevents a Save racing past Delete from re-inserting the just-deleted device row into the database.

`go build ./...`, `go vet ./...`, and `go test ./...` pass.

🤖 Prepared with [Claude Code](https://claude.com/claude-code); race observed and reproduced in production use of the library.