### PR TITLE
send: mark event messages with type=event and meta event_type=creation

### DIFF
--- a/send.go
+++ b/send.go
@@ -923,6 +923,8 @@ func getTypeFromMessage(msg *waE2E.Message) string {
 		return "reaction"
 	case msg.PollCreationMessage != nil, msg.PollUpdateMessage != nil:
 		return "poll"
+	case msg.EventMessage != nil:
+		return "event"
 	case getMediaTypeFromMessage(msg) != "":
 		return "media"
 	case msg.Conversation != nil, msg.ExtendedTextMessage != nil, msg.ProtocolMessage != nil:
@@ -1134,6 +1136,14 @@ func (cli *Client) getMessageContent(
 			Tag: "meta",
 			Attrs: waBinary.Attrs{
 				"polltype": pollType,
+			},
+		})
+	}
+	if msgAttrs["type"] == "event" {
+		content = append(content, waBinary.Node{
+			Tag: "meta",
+			Attrs: waBinary.Attrs{
+				"event_type": "creation",
 			},
 		})
 	}


### PR DESCRIPTION
## Problem

Sending a `waE2E.Message{EventMessage: ...}` via `Client.SendMessage` produces a stanza framed as `type="text"`. The server accepts and relays it, but recipient clients silently ignore the message — the event never renders.

## Fix

Frame event creations the way official clients do, mirroring the existing poll handling (`type="poll"` + `<meta polltype="creation"/>`):

- `getTypeFromMessage`: `EventMessage` → `"event"`
- `getMessageContent`: append `<meta event_type="creation"/>` for event stanzas

Reference capture of a phone-created event received by a whatsmeow companion session:

```
<message ... type="event" ...>
  <enc type="pkmsg" v="2"/>
  <meta event_type="creation"/>
  ...
</message>
```

## Verified

Tested end-to-end on live accounts: with this patch (plus a `MessageSecret` in `MessageContextInfo` and the lifecycle fields set in the `EventMessage`, both app-level concerns), events sent through `SendMessage` render with working RSVP on recipient phones; without it they are dropped.

Related: #809, #663
