### PR TITLE
events: expose on-demand history request correlation ID on HistorySync

### DIFF
--- a/message.go
+++ b/message.go
@@ -713,7 +713,11 @@ func (cli *Client) handleHistorySyncNotificationLoop() {
 			if err != nil {
 				cli.Log.Errorf("Failed to download history sync: %v", err)
 			} else {
-				cli.dispatchEvent(&events.HistorySync{Data: blob})
+				cli.dispatchEvent(&events.HistorySync{
+					Data:                     blob,
+					OriginalMessageID:        notif.GetOriginalMessageID(),
+					PeerDataRequestSessionID: notif.GetPeerDataRequestSessionID(),
+				})
 				err = cli.DeleteMedia(ctx, MediaHistory, notif.GetDirectPath(), notif.GetFileEncSHA256(), notif.GetEncHandle())
 				if err != nil {
 					cli.Log.Warnf("Failed to delete history sync media from server: %v", err)

--- a/types/events/events.go
+++ b/types/events/events.go
@@ -269,6 +269,22 @@ type Disconnected struct{}
 // HistorySync is emitted when the phone has sent a blob of historical messages.
 type HistorySync struct {
 	Data *waHistorySync.HistorySync
+
+	// OriginalMessageID correlates an on-demand history sync back to the
+	// [Client.BuildHistorySyncRequest] that triggered it: it matches the message ID returned by the
+	// [Client.SendMessage]/[Client.SendPeerMessage] that sent the request. It is empty for
+	// unsolicited syncs (bootstrap, recent, push-name, etc.). Copied from the HistorySyncNotification.
+	//
+	// NOTE: for HISTORY_SYNC_ON_DEMAND (the peer-data-operation form used by
+	// [Client.BuildHistorySyncRequest]), WhatsApp leaves this empty and echoes the request id in
+	// PeerDataRequestSessionID instead — prefer that field for on-demand correlation.
+	OriginalMessageID string
+
+	// PeerDataRequestSessionID correlates an ON_DEMAND (peer-data-operation) history sync back to the
+	// request that triggered it: WhatsApp echoes the request message's ID here (equal to the ID
+	// returned by [Client.SendPeerMessage]). This is the field populated for HISTORY_SYNC_ON_DEMAND;
+	// OriginalMessageID is empty on that path. Empty for unsolicited syncs.
+	PeerDataRequestSessionID string
 }
 
 type DecryptFailMode string


### PR DESCRIPTION
## What

Adds two fields to `events.HistorySync`, both copied from the triggering `HistorySyncNotification`:

- `OriginalMessageID`
- `PeerDataRequestSessionID`

Both are empty for unsolicited syncs (bootstrap / recent / push-name / etc.).

## Why

When an app issues an on-demand history request via `BuildHistorySyncRequest` + `SendMessage`/`SendPeerMessage`, the returned `SendResponse.ID` is the request's message ID. WhatsApp echoes that ID back on the resulting `HistorySyncNotification`, but `handleHistorySyncNotificationLoop` discards the notification and dispatches only `events.HistorySync{Data: blob}`:

```go
cli.dispatchEvent(&events.HistorySync{Data: blob})
```

That leaves an app unable to correlate an incoming on-demand `HistorySync` with the specific request that triggered it. It matters when more than one on-demand request for the **same chat** is in flight (e.g. a background metadata scan and a gap-recovery backfill paging the same chat): the resulting `ON_DEMAND` batches carry no request identity, so they're otherwise indistinguishable and a page can be attributed to the wrong consumer.

## Which field carries the correlation ID

The echoed ID lands in **one of two fields depending on the request form**, so this exposes both:

- **`PeerDataRequestSessionID`** for `HISTORY_SYNC_ON_DEMAND` — the peer-data-operation form `BuildHistorySyncRequest` produces. Verified against production WhatsApp: `OriginalMessageID` comes back **empty** on this path, and the request's `SendResponse.ID` is echoed in `peerDataRequestSessionID`, byte-for-byte:

  ```
  SENT   SendResponse.ID          = 3EB05A6A038E168FD1F660
  ECHOED peerDataRequestSessionID = 3EB05A6A038E168FD1F660
  ```

- **`OriginalMessageID`** for the legacy path, kept for any caller that relies on it.

(An earlier revision of this PR exposed only `OriginalMessageID` and dismissed `peerDataRequestSessionID` as un-correlatable — that was an untested assumption. The on-demand path actually populates `peerDataRequestSessionID`, not `OriginalMessageID`.)

Both match `SendResponse.ID` and are empty for unsolicited syncs. Purely additive; existing consumers are unaffected.

## Testing

`gofmt -l`, `go build ./...`, and `go vet ./...` are clean. Verified end-to-end against production WhatsApp: an on-demand history request correlates to its response via `peerDataRequestSessionID` (exact-match on `SendResponse.ID`).
