### PR TITLE
group: fix panic when sending member_add_mode in CreateGroup

### DIFF
--- a/group.go
+++ b/group.go
@@ -61,7 +61,7 @@ func (cli *Client) CreateGroup(ctx context.Context, req ReqCreateGroup) (*types.
 	// TODO member_share_group_history_mode
 	participantNodes = append(participantNodes, waBinary.Node{
 		Tag:     "member_add_mode",
-		Content: cmp.Or(req.MemberAddMode, types.GroupMemberAddModeAllMember),
+		Content: string(cmp.Or(req.MemberAddMode, types.GroupMemberAddModeAllMember)),
 	})
 	for i, participant := range req.Participants {
 		participant = participant.ToNonAD()


### PR DESCRIPTION
`CreateGroup` panics on current `main`.

39b719b added the `member_add_mode` node and passes `cmp.Or(req.MemberAddMode, types.GroupMemberAddModeAllMember)` as `Node.Content`. That value is a `types.GroupMemberAddMode`, not a `string`. `binaryEncoder.write` only matches the plain `string` type, so it falls through to the `default` case and panics with `ErrInvalidType`. Every `CreateGroup` call hits it.

Reproducible on `main`:

```go
binary.Marshal(binary.Node{
	Tag:     "member_add_mode",
	Content: types.GroupMemberAddModeAllMember,
})
// panic: unsupported payload type: types.GroupMemberAddMode
```

The fix converts to `string` explicitly. With the cast the node marshals fine (21 bytes).

I considered adding a reflection fallback in the encoder's `default` case for named types with string/integer underlying kinds, but left it out — the explicit `panic` on unknown types looks deliberate, and this is a one-line call-site bug. Happy to add it if you'd prefer the encoder to be defensive here.

### Checklist

* [x] I have read and followed the contributing guidelines at <https://docs.mau.fi/bridges/general/contributing.html>