### PR TITLE
Stop attaching an invalid business node when sending button/list responses.

### DIFF
--- a/send.go
+++ b/send.go
@@ -997,12 +997,8 @@ func getButtonTypeFromMessage(msg *waE2E.Message) string {
 		return getButtonTypeFromMessage(msg.EphemeralMessage.Message)
 	case msg.ButtonsMessage != nil:
 		return "buttons"
-	case msg.ButtonsResponseMessage != nil:
-		return "buttons_response"
 	case msg.ListMessage != nil:
 		return "list"
-	case msg.ListResponseMessage != nil:
-		return "list_response"
 	case msg.InteractiveResponseMessage != nil:
 		return "interactive_response"
 	default:


### PR DESCRIPTION
Real WhatsApp clients sending a ButtonsResponseMessage or ListResponseMessage
(i.e. tapping a button/list option to reply) do not attach a <biz> node to the
stanza — confirmed by comparing against genuine captured stanzas from the
official client.

whatsmeow's getButtonTypeFromMessage, however, treated these the same as the
original ButtonsMessage/ListMessage and returned a button type for them too,
causing the library to attach a <biz> node that should not be there. WhatsApp's
servers rejected these sends with the following error:

    ERRO[...] Failed to send message: server returned error 479

Removed the ButtonsResponseMessage/ListResponseMessage cases from
getButtonTypeFromMessage so they fall through to the default (no button type,
no <biz> node attached), matching real client behavior. The <enc mediatype="...">
attribute itself was already correct and required no changes — only the <biz>
node attachment was the problem.

Example — message built in Go (whatsapp.go):

  ```
  message := &waE2E.Message{
        ButtonsResponseMessage: &waE2E.ButtonsResponseMessage{
            SelectedButtonID: proto.String("opt_1"),
            Response:         &waE2E.ButtonsResponseMessage_SelectedDisplayText{
                SelectedDisplayText: "YEs",
            },
            Type: waE2E.ButtonsResponseMessage_DISPLAY_TEXT.Enum(),
            ContextInfo: contextInfo, // quoted message, if any
        },
    }
```

Resulting stanza sent to WhatsApp (after the fix — no <biz>):

```
    <message to="5511999999999@s.whatsapp.net" type="text" id="3EB0ABCDEF1234567890">
      <enc v="2" type="msg" mediatype="buttons_response">
        <!-- encrypted payload (Signal/E2E), contains the ButtonsResponseMessage above -->
      </enc>
    </message>
```

Before the fix, the library also attached this alongside <enc>, which is what
triggered the error 479 above:

 ```
   <biz>
      <!-- extra node real clients never send on a button/list response -->
    </biz>
```

The <enc mediatype="buttons_response"> attribute was always correct — the only
difference is the absence of <biz> now, which is what WhatsApp's server was
rejecting.
