### PR TITLE
message: automatically decrypt secret-encrypted edits

### DIFF
--- a/message.go
+++ b/message.go
@@ -1121,7 +1121,14 @@ func (cli *Client) handleDecryptedMessage(ctx context.Context, info *types.Messa
 		return false
 	}
 	evt := &events.Message{Info: *info, RawMessage: msg, RetryCount: retryCount}
-	return cli.dispatchEvent(evt.UnwrapRaw())
+	evt.UnwrapRaw()
+	if evt.Message.GetSecretEncryptedMessage().GetSecretEncType() == waE2E.SecretEncryptedMessage_MESSAGE_EDIT {
+		err := cli.decryptSecretEncryptedMessageEdit(ctx, evt)
+		if err != nil {
+			cli.Log.Warnf("Failed to decrypt secret encrypted message edit %s: %v", info.ID, err)
+		}
+	}
+	return cli.dispatchEvent(evt)
 }
 
 // SendProtocolMessageReceipt sends a receipt for a protocol message back to the phone.

--- a/msgsecret.go
+++ b/msgsecret.go
@@ -263,6 +263,12 @@ func (cli *Client) DecryptSecretEncryptedMessage(ctx context.Context, evt *event
 	encMessage := evt.Message.GetSecretEncryptedMessage()
 	if encMessage == nil {
 		return nil, ErrNotSecretEncryptedMessage
+	} else if encMessage.GetTargetMessageKey().GetID() == "" {
+		return nil, fmt.Errorf("secret encrypted message target key is missing")
+	} else if len(encMessage.GetEncIV()) != 12 {
+		return nil, fmt.Errorf("invalid secret encrypted message IV length: %d", len(encMessage.GetEncIV()))
+	} else if len(encMessage.GetEncPayload()) == 0 {
+		return nil, fmt.Errorf("secret encrypted message payload is missing")
 	}
 	var secretType MsgSecretType
 	switch encMessage.GetSecretEncType() {
@@ -290,6 +296,36 @@ func (cli *Client) DecryptSecretEncryptedMessage(ctx context.Context, evt *event
 		msg.MessageContextInfo = evt.Message.MessageContextInfo
 	}
 	return &msg, nil
+}
+
+// decryptSecretEncryptedMessageEdit decrypts a MESSAGE_EDIT envelope and
+// exposes it in the same event shape as the legacy EditedMessage wrapper.
+func (cli *Client) decryptSecretEncryptedMessageEdit(ctx context.Context, evt *events.Message) error {
+	encMessage := evt.Message.GetSecretEncryptedMessage()
+	if encMessage == nil || encMessage.GetSecretEncType() != waE2E.SecretEncryptedMessage_MESSAGE_EDIT {
+		return ErrNotSecretEncryptedMessage
+	}
+	decrypted, err := cli.DecryptSecretEncryptedMessage(ctx, evt)
+	if err != nil {
+		return fmt.Errorf("failed to decrypt secret encrypted message edit: %w", err)
+	}
+
+	// Some protocol versions encrypt only the edited content, while older
+	// implementations encrypted the full protocol message. Normalize both to
+	// the event shape produced by an EditedMessage wrapper.
+	if decrypted.GetProtocolMessage().GetType() != waE2E.ProtocolMessage_MESSAGE_EDIT {
+		decrypted = &waE2E.Message{
+			ProtocolMessage: &waE2E.ProtocolMessage{
+				Key:           encMessage.GetTargetMessageKey(),
+				Type:          waE2E.ProtocolMessage_MESSAGE_EDIT.Enum(),
+				EditedMessage: decrypted,
+				TimestampMS:   proto.Int64(evt.Info.Timestamp.UnixMilli()),
+			},
+		}
+	}
+	evt.Message = decrypted
+	evt.IsEdit = true
+	return nil
 }
 
 func getKeyFromInfo(msgInfo *types.MessageInfo) *waCommon.MessageKey {


### PR DESCRIPTION
whatsApp now sends some message edits as `SecretEncryptedMessage` envelopes whatsmeow recognized the edit metadata but dispatched the encrypted payload directly, leaving the edited content unavailable and `IsEdit` false unless applications manually called `DecryptSecretEncryptedMessage`

this PR automatically decrypts `MESSAGE_EDIT` envelopes during message processing and normalizes them to the existing edit event format decrypted events now include the edited content and set IsEdit to true, while preserving the raw encrypted message.