### PR TITLE
sqlstore: skip the PN->LID migration transaction when there is nothing to migrate

### DIFF
--- a/store/sqlstore/store.go
+++ b/store/sqlstore/store.go
@@ -143,6 +143,17 @@ const (
 		WHERE our_jid=$1 AND sender_id LIKE $2 || ':%'
 		ON CONFLICT (our_jid, chat_id, sender_id) DO UPDATE SET sender_key=excluded.sender_key
 	`
+	// Existence check for PN-addressed rows, using an explicit prefix range
+	// ($2/$3 are e.g. "12345:" and "12345;") so it can use the primary key
+	// instead of the LIKE scans the migration itself does.
+	//
+	// Sender keys are not checked: a sender key cannot exist without an identity
+	// key or session for the same address, because the sender key distribution
+	// message arrives encrypted in a pairwise session.
+	hasPNRowsToMigrateQuery = `
+		SELECT EXISTS(SELECT 1 FROM whatsmeow_sessions WHERE our_jid=$1 AND their_id>=$2 AND their_id<$3)
+			OR EXISTS(SELECT 1 FROM whatsmeow_identity_keys WHERE our_jid=$1 AND their_id>=$2 AND their_id<$3)
+	`
 )
 
 func (s *SQLStore) GetSession(ctx context.Context, address string) (session []byte, err error) {
@@ -250,9 +261,22 @@ func (s *SQLStore) MigratePNToLID(ctx context.Context, pn, lid types.JID) error 
 	if !s.migratedPNSessionsCache.Add(pnSignal) {
 		return nil
 	}
+	// migratedPNSessionsCache only lives in memory, so after a restart the first
+	// send to each recipient gets here even when the store was fully migrated
+	// long ago. Running the transaction unconditionally is one write transaction
+	// per recipient, which is very noticeable when sending to a lot of them.
+	// Check first and skip the transaction when there is nothing to migrate.
+	var hasPNRows bool
+	err := s.db.QueryRow(ctx, hasPNRowsToMigrateQuery, s.JID, pnSignal+":", pnSignal+";").Scan(&hasPNRows)
+	if err != nil {
+		s.log.Warnf("Failed to check for PN rows to migrate from %s: %v", pnSignal, err)
+	} else if !hasPNRows {
+		s.log.Debugf("No sessions or sender keys found to migrate from %s to %s (pre-check)", pnSignal, lid.SignalAddressUser())
+		return nil
+	}
 	var sessionsUpdated, identityKeysUpdated, senderKeysUpdated int64
 	lidSignal := lid.SignalAddressUser()
-	err := s.db.DoTxn(ctx, nil, func(ctx context.Context) error {
+	err = s.db.DoTxn(ctx, nil, func(ctx context.Context) error {
 		res, err := s.db.Exec(ctx, migratePNToLIDSessionsQuery, s.JID, pnSignal, lidSignal)
 		if err != nil {
 			return fmt.Errorf("failed to migrate sessions: %w", err)


### PR DESCRIPTION
`MigratePNToLID` is guarded only by `migratedPNSessionsCache`, which lives in memory. After every restart it is empty, so the first send to each recipient reaches the function again even when the store was migrated long ago — and it then always opens a write transaction and runs six statements, three of them `LIKE` prefix scans:

```go
if !s.migratedPNSessionsCache.Add(pnSignal) {
    return nil
}
// nothing else is checked before the transaction
err := s.db.DoTxn(ctx, nil, func(ctx context.Context) error {
```

### When this is expensive

`encryptMessageForDevices` calls it once per PN-addressed recipient device, so it scales with the size of the send:

* **Status broadcasts** — recipients come from the contact list as phone numbers and nothing converts them beforehand, so every recipient goes through it.
* **PN-addressed groups** — members come from the group metadata as-is.
* **1:1 messages are not affected** — `SendMessage` replaces the destination with its LID before building the node, so those devices are already LIDs and never enter this path.

It also gets worse as the store fills up. `LIKE` cannot use the index, so each of the three scans covers a table whose size grows with the number of contacts, while the number of calls grows with the number of recipients.

### The change

Check whether any PN-addressed row exists before starting the transaction, using an explicit prefix range (`>= "12345:"`, `< "12345;"`) so the lookup can use the primary key, and return early when there is nothing to migrate. The transaction body is untouched.

A failed check is only logged — it falls through to the transaction, so if the check ever misbehaves the behaviour is exactly what it is today.

Sender keys are deliberately not checked: a sender key cannot exist without an identity key or session for the same address, because the sender key distribution message arrives encrypted in a pairwise session. That is an assumption, and it is written out in the code comment.

### Numbers

SQLite, cold cache, every row already migrated — the state a store is in after a restart:

| recipients | journal | before | after |
|---|---|---|---|
| 5,000 | WAL | 19.2s | 0.08s |
| 5,000 | rollback | 18.2s | 0.19s |
| 48,000 | rollback | 34m53s | 1.9s |

Per recipient that is 3.6ms at 5,000 and 43.6ms at 48,000 — the scan growing with the table.

With every row still needing migration, so the transaction runs anyway, the extra check does not show up: 20.7s → 20.5s at 5,000 recipients on WAL.
