### PR TITLE
sqlstore/lidmap: keep device ID when falling back to the database

### DIFF
--- a/store/sqlstore/lidmap.go
+++ b/store/sqlstore/lidmap.go
@@ -188,7 +188,7 @@ func (s *CachedLIDMap) GetManyLIDsForPNs(ctx context.Context, pns []types.JID) (
 			lidDev := dev
 			lidDev.Server = types.HiddenUserServer
 			lidDev.User = lid
-			result[dev] = lidDev.ToNonAD()
+			result[dev] = lidDev
 		}
 	})
 	return result, err


### PR DESCRIPTION
`GetManyLIDsForPNs` has two paths that disagree about device IDs. The cache hit keeps it:

```go
result[pn] = types.JID{User: lidUser, Device: pn.Device, Server: types.HiddenUserServer}
```

The database fallback drops it via `ToNonAD()`, mapping every device of a contact onto LID device 0.

`encryptMessageForDevices` turns that LID into the Signal address, so two devices of one recipient collapse onto a single address. `sessionAddressToJID[addr] = jid` then keeps only the last one, `retryDevices` ends up one device short, and `fetchPreKeysNoError` skips it - that device has neither a session nor a bundle and fails with `ErrNoSession`. When a session already exists at the shared address, both devices are encrypted against it instead, and the one it does not belong to cannot decrypt and requests a retry.

The fallback runs whenever a PN is not in the in-memory cache, so this hits the first send to a contact after a restart, for recipients with linked devices.

### Which sends this affects

Only ones that reach `encryptMessageForDevices` with PN devices:

* **1:1 messages are not affected.** `SendMessage` swaps a PN destination for its LID before building the node ("Replacing SendMessage destination with LID"), using `GetLIDForPN`, which keeps the device on both of its paths. Every device is then a LID, so `pnDevices` is empty and the batch lookup returns immediately.
* **Status is affected.** `getStatusBroadcastRecipients` returns contacts as phone numbers and nothing converts them, so the batch lookup is the conversion.
* **Groups are affected when addressed by PN.** Members come from the group metadata as-is; LID-addressed groups are fine.

### Testing

Status broadcast limited to one recipient with two devices, alternating between the two versions across four sends. Unpatched, the linked device sends a retry receipt every time and is delivered a second late:

```
<receipt id="3EB0161D..." participant="9492079063155:60@lid" type="retry">
<receipt class="status"><participants message_id="3EB0161D...">
    <user jid="9492079063155@lid"    t="1785927201" type="delivery"/>
    <user jid="9492079063155:60@lid" t="1785927202" type="delivery"/>
```

Patched, no retries and both devices are delivered in the same second:

```
<receipt class="status"><participants message_id="3EB0B70E...">
    <user jid="9492079063155@lid"    t="1785927224" type="delivery"/>
    <user jid="9492079063155:60@lid" t="1785927224" type="delivery"/>
```

On a recipient with no existing session the unpatched version instead fails outright with `Failed to encrypt ... no signal session` and sends nothing to that device.