### PR TITLE
Add Client.PreSendHook for outbound node observability

### DIFF
--- a/client.go
+++ b/client.go
@@ -80,6 +80,22 @@ type Client struct {
 	// AutoReconnectHook is called when auto-reconnection fails. If the function returns false,
 	// the client will not attempt to reconnect. The number of retries can be read from AutoReconnectErrors.
 	AutoReconnectHook func(error) bool
+	// PreSendHook, if set, is called with every node the client is about to send,
+	// immediately before it is marshaled and written to the socket. It is called
+	// synchronously on the sending goroutine.
+	//
+	// Returning false drops the node: it is not sent, and sendNode reports
+	// ErrNodeDroppedByHook to the caller.
+	//
+	// The node must not be modified. It is passed by pointer only to avoid
+	// copying; treat it as read-only.
+	//
+	// This does not observe the Noise handshake frames, which are written before
+	// any binary node exists.
+	//
+	// Intended for egress observability and policy enforcement in clients that
+	// need to audit or restrict their own outbound traffic.
+	PreSendHook func(node *waBinary.Node) bool
 	// If SynchronousAck is set, acks for messages will only be sent after all event handlers return.
 	SynchronousAck             bool
 	EnableDecryptedEventBuffer bool
@@ -899,6 +915,10 @@ Loop:
 func (cli *Client) sendNodeAndGetData(ctx context.Context, node waBinary.Node) ([]byte, error) {
 	if cli == nil {
 		return nil, ErrClientIsNil
+	}
+	if cli.PreSendHook != nil && !cli.PreSendHook(&node) {
+		cli.sendLog.Debugf("Dropping %s: PreSendHook returned false", &node)
+		return nil, ErrNodeDroppedByHook
 	}
 	cli.socketLock.RLock()
 	sock := cli.socket

--- a/errors.go
+++ b/errors.go
@@ -16,12 +16,14 @@ import (
 
 // Miscellaneous errors
 var (
-	ErrClientIsNil     = errors.New("client is nil")
-	ErrNoSession       = errors.New("can't encrypt message for device: no signal session established")
-	ErrIQTimedOut      = errors.New("info query timed out")
-	ErrNotConnected    = errors.New("websocket not connected")
-	ErrNotLoggedIn     = errors.New("the store doesn't contain a device JID")
-	ErrMessageTimedOut = errors.New("timed out waiting for message send response")
+	ErrClientIsNil  = errors.New("client is nil")
+	ErrNoSession    = errors.New("can't encrypt message for device: no signal session established")
+	ErrIQTimedOut   = errors.New("info query timed out")
+	ErrNotConnected = errors.New("websocket not connected")
+	// ErrNodeDroppedByHook is returned when Client.PreSendHook rejected an outgoing node.
+	ErrNodeDroppedByHook = errors.New("outgoing node was dropped by PreSendHook")
+	ErrNotLoggedIn       = errors.New("the store doesn't contain a device JID")
+	ErrMessageTimedOut   = errors.New("timed out waiting for message send response")
 
 	ErrAlreadyConnected = errors.New("websocket is already connected")
 


### PR DESCRIPTION
There is currently no way for an embedder to observe or gate the nodes the client sends. `sendLog` sees them, but only as formatted log output, so structured access means parsing log strings — and a logger cannot prevent a send.

This adds an optional `PreSendHook func(node *waBinary.Node) bool` on `Client`, called in `sendNodeAndGetData` immediately before marshaling. Returning `false` drops the node and reports a new `ErrNodeDroppedByHook`. When unset, behaviour is unchanged.

**Why I want it.** I use whatsmeow for a receive-only companion client, and I want to enforce that property rather than assume it. The library legitimately sends a number of things on its own behalf — delivery receipts, the post-connect `passive` iq, prekey uploads, app-state syncs — which is correct for a general-purpose client, but it means an embedder cannot enumerate its own egress without reading library source and re-checking it on every upgrade. A hook makes that auditable, and lets a client fail closed on a node it did not expect instead of discovering a new outbound call after a version bump.

**Notes:**

- Called synchronously on the sending goroutine, so a slow hook slows sends. Documented on the field.
- The node is passed by pointer to avoid a copy; the doc comment states it must be treated as read-only.
- Does not observe the Noise handshake frames, since those are written before any binary node exists. Documented.
- `ErrNodeDroppedByHook` is new so callers can distinguish a policy drop from a transport failure.

`go build ./...` and `go vet ./...` clean against current main.
