### PR TITLE
call: isolate 1:1 signaling and media handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,13 @@ Most core features are already present:
 * Reading and writing app state (contact list, chat pin/mute status, etc)
 * Sending and handling retry receipts if message decryption fails
 * Sending status messages (experimental, may not work for large contact lists)
+* Placing, receiving, accepting, rejecting and hanging up 1:1 calls
+  (`OfferCall`/`AcceptCall`/`RejectCall`/`HangupCall`/`SetCallMute`, plus the
+  `events.Call*` and `events.CallMedia*` events) — whatsmeow handles
+  signaling, call-key crypto and relay election; the caller supplies the RTP
+  media stack
 
 Things that are not yet implemented:
 
 * Sending broadcast list messages (this is not supported on WhatsApp web either)
-* Calls
+* Group calls

--- a/ack.go
+++ b/ack.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2021 Tulir Asokan
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package whatsmeow
+
+import (
+	"context"
+
+	waBinary "go.mau.fi/whatsmeow/binary"
+	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
+	"go.mau.fi/whatsmeow/voip"
+)
+
+func (cli *Client) handleCallAck(ctx context.Context, node *waBinary.Node) {
+	ag := node.AttrGetter()
+	if ag.String("class") != "call" {
+		return
+	}
+
+	callID := ackCallID(node)
+	meta := types.BasicCallMeta{CallID: callID}
+	if cs := cli.getCall(callID); cs != nil {
+		meta = cs.meta
+	}
+	cli.dispatchEvent(&events.CallAck{BasicCallMeta: meta, Data: node})
+
+	if errCode := ag.String("error"); errCode != "" {
+		cli.Log.Warnf("Call rejected by server, call_id: %s, error_code: %s", callID, errCode)
+		cli.dropCall(callID)
+		cli.dispatchEvent(&events.CallMediaStop{BasicCallMeta: meta, Reason: "server:" + errCode})
+		return
+	}
+
+	if callID == "" {
+		return
+	}
+	cs := cli.getCall(callID)
+	if cs == nil {
+		return
+	}
+	ep := voip.ParseRelay(node, types.CallDirectionOutgoing)
+	if ep == nil {
+		return
+	}
+	cli.applyVoipSettingsCodec(cs, node, callID)
+	cli.captureCallRelay(cs, node)
+}
+
+func ackCallID(node *waBinary.Node) string {
+	if en := voip.FindChild(node, "error"); en != nil {
+		if id := en.AttrGetter().String("call-id"); id != "" {
+			return id
+		}
+	}
+	if r := voip.FindRelay(node); r != nil {
+		return r.AttrGetter().String("call-id")
+	}
+	return ""
+}

--- a/call.go
+++ b/call.go
@@ -12,17 +12,23 @@ import (
 	waBinary "go.mau.fi/whatsmeow/binary"
 	"go.mau.fi/whatsmeow/types"
 	"go.mau.fi/whatsmeow/types/events"
+	"go.mau.fi/whatsmeow/voip"
 )
 
 func (cli *Client) handleCallEvent(ctx context.Context, node *waBinary.Node) {
-	defer cli.maybeDeferredAck(ctx, node)()
-
-	if len(node.GetChildren()) != 1 {
+	children := node.GetChildren()
+	if len(children) != 1 {
+		defer cli.maybeDeferredAck(ctx, node)()
 		cli.dispatchEvent(&events.UnknownCallEvent{Node: node})
 		return
 	}
+	if children[0].Tag == "video" {
+		cli.sendCallVideoAck(ctx, node)
+	} else {
+		defer cli.maybeDeferredAck(ctx, node)()
+	}
 	ag := node.AttrGetter()
-	child := node.GetChildren()[0]
+	child := children[0]
 	cag := child.AttrGetter()
 	basicMeta := types.BasicCallMeta{
 		From:        ag.JID("from"),
@@ -34,18 +40,13 @@ func (cli *Client) handleCallEvent(ctx context.Context, node *waBinary.Node) {
 	if basicMeta.CallCreator.Server == types.HiddenUserServer {
 		basicMeta.CallCreatorAlt = cag.OptionalJIDOrEmpty("caller_pn")
 	} else {
-		// This may not actually exist
 		basicMeta.CallCreatorAlt = cag.OptionalJIDOrEmpty("caller_lid")
 	}
 	switch child.Tag {
 	case "offer":
-		cli.dispatchEvent(&events.CallOffer{
-			BasicCallMeta: basicMeta,
-			CallRemoteMeta: types.CallRemoteMeta{
-				RemotePlatform: ag.String("platform"),
-				RemoteVersion:  ag.String("version"),
-			},
-			Data: &child,
+		cli.onCallOffer(ctx, &child, basicMeta, types.CallRemoteMeta{
+			RemotePlatform: ag.String("platform"),
+			RemoteVersion:  ag.String("version"),
 		})
 	case "offer_notice":
 		cli.dispatchEvent(&events.CallOfferNotice{
@@ -59,15 +60,12 @@ func (cli *Client) handleCallEvent(ctx context.Context, node *waBinary.Node) {
 			BasicCallMeta: basicMeta,
 			Data:          &child,
 		})
+		cli.onRelayLatency(ctx, basicMeta, &child)
 	case "accept":
-		cli.dispatchEvent(&events.CallAccept{
-			BasicCallMeta: basicMeta,
-			CallRemoteMeta: types.CallRemoteMeta{
-				RemotePlatform: ag.String("platform"),
-				RemoteVersion:  ag.String("version"),
-			},
-			Data: &child,
-		})
+		cli.onCallAccept(basicMeta, types.CallRemoteMeta{
+			RemotePlatform: ag.String("platform"),
+			RemoteVersion:  ag.String("version"),
+		}, &child)
 	case "preaccept":
 		cli.dispatchEvent(&events.CallPreAccept{
 			BasicCallMeta: basicMeta,
@@ -86,20 +84,227 @@ func (cli *Client) handleCallEvent(ctx context.Context, node *waBinary.Node) {
 			},
 			Data: &child,
 		})
+		if cs := cli.getCall(basicMeta.CallID); cs != nil {
+			cli.captureCallRelay(cs, &child)
+		}
 	case "terminate":
-		cli.dispatchEvent(&events.CallTerminate{
-			BasicCallMeta: basicMeta,
-			Reason:        cag.String("reason"),
-			Data:          &child,
-		})
+		cli.onCallTerminate(&child, basicMeta, cag.String("reason"))
 	case "reject":
-		cli.dispatchEvent(&events.CallReject{
-			BasicCallMeta: basicMeta,
-			Data:          &child,
-		})
+		cli.onCallReject(&child, basicMeta)
+	case "mute_v2":
+		cli.onCallMuteV2(ctx, basicMeta, cag)
+	case "video":
+		cli.onCallVideo(basicMeta, &child)
 	default:
 		cli.dispatchEvent(&events.UnknownCallEvent{Node: node})
 	}
+}
+
+func (cli *Client) onCallOffer(ctx context.Context, child *waBinary.Node, meta types.BasicCallMeta, remote types.CallRemoteMeta) {
+	cag := child.AttrGetter()
+	if cag.OptionalString("is_call_ended") == "1" || cag.OptionalString("terminate_reason") != "" {
+		cli.Log.Debugf("Ignoring already-ended call offer, call_id: %s", meta.CallID)
+		return
+	}
+
+	callKey, err := cli.decryptIncomingCallKey(ctx, &events.CallOffer{BasicCallMeta: meta, CallRemoteMeta: remote, Data: child})
+	if err != nil {
+		cli.Log.Warnf("Failed to decrypt call key, call_id: %s: %v", meta.CallID, err)
+		return
+	}
+	cli.acceptInboundOffer(ctx, child, meta, remote, callKey)
+}
+
+func (cli *Client) acceptInboundOffer(ctx context.Context, child *waBinary.Node, meta types.BasicCallMeta, remote types.CallRemoteMeta, callKey []byte) *callState {
+	peer := meta.CallCreator
+	if peer.IsEmpty() {
+		peer = meta.From
+	}
+	relay := voip.ParseRelay(child, types.CallDirectionIncoming)
+	isVideo := voip.OfferHasVideo(child)
+
+	cs := cli.getCall(meta.CallID)
+	isNew := cs == nil
+	if isNew {
+		cs = &callState{
+			meta:        meta,
+			selfLID:     cli.getOwnLID(),
+			peerLID:     peer,
+			to:          meta.From,
+			creator:     meta.CallCreator,
+			callKey:     callKey,
+			relay:       relay,
+			localVideo:  isVideo,
+			remoteVideo: isVideo,
+		}
+		cli.putCall(meta.CallID, cs)
+	} else {
+		cli.callsLock.Lock()
+		cs.callKey = callKey
+		if relay != nil {
+			cs.relay = relay
+		}
+		cli.callsLock.Unlock()
+	}
+	cli.applyVoipSettingsCodec(cs, child, meta.CallID)
+
+	pre := voip.BuildEagerPreaccept(meta.CallID, meta.From, meta.CallCreator, cli.generateRequestID(), isVideo)
+	if err := cli.sendNode(ctx, pre); err != nil {
+		cli.Log.Warnf("Failed to send call preaccept, call_id: %s: %v", meta.CallID, err)
+	}
+
+	if isNew {
+		cli.dispatchEvent(&events.CallOffer{BasicCallMeta: meta, CallRemoteMeta: remote, Data: child, Video: isVideo})
+	}
+	cli.maybeEmitMediaReady(cs)
+	return cs
+}
+
+func (cli *Client) applyVoipSettingsCodec(cs *callState, node *waBinary.Node, callID string) {
+	vsNode := voip.FindChild(node, "voip_settings")
+	if vsNode == nil {
+		return
+	}
+	codec, err := voip.ParseCodec(voip.NodeBytes(vsNode))
+	if err != nil {
+		cli.Log.Debugf("Failed to parse voip_settings, call_id: %s: %v", callID, err)
+		return
+	}
+	cli.callsLock.Lock()
+	cs.codec = codec
+	cli.callsLock.Unlock()
+	cli.Log.Debugf("Selected call codec, call_id: %s, codec: %s", callID, codec)
+}
+
+func (cli *Client) onRelayLatency(ctx context.Context, meta types.BasicCallMeta, child *waBinary.Node) {
+	cs := cli.getCall(meta.CallID)
+	if cs == nil {
+		return
+	}
+	cli.captureCallRelay(cs, child)
+	if cs.outgoing {
+		return
+	}
+
+	kids := child.GetChildren()
+	for i := range kids {
+		te := &kids[i]
+		if te.Tag != "te" {
+			continue
+		}
+		tag := te.AttrGetter()
+		resp := voip.BuildRelayLatency(&voip.RelayLatencyParams{
+			CallID:       meta.CallID,
+			To:           meta.From,
+			CallCreator:  meta.CallCreator,
+			LatencyMs:    voip.DecodeLatency(tag.String("latency")),
+			RelayName:    tag.String("relay_name"),
+			AddressBytes: voip.NodeBytes(te),
+		})
+		resp.Attrs["id"] = cli.GenerateMessageID()
+		if err := cli.sendNode(ctx, resp); err != nil {
+			cli.Log.Warnf("Failed to send relaylatency response, call_id: %s: %v", meta.CallID, err)
+			return
+		}
+	}
+}
+
+func (cli *Client) onCallTerminate(child *waBinary.Node, meta types.BasicCallMeta, reason string) {
+	cli.dropCall(meta.CallID)
+	cli.dispatchEvent(&events.CallMediaStop{BasicCallMeta: meta, Reason: reason})
+	cli.dispatchEvent(&events.CallTerminate{BasicCallMeta: meta, Reason: reason, Data: child})
+}
+
+func (cli *Client) onCallReject(child *waBinary.Node, meta types.BasicCallMeta) {
+	cs := cli.getCall(meta.CallID)
+	cli.dropCall(meta.CallID)
+	cli.dispatchEvent(&events.CallReject{BasicCallMeta: meta, Data: child})
+	if cs != nil {
+		cli.dispatchEvent(&events.CallMediaStop{BasicCallMeta: cs.meta, Reason: "rejected"})
+	}
+}
+
+func (cli *Client) onCallMuteV2(ctx context.Context, meta types.BasicCallMeta, mv *waBinary.AttrUtility) {
+	cli.dispatchEvent(&events.CallMute{BasicCallMeta: meta, Muted: mv.String("mute-state") == "1"})
+
+	cs := cli.getCall(meta.CallID)
+	if cs == nil {
+		return
+	}
+	cli.callsLock.Lock()
+	pending := cs.acceptPending
+	cs.acceptPending = false
+	video := cs.localVideo || cs.remoteVideo
+	cli.callsLock.Unlock()
+	if !pending {
+		return
+	}
+
+	accept := voip.BuildAccept(&voip.AcceptParams{
+		CallID: meta.CallID, To: meta.From, CallCreator: meta.CallCreator,
+		AudioRates: []string{"16000"},
+		Metadata:   waBinary.Attrs{"peer_abtest_bucket_id_list": "125208,94276"},
+		Video:      video,
+	})
+	accept.Attrs["id"] = cli.generateRequestID()
+	if err := cli.sendNode(ctx, accept); err != nil {
+		cli.Log.Warnf("Failed to send call accept, call_id: %s: %v", meta.CallID, err)
+	}
+}
+
+func (cli *Client) captureCallRelay(cs *callState, node *waBinary.Node) {
+	direction := types.CallDirectionIncoming
+	if cs.outgoing {
+		direction = types.CallDirectionOutgoing
+	}
+	ep := voip.ParseRelay(node, direction)
+	if ep == nil {
+		return
+	}
+	cli.callsLock.Lock()
+	cs.relay = ep
+	cli.callsLock.Unlock()
+	cli.maybeEmitMediaReady(cs)
+}
+
+func (cli *Client) maybeEmitMediaReady(cs *callState) {
+	cli.callsLock.Lock()
+	if cs.callKey == nil || cs.relay == nil || cs.mediaReadySent {
+		cli.callsLock.Unlock()
+		return
+	}
+	cs.mediaReadySent = true
+	meta, self, peer, callKey, relay, codec := cs.meta, cs.selfLID, cs.peerLID, cs.callKey, *cs.relay, cs.codec
+	direction := types.CallDirectionIncoming
+	if cs.outgoing {
+		direction = types.CallDirectionOutgoing
+	}
+	video := cs.localVideo || cs.remoteVideo
+	cli.callsLock.Unlock()
+
+	cli.dispatchEvent(&events.CallMediaReady{
+		BasicCallMeta: meta,
+		SelfLID:       self,
+		PeerLID:       peer,
+		CallKey:       callKey,
+		Relay:         relay,
+		Codec:         codec,
+		Direction:     direction,
+		Video:         video,
+	})
+	cli.Log.Debugf("Call media ready, call_id: %s, codec: %s", meta.CallID, codec)
+}
+
+func (cli *Client) onCallAccept(meta types.BasicCallMeta, remote types.CallRemoteMeta, child *waBinary.Node) {
+	if cs := cli.getCall(meta.CallID); cs != nil {
+		cli.callsLock.Lock()
+		if !meta.From.IsEmpty() {
+			cs.peerLID = meta.From
+			cs.to = meta.From
+		}
+		cli.callsLock.Unlock()
+	}
+	cli.dispatchEvent(&events.CallAccept{BasicCallMeta: meta, CallRemoteMeta: remote, Data: child})
 }
 
 // RejectCall reject an incoming call.
@@ -109,14 +314,31 @@ func (cli *Client) RejectCall(ctx context.Context, callFrom types.JID, callID st
 		return ErrNotLoggedIn
 	}
 	ownID, callFrom = ownID.ToNonAD(), callFrom.ToNonAD()
+	cs := cli.getCall(callID)
 	rejectNode := waBinary.Node{
 		Tag:     "reject",
 		Attrs:   waBinary.Attrs{"call-id": callID, "call-creator": callFrom, "count": "0"},
 		Content: nil,
 	}
-	return cli.sendNode(ctx, waBinary.Node{
+	if token, err := cli.ensureTCToken(ctx, callFrom); err != nil {
+		cli.Log.Warnf("Failed to get privacy token for call reject to %s: %v", callFrom, err)
+	} else if len(token) > 0 {
+		rejectNode.Content = []waBinary.Node{{
+			Tag:     "tctoken",
+			Content: token,
+		}}
+	}
+	sendErr := cli.sendNode(ctx, waBinary.Node{
 		Tag:     "call",
 		Attrs:   waBinary.Attrs{"id": cli.GenerateMessageID(), "from": ownID, "to": callFrom},
 		Content: []waBinary.Node{rejectNode},
 	})
+	if cs != nil {
+		cli.dispatchEvent(&events.CallMediaStop{BasicCallMeta: cs.meta, Reason: "rejected"})
+	}
+	if sendErr != nil {
+		return sendErr
+	}
+	cli.dropCall(callID)
+	return nil
 }

--- a/call.go
+++ b/call.go
@@ -120,6 +120,9 @@ func (cli *Client) acceptInboundOffer(ctx context.Context, child *waBinary.Node,
 	if peer.IsEmpty() {
 		peer = meta.From
 	}
+	if relayPeer := voip.ParseRelayPeer(child); !relayPeer.IsEmpty() {
+		peer = relayPeer
+	}
 	relay := voip.ParseRelay(child, types.CallDirectionIncoming)
 	isVideo := voip.OfferHasVideo(child)
 
@@ -143,6 +146,9 @@ func (cli *Client) acceptInboundOffer(ctx context.Context, child *waBinary.Node,
 		cs.callKey = callKey
 		if relay != nil {
 			cs.relay = relay
+		}
+		if !peer.IsEmpty() {
+			cs.peerLID = preferQualifiedCallPeer(cs.peerLID, peer)
 		}
 		cli.callsLock.Unlock()
 	}
@@ -261,8 +267,12 @@ func (cli *Client) captureCallRelay(cs *callState, node *waBinary.Node) {
 	if ep == nil {
 		return
 	}
+	peer := voip.ParseRelayPeer(node)
 	cli.callsLock.Lock()
 	cs.relay = ep
+	if !peer.IsEmpty() {
+		cs.peerLID = preferQualifiedCallPeer(cs.peerLID, peer)
+	}
 	cli.callsLock.Unlock()
 	cli.maybeEmitMediaReady(cs)
 }
@@ -296,15 +306,30 @@ func (cli *Client) maybeEmitMediaReady(cs *callState) {
 }
 
 func (cli *Client) onCallAccept(meta types.BasicCallMeta, remote types.CallRemoteMeta, child *waBinary.Node) {
+	peer := meta.From
 	if cs := cli.getCall(meta.CallID); cs != nil {
 		cli.callsLock.Lock()
 		if !meta.From.IsEmpty() {
-			cs.peerLID = meta.From
+			cs.peerLID = preferQualifiedCallPeer(cs.peerLID, meta.From)
 			cs.to = meta.From
 		}
+		peer = cs.peerLID
 		cli.callsLock.Unlock()
 	}
-	cli.dispatchEvent(&events.CallAccept{BasicCallMeta: meta, CallRemoteMeta: remote, Data: child})
+	cli.dispatchEvent(&events.CallAccept{BasicCallMeta: meta, CallRemoteMeta: remote, Data: child, PeerLID: peer})
+}
+
+func preferQualifiedCallPeer(current, signaled types.JID) types.JID {
+	if signaled.IsEmpty() {
+		return current
+	}
+	if current.User == signaled.User &&
+		current.Server == signaled.Server &&
+		current.Device != 0 &&
+		signaled.Device == 0 {
+		return current
+	}
+	return signaled
 }
 
 // RejectCall reject an incoming call.

--- a/call_test.go
+++ b/call_test.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2021 Tulir Asokan
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package whatsmeow
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"go.mau.fi/whatsmeow/store"
+	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
+	waLog "go.mau.fi/whatsmeow/util/log"
+)
+
+func rejectCallTestClient() *Client {
+	self := callStateSelfJID()
+	return &Client{
+		calls: map[string]*callState{},
+		Log:   waLog.Noop,
+		Store: &store.Device{
+			ID:            &self,
+			PrivacyTokens: &store.NoopStore{},
+		},
+	}
+}
+
+func TestRejectCallSendFailureLeavesStateRegistered(t *testing.T) {
+	cli := rejectCallTestClient()
+	cli.putCall("CID", &callState{to: callStatePeerJID(), creator: callStateSelfJID()})
+
+	err := cli.RejectCall(context.Background(), callStatePeerJID(), "CID")
+	if err == nil || !strings.Contains(err.Error(), ErrNotConnected.Error()) {
+		t.Fatalf("RejectCall send-failure error = %v, want it to wrap %v", err, ErrNotConnected)
+	}
+	if cs := cli.getCall("CID"); cs == nil {
+		t.Error("call state was dropped despite the reject send failing")
+	}
+}
+
+func TestRejectCallNotLoggedIn(t *testing.T) {
+	cli := &Client{calls: map[string]*callState{}, Log: waLog.Noop, Store: &store.Device{}}
+	if err := cli.RejectCall(context.Background(), callStatePeerJID(), "CID"); err != ErrNotLoggedIn {
+		t.Fatalf("RejectCall(not logged in) = %v, want %v", err, ErrNotLoggedIn)
+	}
+}
+
+func TestRejectCallEmitsCallMediaStop(t *testing.T) {
+	cli := rejectCallTestClient()
+	ce := &capturedEvents{}
+	cli.AddEventHandler(ce.add)
+	peer := callStatePeerJID()
+	cli.putCall("CID", &callState{
+		meta:    types.BasicCallMeta{CallID: "CID", From: peer, CallCreator: peer},
+		to:      peer,
+		creator: peer,
+	})
+
+	_ = cli.RejectCall(context.Background(), peer, "CID")
+
+	stops := ce.filter(isCallMediaStop)
+	if len(stops) != 1 {
+		t.Fatalf("CallMediaStop dispatch count = %d, want 1", len(stops))
+	}
+	stop, ok := stops[0].(*events.CallMediaStop)
+	if !ok {
+		t.Fatal("captured event is not *events.CallMediaStop")
+	}
+	if stop.Reason != "rejected" {
+		t.Errorf("Reason = %q, want rejected", stop.Reason)
+	}
+}
+
+func TestRejectCallUnknownCallEmitsNoMediaStop(t *testing.T) {
+	cli := rejectCallTestClient()
+	ce := &capturedEvents{}
+	cli.AddEventHandler(ce.add)
+
+	_ = cli.RejectCall(context.Background(), callStatePeerJID(), "NOPE")
+
+	if n := len(ce.filter(isCallMediaStop)); n != 0 {
+		t.Errorf("CallMediaStop dispatch count = %d, want 0 for an unknown call", n)
+	}
+}

--- a/calls.go
+++ b/calls.go
@@ -1,0 +1,217 @@
+// Copyright (c) 2021 Tulir Asokan
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package whatsmeow
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+
+	waBinary "go.mau.fi/whatsmeow/binary"
+	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
+	"go.mau.fi/whatsmeow/voip"
+)
+
+type callState struct {
+	meta             types.BasicCallMeta
+	selfLID, peerLID types.JID
+	to, creator      types.JID
+	outgoing         bool
+	callKey          []byte
+	relay            *types.RelayEndpoint
+	codec            types.CallCodec
+	acceptPending    bool
+	mediaReadySent   bool
+	localVideo       bool
+	remoteVideo      bool
+}
+
+// CallOfferOptions configures a new outgoing 1:1 call.
+type CallOfferOptions struct {
+	Video bool
+}
+
+func (cli *Client) getCall(callID string) *callState {
+	cli.callsLock.Lock()
+	defer cli.callsLock.Unlock()
+	return cli.calls[callID]
+}
+
+func (cli *Client) putCall(callID string, cs *callState) {
+	cli.callsLock.Lock()
+	defer cli.callsLock.Unlock()
+	cli.calls[callID] = cs
+}
+
+func (cli *Client) dropCall(callID string) {
+	cli.callsLock.Lock()
+	defer cli.callsLock.Unlock()
+	delete(cli.calls, callID)
+}
+
+func newCallID() string {
+	var b [16]byte
+	_, _ = rand.Read(b[:])
+	return strings.ToUpper(hex.EncodeToString(b[:]))
+}
+
+func (cli *Client) resolvePeerCallLID(ctx context.Context, target types.JID) (types.JID, error) {
+	if target.Server == types.HiddenUserServer {
+		return target, nil
+	}
+	if lid, err := cli.Store.LIDs.GetLIDForPN(ctx, target); err == nil && !lid.IsEmpty() {
+		return lid, nil
+	}
+	info, err := cli.GetUserInfo(ctx, []types.JID{target})
+	if err != nil {
+		return types.EmptyJID, fmt.Errorf("whatsmeow: usync %s: %w", target.User, err)
+	}
+	for _, ui := range info {
+		if !ui.LID.IsEmpty() {
+			return ui.LID, nil
+		}
+	}
+	if lid, err := cli.Store.LIDs.GetLIDForPN(ctx, target); err == nil && !lid.IsEmpty() {
+		return lid, nil
+	}
+	return types.EmptyJID, fmt.Errorf("whatsmeow: usync returned no LID for %s (peer unreachable or not on WhatsApp)", target.User)
+}
+
+func (cli *Client) composeOffer(callID string, self, peer types.JID, deviceKeys []voip.DeviceKey, privacyToken, deviceIdentity []byte, video bool) waBinary.Node {
+	offer := voip.BuildOffer(&voip.OfferParams{
+		CallID:         callID,
+		To:             peer,
+		CallCreator:    self,
+		DeviceKeys:     deviceKeys,
+		PrivacyToken:   privacyToken,
+		Capability:     voip.CapabilityOffer,
+		DeviceIdentity: deviceIdentity,
+		Video:          video,
+	})
+	offer.Attrs["id"] = cli.GenerateMessageID()
+	return offer
+}
+
+func (cli *Client) newOutgoingCallState(callID string, self, peer types.JID, callKey []byte, video bool) *callState {
+	return &callState{
+		meta: types.BasicCallMeta{
+			From:        self,
+			Timestamp:   time.Now(),
+			CallCreator: self,
+			CallID:      callID,
+		},
+		selfLID:     self,
+		peerLID:     peer,
+		to:          peer,
+		creator:     self,
+		outgoing:    true,
+		callKey:     callKey,
+		localVideo:  video,
+		remoteVideo: video,
+	}
+}
+
+// OfferCall places a 1:1 call to target.
+func (cli *Client) OfferCall(ctx context.Context, target types.JID, options ...CallOfferOptions) (callID string, err error) {
+	var opts CallOfferOptions
+	if len(options) > 0 {
+		opts = options[0]
+	}
+	self := cli.getOwnLID()
+	if self.IsEmpty() {
+		return "", ErrNotLoggedIn
+	}
+	peer, err := cli.resolvePeerCallLID(ctx, target)
+	if err != nil {
+		return "", err
+	}
+	devices, err := cli.GetUserDevices(ctx, []types.JID{peer})
+	if err != nil {
+		return "", fmt.Errorf("whatsmeow: call device discovery: %w", err)
+	}
+	if len(devices) == 0 {
+		return "", fmt.Errorf("whatsmeow: peer %s has no devices (unreachable / not on WhatsApp)", peer)
+	}
+
+	callKey := make([]byte, 32)
+	if _, err = rand.Read(callKey); err != nil {
+		return "", err
+	}
+	deviceKeys, deviceIdentity, err := cli.encryptCallKeyForDevices(ctx, devices, callKey)
+	if err != nil {
+		return "", err
+	}
+
+	var privacyToken []byte
+	if pt, ptErr := cli.Store.PrivacyTokens.GetPrivacyToken(ctx, peer); ptErr == nil && pt != nil {
+		privacyToken = pt.Token
+	}
+
+	callID = newCallID()
+	offer := cli.composeOffer(callID, self, peer, deviceKeys, privacyToken, deviceIdentity, opts.Video)
+
+	cli.putCall(callID, cli.newOutgoingCallState(callID, self, peer, callKey, opts.Video))
+
+	if err = cli.sendNode(ctx, offer); err != nil {
+		return callID, fmt.Errorf("whatsmeow: send call offer: %w", err)
+	}
+	cli.Log.Debugf("Sent call offer, call_id: %s, peer_lid: %s, device_count: %d", callID, peer, len(devices))
+	return callID, nil
+}
+
+// AcceptCall arms the deferred accept for an inbound call.
+func (cli *Client) AcceptCall(ctx context.Context, callID string) error {
+	cli.callsLock.Lock()
+	defer cli.callsLock.Unlock()
+	cs := cli.calls[callID]
+	if cs == nil {
+		return fmt.Errorf("whatsmeow: unknown call %s", callID)
+	}
+	cs.acceptPending = true
+	return nil
+}
+
+// HangupCall ends callID (either call direction).
+func (cli *Client) HangupCall(ctx context.Context, callID string) error {
+	cs := cli.getCall(callID)
+	if cs == nil {
+		return fmt.Errorf("whatsmeow: unknown call %s", callID)
+	}
+	term := voip.BuildTerminate(&voip.TerminateParams{CallID: callID, To: cs.to, CallCreator: cs.creator})
+	term.Attrs["id"] = cli.GenerateMessageID()
+	sendErr := cli.sendNode(ctx, term)
+	cli.dispatchEvent(&events.CallMediaStop{BasicCallMeta: cs.meta, Reason: "hangup"})
+	if sendErr != nil {
+		return fmt.Errorf("whatsmeow: send call terminate: %w", sendErr)
+	}
+	cli.dropCall(callID)
+	cli.Log.Debugf("Sent call terminate, call_id: %s", callID)
+	return nil
+}
+
+// SetCallMute sends our local mute-state change for callID.
+func (cli *Client) SetCallMute(ctx context.Context, callID string, muted bool) error {
+	cs := cli.getCall(callID)
+	if cs == nil {
+		return fmt.Errorf("whatsmeow: unknown call %s", callID)
+	}
+	state := "0"
+	if muted {
+		state = "1"
+	}
+	mute := voip.BuildMute(callID, cs.to, cs.creator, state)
+	mute.Attrs["id"] = cli.GenerateMessageID()
+	if err := cli.sendNode(ctx, mute); err != nil {
+		return fmt.Errorf("whatsmeow: send call mute: %w", err)
+	}
+	cli.Log.Debugf("Sent call mute, call_id: %s, muted: %t", callID, muted)
+	return nil
+}

--- a/client.go
+++ b/client.go
@@ -121,6 +121,9 @@ type Client struct {
 	eventHandlers     []wrappedEventHandler
 	eventHandlersLock sync.RWMutex
 
+	calls     map[string]*callState
+	callsLock sync.Mutex
+
 	messageRetries     map[string]int
 	messageRetriesLock sync.Mutex
 	retrySema          *semaphore.Weighted
@@ -277,6 +280,7 @@ func NewClient(deviceStore *store.Device, log waLog.Logger) *Client {
 		tcTokenSenderTS:  make(map[types.JID]time.Time),
 		groupCache:       make(map[types.JID]*groupMetaCache),
 		userDevicesCache: make(map[types.JID]deviceCache),
+		calls:            make(map[string]*callState),
 
 		recentMessagesMap:      make(map[recentMessageKey]RecentMessage, recentMessagesSize),
 		sessionRecreateHistory: make(map[types.JID]time.Time),
@@ -300,6 +304,7 @@ func NewClient(deviceStore *store.Device, log waLog.Logger) *Client {
 		"appdata":      cli.handleEncryptedMessage,
 		"receipt":      cli.handleReceipt,
 		"call":         cli.handleCallEvent,
+		"ack":          cli.handleCallAck,
 		"chatstate":    cli.handleChatState,
 		"presence":     cli.handlePresence,
 		"notification": cli.handleNotification,
@@ -853,6 +858,8 @@ func (cli *Client) handleFrame(ctx context.Context, data []byte) {
 		// TODO should we do something else?
 	} else if cli.receiveResponse(ctx, node) {
 		// handled
+	} else if node.Tag == "ack" && !ackShouldEnqueue(node) {
+		// drop non-call acks silently
 	} else if _, ok := cli.nodeHandlers[node.Tag]; ok {
 		select {
 		case cli.handlerQueue <- node:
@@ -869,6 +876,10 @@ func (cli *Client) handleFrame(ctx context.Context, data []byte) {
 	} else if node.Tag != "ack" {
 		cli.Log.Debugf("Didn't handle WhatsApp node %s", node.Tag)
 	}
+}
+
+func ackShouldEnqueue(node *waBinary.Node) bool {
+	return node.AttrGetter().String("class") == "call"
 }
 
 func (cli *Client) handlerQueueLoop(evtCtx, connCtx context.Context) {

--- a/keys.go
+++ b/keys.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2021 Tulir Asokan
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package whatsmeow
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"google.golang.org/protobuf/proto"
+
+	waBinary "go.mau.fi/whatsmeow/binary"
+	"go.mau.fi/whatsmeow/proto/waE2E"
+	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
+	"go.mau.fi/whatsmeow/voip"
+)
+
+func callKeyPlaintext(callKey []byte) ([]byte, error) {
+	return proto.Marshal(&waE2E.Message{Call: &waE2E.Call{CallKey: callKey}})
+}
+
+// encryptCallKeyForDevices encrypts callKey to each of the peer's devices.
+//
+// NOT VALIDATED: exercised by the live call E2E; unit-covered only for the
+// plaintext wrap (callKeyPlaintext).
+func (cli *Client) encryptCallKeyForDevices(ctx context.Context, devices []types.JID, callKey []byte) (keys []voip.DeviceKey, deviceIdentity []byte, err error) {
+	pt, err := callKeyPlaintext(callKey)
+	if err != nil {
+		return nil, nil, err
+	}
+	keys = make([]voip.DeviceKey, 0, len(devices))
+	needIdentity := false
+	for _, dev := range devices {
+		enc, ni, encErr := cli.encryptMessageForDevice(ctx, pt, dev, nil, nil, nil)
+		if encErr != nil {
+			bundles := cli.fetchPreKeysNoError(ctx, []types.JID{dev})
+			enc, ni, encErr = cli.encryptMessageForDevice(ctx, pt, dev, bundles[dev], nil, nil)
+			if encErr != nil {
+				return nil, nil, fmt.Errorf("whatsmeow: encrypt call key for %s: %w", dev, encErr)
+			}
+		}
+		ct, ok := enc.Content.([]byte)
+		if !ok {
+			return nil, nil, fmt.Errorf("whatsmeow: enc node for %s has no ciphertext", dev)
+		}
+		needIdentity = needIdentity || ni
+		keys = append(keys, voip.DeviceKey{DeviceJID: dev, Ciphertext: ct, EncType: enc.AttrGetter().String("type")})
+	}
+	if needIdentity {
+		deviceIdentity, err = proto.Marshal(cli.Store.Account)
+		if err != nil {
+			return nil, nil, fmt.Errorf("whatsmeow: marshal device identity: %w", err)
+		}
+	}
+	return keys, deviceIdentity, nil
+}
+
+// decryptIncomingCallKey decrypts the callKey carried in an incoming call offer.
+//
+// NOT VALIDATED: exercised by the live call E2E; unit-covered only for the
+// plaintext wrap (callKeyPlaintext).
+func (cli *Client) decryptIncomingCallKey(ctx context.Context, offer *events.CallOffer) ([]byte, error) {
+	if offer == nil || offer.Data == nil {
+		return nil, errors.New("whatsmeow: call offer has no data node")
+	}
+	children := offer.Data.GetChildren()
+	var enc *waBinary.Node
+	for i := range children {
+		if children[i].Tag == "enc" {
+			enc = &children[i]
+			break
+		}
+	}
+	if enc == nil {
+		return nil, errors.New("whatsmeow: call offer has no enc node")
+	}
+	isPreKey := enc.AttrGetter().String("type") == "pkmsg"
+	pt, _, err := cli.decryptDM(ctx, enc, offer.From, isPreKey, offer.Timestamp)
+	if err != nil {
+		return nil, fmt.Errorf("whatsmeow: decrypt call key: %w", err)
+	}
+	var msg waE2E.Message
+	if err = proto.Unmarshal(pt, &msg); err != nil {
+		return nil, fmt.Errorf("whatsmeow: unmarshal call key message: %w", err)
+	}
+	callKey := msg.GetCall().GetCallKey()
+	if len(callKey) == 0 {
+		return nil, errors.New("whatsmeow: call offer carried no callKey")
+	}
+	return callKey, nil
+}

--- a/keys_test.go
+++ b/keys_test.go
@@ -1,0 +1,112 @@
+// Copyright (c) 2021 Tulir Asokan
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package whatsmeow
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"google.golang.org/protobuf/proto"
+
+	waBinary "go.mau.fi/whatsmeow/binary"
+	"go.mau.fi/whatsmeow/proto/waE2E"
+	"go.mau.fi/whatsmeow/types/events"
+)
+
+func TestCallKeyPlaintext(t *testing.T) {
+	callKey := make([]byte, 32)
+	for i := range callKey {
+		callKey[i] = byte(i + 1)
+	}
+	pt, err := callKeyPlaintext(callKey)
+	if err != nil {
+		t.Fatalf("callKeyPlaintext: %v", err)
+	}
+	var msg waE2E.Message
+	if err := proto.Unmarshal(pt, &msg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	got := msg.GetCall().GetCallKey()
+	if !bytes.Equal(got, callKey) {
+		t.Errorf("GetCall().GetCallKey() = %x, want %x", got, callKey)
+	}
+}
+
+const decryptCallKeyErrPrefix = "whatsmeow: decrypt call key:"
+
+func TestDecryptIncomingCallKeyNilOffer(t *testing.T) {
+	cli := &Client{}
+	_, err := cli.decryptIncomingCallKey(context.Background(), nil)
+	if err == nil || !strings.Contains(err.Error(), "no data node") {
+		t.Fatalf("decryptIncomingCallKey(nil) error = %v, want \"no data node\"", err)
+	}
+}
+
+func TestDecryptIncomingCallKeyNoDataNode(t *testing.T) {
+	cli := &Client{}
+	offer := &events.CallOffer{}
+	_, err := cli.decryptIncomingCallKey(context.Background(), offer)
+	if err == nil || !strings.Contains(err.Error(), "no data node") {
+		t.Fatalf("decryptIncomingCallKey(no Data) error = %v, want \"no data node\"", err)
+	}
+}
+
+func TestDecryptIncomingCallKeyNoEncChild(t *testing.T) {
+	cli := &Client{}
+	offer := &events.CallOffer{
+		Data: &waBinary.Node{Tag: "offer", Content: []waBinary.Node{{Tag: "audio"}, {Tag: "video"}}},
+	}
+	_, err := cli.decryptIncomingCallKey(context.Background(), offer)
+	if err == nil || !strings.Contains(err.Error(), "no enc node") {
+		t.Fatalf("decryptIncomingCallKey(no enc child) error = %v, want \"no enc node\"", err)
+	}
+}
+
+func TestDecryptIncomingCallKeyFindsEncAmongDecoys(t *testing.T) {
+	cli := &Client{}
+	offer := &events.CallOffer{
+		Data: &waBinary.Node{
+			Tag: "offer",
+			Content: []waBinary.Node{
+				{Tag: "audio"},
+				{Tag: "enc", Attrs: waBinary.Attrs{"type": "msg"}, Content: []byte("not-a-real-signal-message")},
+				{Tag: "video"},
+			},
+		},
+	}
+	_, err := cli.decryptIncomingCallKey(context.Background(), offer)
+	if err == nil {
+		t.Fatal("decryptIncomingCallKey(enc among decoys) error = nil, want a decrypt-attempt error")
+	}
+	if strings.Contains(err.Error(), "no data node") || strings.Contains(err.Error(), "no enc node") {
+		t.Fatalf("decryptIncomingCallKey(enc among decoys) error = %v, want extraction to succeed (no sentinel error)", err)
+	}
+	if !strings.HasPrefix(err.Error(), decryptCallKeyErrPrefix) {
+		t.Errorf("decryptIncomingCallKey(enc among decoys) error = %v, want prefix %q (reached decrypt attempt)", err, decryptCallKeyErrPrefix)
+	}
+}
+
+func TestDecryptIncomingCallKeyDetectsPreKeyType(t *testing.T) {
+	cli := &Client{}
+	offer := &events.CallOffer{
+		Data: &waBinary.Node{
+			Tag: "offer",
+			Content: []waBinary.Node{
+				{Tag: "enc", Attrs: waBinary.Attrs{"type": "pkmsg"}, Content: []byte("not-a-real-signal-message")},
+			},
+		},
+	}
+	_, err := cli.decryptIncomingCallKey(context.Background(), offer)
+	if err == nil || !strings.HasPrefix(err.Error(), decryptCallKeyErrPrefix) {
+		t.Fatalf("decryptIncomingCallKey(pkmsg) error = %v, want prefix %q", err, decryptCallKeyErrPrefix)
+	}
+	if !strings.Contains(err.Error(), "prekey message") {
+		t.Errorf("decryptIncomingCallKey(pkmsg) error = %v, want it to have taken the pre-key parse path", err)
+	}
+}

--- a/router_test.go
+++ b/router_test.go
@@ -1,0 +1,477 @@
+// Copyright (c) 2021 Tulir Asokan
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package whatsmeow
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	waBinary "go.mau.fi/whatsmeow/binary"
+	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
+	waLog "go.mau.fi/whatsmeow/util/log"
+)
+
+type capturedLog struct {
+	mu    sync.Mutex
+	warns []string
+}
+
+func (l *capturedLog) Warnf(msg string, args ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.warns = append(l.warns, fmt.Sprintf(msg, args...))
+}
+func (l *capturedLog) Errorf(string, ...any)   {}
+func (l *capturedLog) Infof(string, ...any)    {}
+func (l *capturedLog) Debugf(string, ...any)   {}
+func (l *capturedLog) Sub(string) waLog.Logger { return l }
+
+func (l *capturedLog) hasWarn(substr string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, w := range l.warns {
+		if strings.Contains(w, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+type capturedEvents struct {
+	mu   sync.Mutex
+	evts []any
+}
+
+func (c *capturedEvents) add(evt any) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.evts = append(c.evts, evt)
+}
+
+func (c *capturedEvents) filter(pred func(any) bool) []any {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var out []any
+	for _, e := range c.evts {
+		if pred(e) {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+func routerTestClient() (*Client, *capturedLog, *capturedEvents) {
+	log := &capturedLog{}
+	cli := &Client{calls: map[string]*callState{}, Log: log}
+	ce := &capturedEvents{}
+	cli.AddEventHandler(ce.add)
+	return cli, log, ce
+}
+
+func routerCallMeta() types.BasicCallMeta {
+	return types.BasicCallMeta{
+		From:        callStatePeerJID(),
+		CallCreator: callStatePeerJID(),
+		CallID:      "ROUTERCID",
+	}
+}
+
+func syntheticRelayNode() waBinary.Node {
+	return waBinary.Node{
+		Tag: "relay",
+		Content: []waBinary.Node{
+			{Tag: "key", Content: []byte("relay-integrity-key")},
+			{Tag: "token", Attrs: waBinary.Attrs{"id": "0"}, Content: []byte("token-zero")},
+			{Tag: "token", Attrs: waBinary.Attrs{"id": "1"}, Content: []byte("token-one")},
+			{
+				Tag: "te2",
+				Attrs: waBinary.Attrs{
+					"relay_id":      "5",
+					"relay_name":    "gru1c02",
+					"token_id":      "0",
+					"auth_token_id": "1",
+					"is_fna":        "0",
+				},
+				Content: []byte{10, 0, 0, 1, 0x1f, 0x90},
+			},
+		},
+	}
+}
+
+func routerRelayAckNode(callID string) waBinary.Node {
+	relay := syntheticRelayNode()
+	relay.Attrs = waBinary.Attrs{"call-id": callID}
+	return waBinary.Node{
+		Tag:     "ack",
+		Attrs:   waBinary.Attrs{"class": "call"},
+		Content: []waBinary.Node{relay},
+	}
+}
+
+func isCallOffer(e any) bool      { _, ok := e.(*events.CallOffer); return ok }
+func isCallMediaReady(e any) bool { _, ok := e.(*events.CallMediaReady); return ok }
+func isCallMediaStop(e any) bool  { _, ok := e.(*events.CallMediaStop); return ok }
+func isCallTerminate(e any) bool  { _, ok := e.(*events.CallTerminate); return ok }
+
+func TestOnCallOfferIgnoresAlreadyEndedOffer(t *testing.T) {
+	cli, _, ce := routerTestClient()
+	node := waBinary.Node{
+		Tag:   "call",
+		Attrs: waBinary.Attrs{"from": callStatePeerJID()},
+		Content: []waBinary.Node{{
+			Tag:   "offer",
+			Attrs: waBinary.Attrs{"call-id": "ROUTERCID", "call-creator": callStatePeerJID(), "is_call_ended": "1"},
+		}},
+	}
+	cli.handleCallEvent(context.Background(), &node)
+
+	if cli.getCall("ROUTERCID") != nil {
+		t.Error("already-ended offer registered call state, want none")
+	}
+	if n := len(ce.filter(isCallOffer)); n != 0 {
+		t.Errorf("CallOffer dispatch count = %d, want 0", n)
+	}
+}
+
+func TestOnCallOfferUndecryptableKeyIsIgnored(t *testing.T) {
+	cli, _, ce := routerTestClient()
+	node := waBinary.Node{
+		Tag:   "call",
+		Attrs: waBinary.Attrs{"from": callStatePeerJID()},
+		Content: []waBinary.Node{{
+			Tag:   "offer",
+			Attrs: waBinary.Attrs{"call-id": "ROUTERCID", "call-creator": callStatePeerJID()},
+			Content: []waBinary.Node{
+				{Tag: "enc", Attrs: waBinary.Attrs{"type": "msg"}, Content: []byte("not-a-real-signal-message")},
+			},
+		}},
+	}
+	cli.handleCallEvent(context.Background(), &node)
+
+	if cli.getCall("ROUTERCID") != nil {
+		t.Error("undecryptable offer registered call state, want none")
+	}
+	if n := len(ce.filter(isCallOffer)); n != 0 {
+		t.Errorf("CallOffer dispatch count = %d, want 0", n)
+	}
+}
+
+func TestAcceptInboundOfferRegistersPreacceptsAndDispatches(t *testing.T) {
+	cli, log, ce := routerTestClient()
+	meta := routerCallMeta()
+	remote := types.CallRemoteMeta{RemotePlatform: "android", RemoteVersion: "2.24"}
+	offerChild := waBinary.Node{Tag: "offer"}
+	callKey := bytes.Repeat([]byte{0x01}, 32)
+
+	cs := cli.acceptInboundOffer(context.Background(), &offerChild, meta, remote, callKey)
+
+	if cs == nil {
+		t.Fatal("acceptInboundOffer returned nil callState")
+	}
+	if got := cli.getCall(meta.CallID); got != cs {
+		t.Fatalf("getCall(%s) = %+v, want the registered state", meta.CallID, got)
+	}
+	if !bytes.Equal(cs.callKey, callKey) {
+		t.Errorf("callKey = %x, want %x", cs.callKey, callKey)
+	}
+	if cs.to != meta.From || cs.creator != meta.CallCreator {
+		t.Errorf("to/creator = %v/%v, want %v/%v", cs.to, cs.creator, meta.From, meta.CallCreator)
+	}
+	if cs.outgoing {
+		t.Error("outgoing = true, want false for an inbound offer")
+	}
+	if !log.hasWarn("preaccept") {
+		t.Error("expected a preaccept send attempt (observed via the ErrNotConnected warning)")
+	}
+	if n := len(ce.filter(isCallOffer)); n != 1 {
+		t.Errorf("CallOffer dispatch count = %d, want 1", n)
+	}
+	if n := len(ce.filter(isCallMediaReady)); n != 0 {
+		t.Errorf("CallMediaReady dispatch count = %d, want 0 (no relay yet)", n)
+	}
+}
+
+func TestAcceptInboundOfferWithRelayFiresMediaReady(t *testing.T) {
+	cli, _, ce := routerTestClient()
+	meta := routerCallMeta()
+	meta.CallID = "ROUTERCID2"
+	offerChild := waBinary.Node{Tag: "offer", Content: []waBinary.Node{syntheticRelayNode()}}
+	callKey := bytes.Repeat([]byte{0x02}, 32)
+
+	cli.acceptInboundOffer(context.Background(), &offerChild, meta, types.CallRemoteMeta{}, callKey)
+
+	if n := len(ce.filter(isCallMediaReady)); n != 1 {
+		t.Fatalf("CallMediaReady dispatch count = %d, want 1", n)
+	}
+}
+
+func TestAcceptInboundOfferRetransmitPreservesAcceptPending(t *testing.T) {
+	cli, log, ce := routerTestClient()
+	meta := routerCallMeta()
+	remote := types.CallRemoteMeta{}
+	callKey := bytes.Repeat([]byte{0x05}, 32)
+
+	first := waBinary.Node{Tag: "offer"}
+	cs := cli.acceptInboundOffer(context.Background(), &first, meta, remote, callKey)
+	if err := cli.AcceptCall(context.Background(), meta.CallID); err != nil {
+		t.Fatalf("AcceptCall: %v", err)
+	}
+	if !cs.acceptPending {
+		t.Fatal("acceptPending not armed after AcceptCall")
+	}
+
+	second := waBinary.Node{Tag: "offer", Content: []waBinary.Node{syntheticRelayNode()}}
+	cs2 := cli.acceptInboundOffer(context.Background(), &second, meta, remote, callKey)
+	if cs2 != cs {
+		t.Fatal("offer retransmit replaced the callState entry, want the same pointer reused")
+	}
+	if !cs.acceptPending {
+		t.Error("acceptPending was reset by the offer retransmit, want it preserved")
+	}
+	if got := cli.getCall(meta.CallID); got != cs {
+		t.Fatalf("getCall(%s) = %+v, want the original registered state", meta.CallID, got)
+	}
+	if n := len(ce.filter(isCallOffer)); n != 1 {
+		t.Errorf("CallOffer dispatch count = %d, want 1 (no duplicate incoming-call notification)", n)
+	}
+	if n := len(ce.filter(isCallMediaReady)); n != 1 {
+		t.Fatalf("CallMediaReady dispatch count = %d, want 1 (relay arrived on the retransmit)", n)
+	}
+
+	third := waBinary.Node{Tag: "offer", Content: []waBinary.Node{syntheticRelayNode()}}
+	cli.acceptInboundOffer(context.Background(), &third, meta, remote, callKey)
+	if n := len(ce.filter(isCallMediaReady)); n != 1 {
+		t.Errorf("CallMediaReady dispatch count after a second relay-carrying offer = %d, want 1 (no duplicate)", n)
+	}
+
+	muteNode := waBinary.Node{
+		Tag:   "call",
+		Attrs: waBinary.Attrs{"from": meta.From},
+		Content: []waBinary.Node{{
+			Tag:   "mute_v2",
+			Attrs: waBinary.Attrs{"call-id": meta.CallID, "call-creator": meta.CallCreator, "mute-state": "1"},
+		}},
+	}
+	cli.handleCallEvent(context.Background(), &muteNode)
+
+	if cs.acceptPending {
+		t.Error("acceptPending still true after mute_v2, want cleared by the deferred accept")
+	}
+	if !log.hasWarn("send call accept") {
+		t.Error("expected the deferred accept send attempt to have survived the retransmit (observed via the ErrNotConnected warning)")
+	}
+}
+
+func TestHandleCallAckRelayFiresMediaReadyOnceAndNotTwice(t *testing.T) {
+	cli, _, ce := routerTestClient()
+	cs := &callState{meta: routerCallMeta(), callKey: bytes.Repeat([]byte{3}, 32)}
+	cli.putCall("ROUTERCID", cs)
+
+	ack := routerRelayAckNode("ROUTERCID")
+	cli.handleCallAck(context.Background(), &ack)
+	cli.handleCallAck(context.Background(), &ack)
+
+	ready := ce.filter(isCallMediaReady)
+	if len(ready) != 1 {
+		t.Fatalf("CallMediaReady dispatch count = %d, want 1 (no duplicate on second ack)", len(ready))
+	}
+	evt, ok := ready[0].(*events.CallMediaReady)
+	if !ok {
+		t.Fatal("captured event is not *events.CallMediaReady")
+	}
+	if evt.Relay.IPv4 != "10.0.0.1" || evt.Relay.Port != 8080 {
+		t.Errorf("Relay = %+v, want 10.0.0.1:8080", evt.Relay)
+	}
+	if !bytes.Equal(evt.Relay.Key, []byte("relay-integrity-key")) {
+		t.Errorf("Relay.Key = %q, want relay-integrity-key", evt.Relay.Key)
+	}
+}
+
+func routerTransportRelayNode(callID string, peer types.JID) waBinary.Node {
+	return waBinary.Node{
+		Tag:   "call",
+		Attrs: waBinary.Attrs{"from": peer},
+		Content: []waBinary.Node{{
+			Tag:     "transport",
+			Attrs:   waBinary.Attrs{"call-id": callID, "call-creator": peer},
+			Content: []waBinary.Node{syntheticRelayNode()},
+		}},
+	}
+}
+
+func TestTransportRelayFiresMediaReadyOnceAndNotTwice(t *testing.T) {
+	cli, _, ce := routerTestClient()
+	peer := callStatePeerJID()
+	cli.putCall("ROUTERCID", &callState{
+		meta:    types.BasicCallMeta{CallID: "ROUTERCID", From: peer, CallCreator: peer},
+		to:      peer,
+		creator: peer,
+		callKey: bytes.Repeat([]byte{4}, 32),
+	})
+
+	node := routerTransportRelayNode("ROUTERCID", peer)
+	cli.handleCallEvent(context.Background(), &node)
+	cli.handleCallEvent(context.Background(), &node)
+
+	ready := ce.filter(isCallMediaReady)
+	if len(ready) != 1 {
+		t.Fatalf("CallMediaReady dispatch count = %d, want 1 (no duplicate on second transport)", len(ready))
+	}
+	evt, ok := ready[0].(*events.CallMediaReady)
+	if !ok {
+		t.Fatal("captured event is not *events.CallMediaReady")
+	}
+	if evt.Relay.IPv4 != "10.0.0.1" || evt.Relay.Port != 8080 {
+		t.Errorf("Relay = %+v, want 10.0.0.1:8080", evt.Relay)
+	}
+	if !bytes.Equal(evt.Relay.Key, []byte("relay-integrity-key")) {
+		t.Errorf("Relay.Key = %q, want relay-integrity-key", evt.Relay.Key)
+	}
+
+	cs := cli.getCall("ROUTERCID")
+	if cs == nil {
+		t.Fatal("call state disappeared after transport")
+	}
+	if cs.relay == nil {
+		t.Fatal("cs.relay is nil, want the parsed relay")
+	}
+}
+
+func TestHandleCallAckErrorDropsStateAndEmitsMediaStop(t *testing.T) {
+	cli, _, ce := routerTestClient()
+	cli.putCall("ROUTERCID", &callState{meta: routerCallMeta()})
+
+	ack := waBinary.Node{
+		Tag:   "ack",
+		Attrs: waBinary.Attrs{"class": "call", "error": "500"},
+		Content: []waBinary.Node{{
+			Tag:   "error",
+			Attrs: waBinary.Attrs{"call-id": "ROUTERCID"},
+		}},
+	}
+	cli.handleCallAck(context.Background(), &ack)
+
+	if cli.getCall("ROUTERCID") != nil {
+		t.Error("call state was not dropped after a server error ack")
+	}
+	stops := ce.filter(isCallMediaStop)
+	if len(stops) != 1 {
+		t.Fatalf("CallMediaStop dispatch count = %d, want 1", len(stops))
+	}
+	stop, ok := stops[0].(*events.CallMediaStop)
+	if !ok {
+		t.Fatal("captured event is not *events.CallMediaStop")
+	}
+	if stop.Reason != "server:500" {
+		t.Errorf("Reason = %q, want server:500", stop.Reason)
+	}
+}
+
+func TestHandleCallAckIgnoresNonCallClass(t *testing.T) {
+	cli, _, ce := routerTestClient()
+	ack := waBinary.Node{Tag: "ack", Attrs: waBinary.Attrs{"class": "message"}}
+	cli.handleCallAck(context.Background(), &ack)
+
+	if n := len(ce.filter(func(any) bool { return true })); n != 0 {
+		t.Errorf("non-call ack dispatched %d events, want 0", n)
+	}
+}
+
+func TestMuteV2FirstFiresDeferredAcceptOnce(t *testing.T) {
+	cli, log, ce := routerTestClient()
+	peer := callStatePeerJID()
+	cli.putCall("ROUTERCID", &callState{
+		meta:          types.BasicCallMeta{CallID: "ROUTERCID", From: peer, CallCreator: peer},
+		to:            peer,
+		creator:       peer,
+		acceptPending: true,
+	})
+
+	muteNode := func(state string) waBinary.Node {
+		return waBinary.Node{
+			Tag:   "call",
+			Attrs: waBinary.Attrs{"from": peer},
+			Content: []waBinary.Node{{
+				Tag:   "mute_v2",
+				Attrs: waBinary.Attrs{"call-id": "ROUTERCID", "call-creator": peer, "mute-state": state},
+			}},
+		}
+	}
+
+	first := muteNode("1")
+	cli.handleCallEvent(context.Background(), &first)
+
+	cs := cli.getCall("ROUTERCID")
+	if cs == nil {
+		t.Fatal("call state disappeared after mute_v2")
+	}
+	if cs.acceptPending {
+		t.Error("acceptPending still true after first mute_v2, want cleared")
+	}
+	if !log.hasWarn("accept") {
+		t.Error("expected an accept send attempt (observed via the ErrNotConnected warning)")
+	}
+	if n := len(ce.filter(func(e any) bool { m, ok := e.(*events.CallMute); return ok && m.Muted })); n != 1 {
+		t.Errorf("CallMute(muted=true) dispatch count = %d, want 1", n)
+	}
+
+	second := muteNode("0")
+	cli.handleCallEvent(context.Background(), &second)
+	if n := len(ce.filter(func(e any) bool { m, ok := e.(*events.CallMute); return ok && !m.Muted })); n != 1 {
+		t.Errorf("CallMute(muted=false) dispatch count = %d, want 1", n)
+	}
+}
+
+func TestAckShouldEnqueueOnlyCallClass(t *testing.T) {
+	callAck := waBinary.Node{Tag: "ack", Attrs: waBinary.Attrs{"class": "call"}}
+	if !ackShouldEnqueue(&callAck) {
+		t.Error("class=call ack should enqueue")
+	}
+	msgAck := waBinary.Node{Tag: "ack", Attrs: waBinary.Attrs{"class": "message"}}
+	if ackShouldEnqueue(&msgAck) {
+		t.Error("class=message ack should not enqueue")
+	}
+	noClassAck := waBinary.Node{Tag: "ack"}
+	if ackShouldEnqueue(&noClassAck) {
+		t.Error("ack with no class attr should not enqueue")
+	}
+}
+
+func TestCallTerminateDropsStateAndEmitsMediaStop(t *testing.T) {
+	cli, _, ce := routerTestClient()
+	peer := callStatePeerJID()
+	cli.putCall("ROUTERCID", &callState{meta: types.BasicCallMeta{CallID: "ROUTERCID", From: peer, CallCreator: peer}})
+
+	node := waBinary.Node{
+		Tag:   "call",
+		Attrs: waBinary.Attrs{"from": peer},
+		Content: []waBinary.Node{{
+			Tag:   "terminate",
+			Attrs: waBinary.Attrs{"call-id": "ROUTERCID", "call-creator": peer, "reason": "hangup"},
+		}},
+	}
+	cli.handleCallEvent(context.Background(), &node)
+
+	if cli.getCall("ROUTERCID") != nil {
+		t.Error("call state was not dropped on terminate")
+	}
+	stops := ce.filter(isCallMediaStop)
+	if len(stops) != 1 {
+		t.Fatalf("CallMediaStop dispatch count = %d, want 1", len(stops))
+	}
+	if s := stops[0].(*events.CallMediaStop); s.Reason != "hangup" {
+		t.Errorf("CallMediaStop.Reason = %q, want hangup", s.Reason)
+	}
+	if n := len(ce.filter(isCallTerminate)); n != 1 {
+		t.Errorf("CallTerminate dispatch count = %d, want 1", n)
+	}
+}

--- a/router_test.go
+++ b/router_test.go
@@ -118,6 +118,7 @@ func routerRelayAckNode(callID string) waBinary.Node {
 }
 
 func isCallOffer(e any) bool      { _, ok := e.(*events.CallOffer); return ok }
+func isCallAccept(e any) bool     { _, ok := e.(*events.CallAccept); return ok }
 func isCallMediaReady(e any) bool { _, ok := e.(*events.CallMediaReady); return ok }
 func isCallMediaStop(e any) bool  { _, ok := e.(*events.CallMediaStop); return ok }
 func isCallTerminate(e any) bool  { _, ok := e.(*events.CallTerminate); return ok }
@@ -211,6 +212,52 @@ func TestAcceptInboundOfferWithRelayFiresMediaReady(t *testing.T) {
 
 	if n := len(ce.filter(isCallMediaReady)); n != 1 {
 		t.Fatalf("CallMediaReady dispatch count = %d, want 1", n)
+	}
+}
+
+func TestAcceptInboundOfferUsesRelayElectedPeerDevice(t *testing.T) {
+	cli, _, ce := routerTestClient()
+	meta := routerCallMeta()
+	meta.CallID = "ROUTERDEVICECID"
+	companion := meta.CallCreator
+	companion.Device = 7
+	relay := syntheticRelayNode()
+	relay.Attrs = waBinary.Attrs{"peer_pid": "2"}
+	relay.Content = append(relay.GetChildren(),
+		waBinary.Node{Tag: "participant", Attrs: waBinary.Attrs{"pid": "2", "jid": companion}},
+	)
+	offerChild := waBinary.Node{Tag: "offer", Content: []waBinary.Node{relay}}
+
+	cli.acceptInboundOffer(context.Background(), &offerChild, meta, types.CallRemoteMeta{}, bytes.Repeat([]byte{0x02}, 32))
+
+	ready := ce.filter(isCallMediaReady)
+	if len(ready) != 1 {
+		t.Fatalf("CallMediaReady dispatch count = %d, want 1", len(ready))
+	}
+	if peer := ready[0].(*events.CallMediaReady).PeerLID; peer != companion {
+		t.Fatalf("CallMediaReady.PeerLID = %s, want %s", peer, companion)
+	}
+}
+
+func TestCallAcceptPreservesRelayElectedPeerDevice(t *testing.T) {
+	cli, _, ce := routerTestClient()
+	meta := routerCallMeta()
+	companion := meta.From
+	companion.Device = 7
+	cli.putCall(meta.CallID, &callState{meta: meta, peerLID: companion})
+
+	cli.onCallAccept(meta, types.CallRemoteMeta{}, &waBinary.Node{Tag: "accept"})
+
+	cs := cli.getCall(meta.CallID)
+	if cs.peerLID != companion {
+		t.Fatalf("call peer after accept = %s, want %s", cs.peerLID, companion)
+	}
+	accepts := ce.filter(isCallAccept)
+	if len(accepts) != 1 {
+		t.Fatalf("CallAccept dispatch count = %d, want 1", len(accepts))
+	}
+	if peer := accepts[0].(*events.CallAccept).PeerLID; peer != companion {
+		t.Fatalf("CallAccept.PeerLID = %s, want %s", peer, companion)
 	}
 }
 

--- a/state_test.go
+++ b/state_test.go
@@ -1,0 +1,222 @@
+// Copyright (c) 2021 Tulir Asokan
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package whatsmeow
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
+	waLog "go.mau.fi/whatsmeow/util/log"
+	"go.mau.fi/whatsmeow/voip"
+)
+
+func callStatePeerJID() types.JID {
+	return types.JID{User: "214482127208608", Server: types.HiddenUserServer}
+}
+
+func callStateSelfJID() types.JID {
+	return types.JID{User: "111111111111111", Server: types.HiddenUserServer}
+}
+
+func TestCallStateGetPutDrop(t *testing.T) {
+	cli := &Client{calls: map[string]*callState{}}
+	if cs := cli.getCall("CID"); cs != nil {
+		t.Fatalf("getCall(unregistered) = %+v, want nil", cs)
+	}
+	want := &callState{to: callStatePeerJID(), creator: callStateSelfJID()}
+	cli.putCall("CID", want)
+	if got := cli.getCall("CID"); got != want {
+		t.Fatalf("getCall(registered) = %+v, want %+v", got, want)
+	}
+	cli.dropCall("CID")
+	if cs := cli.getCall("CID"); cs != nil {
+		t.Fatalf("getCall(dropped) = %+v, want nil", cs)
+	}
+}
+
+func TestComposeOfferBuildsCallOfferWithID(t *testing.T) {
+	cli := &Client{}
+	self, peer := callStateSelfJID(), callStatePeerJID()
+	dk := voip.DeviceKey{DeviceJID: peer, Ciphertext: []byte{1, 2, 3}, EncType: "pkmsg"}
+	offer := cli.composeOffer("CID", self, peer, []voip.DeviceKey{dk}, []byte{0xaa}, []byte{0xbb}, false)
+
+	if offer.Tag != "call" {
+		t.Errorf("outer tag = %q, want call", offer.Tag)
+	}
+	if id := offer.AttrGetter().String("id"); id == "" {
+		t.Error("call stanza id was not stamped")
+	}
+	if to, _ := offer.Attrs["to"].(types.JID); to != peer {
+		t.Errorf("to = %v, want %v", to, peer)
+	}
+
+	actions := offer.GetChildren()
+	if len(actions) != 1 {
+		t.Fatalf("call action count = %d, want 1", len(actions))
+	}
+	action := actions[0]
+	if action.Tag != "offer" {
+		t.Fatalf("action tag = %q, want offer", action.Tag)
+	}
+	if cid := action.AttrGetter().String("call-id"); cid != "CID" {
+		t.Errorf("call-id = %q, want CID", cid)
+	}
+	if creator, _ := action.Attrs["call-creator"].(types.JID); creator != self {
+		t.Errorf("call-creator = %v, want %v", creator, self)
+	}
+	want := []string{"privacy", "audio", "audio", "net", "capability", "enc", "encopt", "device-identity"}
+	children := action.GetChildren()
+	got := make([]string, len(children))
+	for i := range children {
+		got[i] = children[i].Tag
+	}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("child tags = %v, want %v", got, want)
+	}
+}
+
+func TestNewOutgoingCallStateMapsFields(t *testing.T) {
+	cli := &Client{calls: map[string]*callState{}}
+	self, peer := callStateSelfJID(), callStatePeerJID()
+	callKey := []byte{1, 2, 3, 4}
+
+	cs := cli.newOutgoingCallState("CID", self, peer, callKey, false)
+
+	if cs.meta.CallID != "CID" {
+		t.Errorf("meta.CallID = %q, want CID", cs.meta.CallID)
+	}
+	if cs.meta.From != self || cs.meta.CallCreator != self {
+		t.Errorf("meta.From/CallCreator = %v/%v, want both %v", cs.meta.From, cs.meta.CallCreator, self)
+	}
+	if cs.selfLID != self {
+		t.Errorf("selfLID = %v, want %v", cs.selfLID, self)
+	}
+	if cs.peerLID != peer {
+		t.Errorf("peerLID = %v, want %v", cs.peerLID, peer)
+	}
+	if cs.to != peer {
+		t.Errorf("to = %v, want %v (the offer is sent to the peer)", cs.to, peer)
+	}
+	if cs.creator != self {
+		t.Errorf("creator = %v, want %v (we placed this call)", cs.creator, self)
+	}
+	if !cs.outgoing {
+		t.Error("outgoing = false, want true for a call we placed")
+	}
+	if string(cs.callKey) != string(callKey) {
+		t.Errorf("callKey = %v, want %v", cs.callKey, callKey)
+	}
+
+	cli.putCall("CID", cs)
+	if cli.getCall("CID") == nil {
+		t.Fatal("getCall(CID) = nil after putCall, want the registered state")
+	}
+}
+
+func TestResolvePeerCallLIDAlreadyLID(t *testing.T) {
+	cli := &Client{}
+	peer := callStatePeerJID()
+	got, err := cli.resolvePeerCallLID(context.Background(), peer)
+	if err != nil {
+		t.Fatalf("resolvePeerCallLID: %v", err)
+	}
+	if got != peer {
+		t.Errorf("resolvePeerCallLID = %v, want %v unchanged", got, peer)
+	}
+}
+
+func TestAcceptCallArmsDeferredAccept(t *testing.T) {
+	cli := &Client{calls: map[string]*callState{}, Log: waLog.Noop}
+	cli.putCall("CID", &callState{})
+	if err := cli.AcceptCall(context.Background(), "CID"); err != nil {
+		t.Fatalf("AcceptCall: %v", err)
+	}
+	cs := cli.getCall("CID")
+	if cs == nil || !cs.acceptPending {
+		t.Fatalf("acceptPending = %+v, want true", cs)
+	}
+}
+
+func TestAcceptCallUnknownCallReturnsError(t *testing.T) {
+	cli := &Client{calls: map[string]*callState{}, Log: waLog.Noop}
+	if err := cli.AcceptCall(context.Background(), "NOPE"); err == nil {
+		t.Fatal("AcceptCall(unknown) = nil error, want error")
+	}
+}
+
+func TestHangupCallUnknownCallReturnsError(t *testing.T) {
+	cli := &Client{calls: map[string]*callState{}, Log: waLog.Noop}
+	if err := cli.HangupCall(context.Background(), "NOPE"); err == nil {
+		t.Fatal("HangupCall(unknown) = nil error, want error")
+	}
+}
+
+func TestHangupCallSendFailureLeavesStateRegistered(t *testing.T) {
+	cli := &Client{calls: map[string]*callState{}, Log: waLog.Noop}
+	cli.putCall("CID", &callState{to: callStatePeerJID(), creator: callStateSelfJID()})
+	err := cli.HangupCall(context.Background(), "CID")
+	if err == nil || !strings.Contains(err.Error(), ErrNotConnected.Error()) {
+		t.Fatalf("HangupCall send-failure error = %v, want it to wrap %v", err, ErrNotConnected)
+	}
+	if cs := cli.getCall("CID"); cs == nil {
+		t.Error("call state was dropped despite the terminate send failing")
+	}
+}
+
+func TestHangupCallEmitsCallMediaStop(t *testing.T) {
+	cli, _, ce := routerTestClient()
+	peer := callStatePeerJID()
+	cli.putCall("CID", &callState{
+		meta:    types.BasicCallMeta{CallID: "CID", From: peer, CallCreator: peer},
+		to:      peer,
+		creator: peer,
+	})
+
+	_ = cli.HangupCall(context.Background(), "CID")
+
+	stops := ce.filter(isCallMediaStop)
+	if len(stops) != 1 {
+		t.Fatalf("CallMediaStop dispatch count = %d, want 1", len(stops))
+	}
+	stop, ok := stops[0].(*events.CallMediaStop)
+	if !ok {
+		t.Fatal("captured event is not *events.CallMediaStop")
+	}
+	if stop.Reason != "hangup" {
+		t.Errorf("Reason = %q, want hangup", stop.Reason)
+	}
+	if stop.CallID != "CID" {
+		t.Errorf("CallID = %q, want CID", stop.CallID)
+	}
+}
+
+func TestHangupCallUnknownCallEmitsNoMediaStop(t *testing.T) {
+	cli, _, ce := routerTestClient()
+	_ = cli.HangupCall(context.Background(), "NOPE")
+	if n := len(ce.filter(isCallMediaStop)); n != 0 {
+		t.Errorf("CallMediaStop dispatch count = %d, want 0 for an unknown call", n)
+	}
+}
+
+func TestSetCallMuteUnknownCallReturnsError(t *testing.T) {
+	cli := &Client{calls: map[string]*callState{}, Log: waLog.Noop}
+	if err := cli.SetCallMute(context.Background(), "NOPE", true); err == nil {
+		t.Fatal("SetCallMute(unknown) = nil error, want error")
+	}
+}
+
+func TestSetCallMuteReachesSend(t *testing.T) {
+	cli := &Client{calls: map[string]*callState{}, Log: waLog.Noop}
+	cli.putCall("CID", &callState{to: callStatePeerJID(), creator: callStateSelfJID()})
+	err := cli.SetCallMute(context.Background(), "CID", true)
+	if err == nil || !strings.Contains(err.Error(), ErrNotConnected.Error()) {
+		t.Fatalf("SetCallMute send error = %v, want it to wrap %v", err, ErrNotConnected)
+	}
+}

--- a/types/call.go
+++ b/types/call.go
@@ -18,6 +18,64 @@ type BasicCallMeta struct {
 }
 
 type CallRemoteMeta struct {
-	RemotePlatform string // The platform of the caller's WhatsApp client
-	RemoteVersion  string // Version of the caller's WhatsApp client
+	RemotePlatform string
+	RemoteVersion  string
+}
+
+// CallDirection identifies which side originated a 1:1 call.
+type CallDirection uint8
+
+const (
+	CallDirectionIncoming CallDirection = iota
+	CallDirectionOutgoing
+)
+
+// CallVideoState is the state value carried by an in-call video stanza. Local and
+// remote video flows are independent: stopping one does not stop the other.
+type CallVideoState int
+
+const (
+	CallVideoStateDisabled         CallVideoState = 0
+	CallVideoStateEnabled          CallVideoState = 1
+	CallVideoStateUpgradeRequest   CallVideoState = 3
+	CallVideoStateUpgradeAccept    CallVideoState = 4
+	CallVideoStateUpgradeReject    CallVideoState = 5
+	CallVideoStateStopped          CallVideoState = 6
+	CallVideoStateUpgradeCancel    CallVideoState = 8
+	CallVideoStateUpgradeRequestV2 CallVideoState = 11
+)
+
+// CallCodec identifies which media codec a 1:1 call negotiated.
+type CallCodec uint8
+
+const (
+	CallCodecMLow CallCodec = iota
+	CallCodecOpus
+)
+
+// String returns a human-readable name for the codec.
+func (c CallCodec) String() string {
+	switch c {
+	case CallCodecMLow:
+		return "mlow"
+	case CallCodecOpus:
+		return "opus"
+	default:
+		return "unknown"
+	}
+}
+
+// RelayEndpoint is the elected media relay for a 1:1 call.
+type RelayEndpoint struct {
+	RelayID     uint32
+	TokenID     uint32
+	AuthTokenID uint32
+	RelayName   string
+	IsFNA       bool
+	IPv4        string
+	Port        uint16
+
+	Key       []byte
+	Token     []byte
+	AuthToken []byte
 }

--- a/types/call_test.go
+++ b/types/call_test.go
@@ -1,0 +1,15 @@
+// Copyright (c) 2021 Tulir Asokan
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package types
+
+import "testing"
+
+func TestCallCodecString(t *testing.T) {
+	if CallCodecMLow.String() != "mlow" || CallCodecOpus.String() != "opus" {
+		t.Fatalf("codec strings wrong: %q %q", CallCodecMLow, CallCodecOpus)
+	}
+}

--- a/types/events/call.go
+++ b/types/events/call.go
@@ -11,15 +11,14 @@ import (
 	"go.mau.fi/whatsmeow/types"
 )
 
-// CallOffer is emitted when the user receives a call on WhatsApp.
 type CallOffer struct {
 	types.BasicCallMeta
 	types.CallRemoteMeta
 
-	Data *waBinary.Node // The call offer data
+	Data  *waBinary.Node
+	Video bool
 }
 
-// CallAccept is emitted when a call is accepted on WhatsApp.
 type CallAccept struct {
 	types.BasicCallMeta
 	types.CallRemoteMeta
@@ -41,37 +40,72 @@ type CallTransport struct {
 	Data *waBinary.Node
 }
 
-// CallOfferNotice is emitted when the user receives a notice of a call on WhatsApp.
-// This seems to be primarily for group calls (whereas CallOffer is for 1:1 calls).
 type CallOfferNotice struct {
 	types.BasicCallMeta
 
-	Media string // "audio" or "video" depending on call type
-	Type  string // "group" when it's a group call
+	Media string
+	Type  string
 
 	Data *waBinary.Node
 }
 
-// CallRelayLatency is emitted slightly after the user receives a call on WhatsApp.
 type CallRelayLatency struct {
 	types.BasicCallMeta
 	Data *waBinary.Node
 }
 
-// CallTerminate is emitted when the other party terminates a call on WhatsApp.
 type CallTerminate struct {
 	types.BasicCallMeta
 	Reason string
 	Data   *waBinary.Node
 }
 
-// CallReject is sent when the other party rejects the call on WhatsApp.
 type CallReject struct {
 	types.BasicCallMeta
 	Data *waBinary.Node
 }
 
-// UnknownCallEvent is emitted when a call element with unknown content is received.
 type UnknownCallEvent struct {
 	Node *waBinary.Node
+}
+
+type CallMediaReady struct {
+	types.BasicCallMeta
+
+	SelfLID types.JID
+	PeerLID types.JID
+
+	CallKey   []byte
+	Relay     types.RelayEndpoint
+	Codec     types.CallCodec
+	Direction types.CallDirection
+	Video     bool
+}
+
+type CallMediaStop struct {
+	types.BasicCallMeta
+
+	Reason string
+}
+
+type CallMute struct {
+	types.BasicCallMeta
+
+	Muted bool
+}
+
+type CallAck struct {
+	types.BasicCallMeta
+
+	Data *waBinary.Node
+}
+
+// CallVideo describes one independent remote video-flow transition.
+type CallVideo struct {
+	types.BasicCallMeta
+
+	State          types.CallVideoState
+	Orientation    int
+	HasOrientation bool
+	Data           *waBinary.Node
 }

--- a/types/events/call.go
+++ b/types/events/call.go
@@ -23,7 +23,8 @@ type CallAccept struct {
 	types.BasicCallMeta
 	types.CallRemoteMeta
 
-	Data *waBinary.Node
+	Data    *waBinary.Node
+	PeerLID types.JID
 }
 
 type CallPreAccept struct {

--- a/video.go
+++ b/video.go
@@ -1,0 +1,84 @@
+// Copyright (c) 2021 Tulir Asokan
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package whatsmeow
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	waBinary "go.mau.fi/whatsmeow/binary"
+	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
+	"go.mau.fi/whatsmeow/voip"
+)
+
+func (cli *Client) sendCallVideoAck(ctx context.Context, node *waBinary.Node) {
+	ack, ok := voip.BuildVideoAck(node)
+	if !ok {
+		cli.Log.Warnf("Failed to build call video acknowledgement")
+		return
+	}
+	if err := cli.sendNode(ctx, ack); err != nil {
+		cli.Log.Warnf("Failed to send call video acknowledgement: %v", err)
+	}
+}
+
+func (cli *Client) onCallVideo(meta types.BasicCallMeta, node *waBinary.Node) {
+	ag := node.AttrGetter()
+	stateValue, err := strconv.Atoi(ag.String("state"))
+	if err != nil {
+		cli.Log.Warnf("Invalid call video state, call_id: %s: %v", meta.CallID, err)
+		return
+	}
+	orientation, orientationErr := strconv.Atoi(ag.String("device_orientation"))
+	hasOrientation := orientationErr == nil
+	state := types.CallVideoState(stateValue)
+
+	if cs := cli.getCall(meta.CallID); cs != nil {
+		cli.callsLock.Lock()
+		switch state {
+		case types.CallVideoStateEnabled:
+			cs.remoteVideo = true
+		case types.CallVideoStateDisabled, types.CallVideoStateStopped:
+			cs.remoteVideo = false
+		}
+		cli.callsLock.Unlock()
+	}
+
+	cli.dispatchEvent(&events.CallVideo{
+		BasicCallMeta:  meta,
+		State:          state,
+		Orientation:    orientation,
+		HasOrientation: hasOrientation,
+		Data:           node,
+	})
+}
+
+// SetCallVideo sends one independent local video-flow transition for callID.
+func (cli *Client) SetCallVideo(ctx context.Context, callID string, state types.CallVideoState, orientation *int) error {
+	if orientation != nil && (*orientation < 0 || *orientation > 3) {
+		return fmt.Errorf("whatsmeow: call video orientation %d is outside 0..3", *orientation)
+	}
+	cs := cli.getCall(callID)
+	if cs == nil {
+		return fmt.Errorf("whatsmeow: unknown call %s", callID)
+	}
+	node := voip.BuildVideoState(callID, cs.to, cs.creator, cli.generateRequestID(), state, orientation)
+	if err := cli.sendNode(ctx, node); err != nil {
+		return fmt.Errorf("whatsmeow: send call video state: %w", err)
+	}
+	cli.callsLock.Lock()
+	switch state {
+	case types.CallVideoStateUpgradeRequest, types.CallVideoStateUpgradeRequestV2, types.CallVideoStateEnabled:
+		cs.localVideo = true
+	case types.CallVideoStateDisabled, types.CallVideoStateStopped, types.CallVideoStateUpgradeCancel:
+		cs.localVideo = false
+	}
+	cli.callsLock.Unlock()
+	return nil
+}

--- a/voip/relay.go
+++ b/voip/relay.go
@@ -1,0 +1,303 @@
+// Copyright (c) 2021 Tulir Asokan
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package voip
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	waBinary "go.mau.fi/whatsmeow/binary"
+	"go.mau.fi/whatsmeow/types"
+)
+
+type voipSettings struct {
+	UseMlowCodecV1 bool
+	FrameMs        int
+	TargetBitrate  int
+}
+
+func parseVoipSettings(content []byte) (*voipSettings, error) {
+	if len(bytes.TrimSpace(content)) == 0 {
+		return &voipSettings{UseMlowCodecV1: true}, nil
+	}
+	var doc struct {
+		Encode struct {
+			UseMlowCodecV1 string `json:"use_mlow_codec_v1"`
+			FrameMs        string `json:"frame_ms"`
+		} `json:"encode"`
+		RC struct {
+			TargetBitrate string `json:"target_bitrate"`
+		} `json:"rc"`
+	}
+	if err := json.Unmarshal(content, &doc); err != nil {
+		return nil, fmt.Errorf("whatsmeow: parse voip_settings: %w", err)
+	}
+	return &voipSettings{
+		UseMlowCodecV1: doc.Encode.UseMlowCodecV1 != "false",
+		FrameMs:        atoiOrZero(doc.Encode.FrameMs),
+		TargetBitrate:  atoiOrZero(doc.RC.TargetBitrate),
+	}, nil
+}
+
+func atoiOrZero(s string) int {
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+func selectCallCodec(vs *voipSettings) types.CallCodec {
+	if vs == nil || vs.UseMlowCodecV1 {
+		return types.CallCodecMLow
+	}
+	return types.CallCodecOpus
+}
+
+type relayAddress struct {
+	ipv4 string
+	port uint16
+}
+
+type relayEndpoint struct {
+	relayID     uint32
+	relayName   string
+	tokenID     uint32
+	authTokenID uint32
+	isFNA       bool
+	addresses   []relayAddress
+}
+
+type relayData struct {
+	relayKeyASCII []byte
+	relayTokens   [][]byte
+	endpoints     []relayEndpoint
+}
+
+func nodeBytes(n *waBinary.Node) []byte {
+	switch c := n.Content.(type) {
+	case []byte:
+		return c
+	case string:
+		return []byte(c)
+	}
+	return nil
+}
+
+func childByTag(n *waBinary.Node, tag string) *waBinary.Node {
+	kids := n.GetChildren()
+	for i := range kids {
+		if kids[i].Tag == tag {
+			return &kids[i]
+		}
+	}
+	return nil
+}
+
+func findRelay(n *waBinary.Node) *waBinary.Node {
+	if n == nil {
+		return nil
+	}
+	if n.Tag == "relay" {
+		return n
+	}
+	kids := n.GetChildren()
+	for i := range kids {
+		if r := findRelay(&kids[i]); r != nil {
+			return r
+		}
+	}
+	return nil
+}
+
+func findChild(n *waBinary.Node, tag string) *waBinary.Node {
+	if n == nil {
+		return nil
+	}
+	if n.Tag == tag {
+		return n
+	}
+	kids := n.GetChildren()
+	for i := range kids {
+		if r := findChild(&kids[i], tag); r != nil {
+			return r
+		}
+	}
+	return nil
+}
+
+func decodeLatency(enc string) uint32 {
+	v, err := strconv.ParseUint(enc, 10, 32)
+	if err != nil || v < 0x0200_0000 {
+		return 0
+	}
+	return uint32(v) - 0x0200_0000
+}
+
+func attrUint(n *waBinary.Node, key string) uint32 {
+	v, _ := strconv.ParseUint(n.AttrGetter().String(key), 10, 32)
+	return uint32(v)
+}
+
+const maxRelayTokens = 64
+
+func parseIndexedTokens(node *waBinary.Node, tag string) [][]byte {
+	var tokens [][]byte
+	kids := node.GetChildren()
+	for i := range kids {
+		c := &kids[i]
+		if c.Tag != tag {
+			continue
+		}
+		b := nodeBytes(c)
+		if b == nil {
+			continue
+		}
+		id := len(tokens)
+		if s := c.AttrGetter().String("id"); s != "" {
+			if n, err := strconv.Atoi(s); err == nil {
+				id = n
+			}
+		}
+		if id < 0 || id >= maxRelayTokens {
+			continue
+		}
+		for len(tokens) <= id {
+			tokens = append(tokens, nil)
+		}
+		tokens[id] = b
+	}
+	return tokens
+}
+
+func parseRelayData(node *waBinary.Node) *relayData {
+	rd := &relayData{}
+	if key := childByTag(node, "key"); key != nil {
+		rd.relayKeyASCII = nodeBytes(key)
+	}
+	rd.relayTokens = parseIndexedTokens(node, "token")
+
+	kids := node.GetChildren()
+	for i := range kids {
+		te2 := &kids[i]
+		if te2.Tag != "te2" {
+			continue
+		}
+		ab := nodeBytes(te2)
+		if len(ab) != 6 {
+			continue
+		}
+		ep := relayEndpoint{
+			relayID:     attrUint(te2, "relay_id"),
+			relayName:   te2.AttrGetter().String("relay_name"),
+			tokenID:     attrUint(te2, "token_id"),
+			authTokenID: attrUint(te2, "auth_token_id"),
+			isFNA:       te2.AttrGetter().String("is_fna") == "1",
+			addresses: []relayAddress{{
+				ipv4: fmt.Sprintf("%d.%d.%d.%d", ab[0], ab[1], ab[2], ab[3]),
+				port: binary.BigEndian.Uint16(ab[4:6]),
+			}},
+		}
+		rd.endpoints = append(rd.endpoints, ep)
+	}
+	return rd
+}
+
+func getMediaRelayEndpoint(rd *relayData, direction types.CallDirection) *relayEndpoint {
+	if direction == types.CallDirectionIncoming {
+		for i := range rd.endpoints {
+			if e := &rd.endpoints[i]; e.isFNA {
+				return e
+			}
+		}
+	}
+	for i := range rd.endpoints {
+		if e := &rd.endpoints[i]; !e.isFNA && e.authTokenID != 0 {
+			return e
+		}
+	}
+	for i := range rd.endpoints {
+		if e := &rd.endpoints[i]; !e.isFNA {
+			return e
+		}
+	}
+	if len(rd.endpoints) > 0 {
+		return &rd.endpoints[0]
+	}
+	return nil
+}
+
+func relayToken(tokens [][]byte, id uint32) []byte {
+	if int(id) >= len(tokens) {
+		return nil
+	}
+	return tokens[id]
+}
+
+func parseElectedRelay(node *waBinary.Node, direction types.CallDirection) *types.RelayEndpoint {
+	relay := findRelay(node)
+	if relay == nil {
+		return nil
+	}
+	rd := parseRelayData(relay)
+	ep := getMediaRelayEndpoint(rd, direction)
+	if ep == nil {
+		return nil
+	}
+	out := &types.RelayEndpoint{
+		RelayID:     ep.relayID,
+		TokenID:     ep.tokenID,
+		AuthTokenID: ep.authTokenID,
+		RelayName:   ep.relayName,
+		IsFNA:       ep.isFNA,
+		Key:         rd.relayKeyASCII,
+		Token:       relayToken(rd.relayTokens, ep.tokenID),
+		AuthToken:   relayToken(rd.relayTokens, ep.authTokenID),
+	}
+	if len(ep.addresses) > 0 {
+		out.IPv4 = ep.addresses[0].ipv4
+		out.Port = ep.addresses[0].port
+	}
+	return out
+}
+
+// NodeBytes returns a node's byte or string content as bytes.
+func NodeBytes(node *waBinary.Node) []byte {
+	return nodeBytes(node)
+}
+
+// FindChild recursively finds the first child with tag.
+func FindChild(node *waBinary.Node, tag string) *waBinary.Node {
+	return findChild(node, tag)
+}
+
+// FindRelay recursively finds a relay node.
+func FindRelay(node *waBinary.Node) *waBinary.Node {
+	return findRelay(node)
+}
+
+// DecodeLatency decodes WhatsApp's relay latency representation.
+func DecodeLatency(encoded string) uint32 {
+	return decodeLatency(encoded)
+}
+
+// ParseCodec selects the advertised audio codec from a voip_settings payload.
+func ParseCodec(content []byte) (types.CallCodec, error) {
+	settings, err := parseVoipSettings(content)
+	if err != nil {
+		return types.CallCodecMLow, err
+	}
+	return selectCallCodec(settings), nil
+}
+
+// ParseRelay resolves the media endpoint appropriate for the call direction.
+func ParseRelay(node *waBinary.Node, direction types.CallDirection) *types.RelayEndpoint {
+	return parseElectedRelay(node, direction)
+}

--- a/voip/relay.go
+++ b/voip/relay.go
@@ -268,6 +268,27 @@ func parseElectedRelay(node *waBinary.Node, direction types.CallDirection) *type
 	return out
 }
 
+func parseRelayPeer(node *waBinary.Node) types.JID {
+	relay := findRelay(node)
+	if relay == nil {
+		return types.EmptyJID
+	}
+	peerPID := relay.AttrGetter().String("peer_pid")
+	if peerPID == "" {
+		return types.EmptyJID
+	}
+	children := relay.GetChildren()
+	for i := range children {
+		participant := &children[i]
+		if participant.Tag == "participant" && participant.AttrGetter().String("pid") == peerPID {
+			if jid := participant.AttrGetter().JID("jid"); !jid.IsEmpty() {
+				return jid
+			}
+		}
+	}
+	return types.EmptyJID
+}
+
 // NodeBytes returns a node's byte or string content as bytes.
 func NodeBytes(node *waBinary.Node) []byte {
 	return nodeBytes(node)
@@ -300,4 +321,9 @@ func ParseCodec(content []byte) (types.CallCodec, error) {
 // ParseRelay resolves the media endpoint appropriate for the call direction.
 func ParseRelay(node *waBinary.Node, direction types.CallDirection) *types.RelayEndpoint {
 	return parseElectedRelay(node, direction)
+}
+
+// ParseRelayPeer resolves the device-qualified media participant selected by peer_pid.
+func ParseRelayPeer(node *waBinary.Node) types.JID {
+	return parseRelayPeer(node)
 }

--- a/voip/relay.go
+++ b/voip/relay.go
@@ -257,9 +257,12 @@ func parseElectedRelay(node *waBinary.Node, direction types.CallDirection) *type
 		AuthTokenID: ep.authTokenID,
 		RelayName:   ep.relayName,
 		IsFNA:       ep.isFNA,
-		Key:         rd.relayKeyASCII,
-		Token:       relayToken(rd.relayTokens, ep.tokenID),
-		AuthToken:   relayToken(rd.relayTokens, ep.authTokenID),
+		// Relay credentials are handed to the external media backend through
+		// CallMediaReady. Keep the public result independent from the incoming
+		// stanza buffers and from the parser's token table.
+		Key:       bytes.Clone(rd.relayKeyASCII),
+		Token:     bytes.Clone(relayToken(rd.relayTokens, ep.tokenID)),
+		AuthToken: bytes.Clone(relayToken(rd.relayTokens, ep.authTokenID)),
 	}
 	if len(ep.addresses) > 0 {
 		out.IPv4 = ep.addresses[0].ipv4

--- a/voip/relay_test.go
+++ b/voip/relay_test.go
@@ -133,6 +133,22 @@ func TestRelayParseElectsEndpoint(t *testing.T) {
 	}
 }
 
+func TestRelayParseResolvesElectedPeerDevice(t *testing.T) {
+	primary := types.NewJID("242653052539031", types.HiddenUserServer)
+	companion := primary
+	companion.Device = 7
+	node := syntheticRelayNode()
+	node.Attrs = waBinary.Attrs{"peer_pid": "2", "self_pid": "1"}
+	node.Content = append(node.GetChildren(),
+		waBinary.Node{Tag: "participant", Attrs: waBinary.Attrs{"pid": "0", "jid": primary}},
+		waBinary.Node{Tag: "participant", Attrs: waBinary.Attrs{"pid": "2", "jid": companion}},
+	)
+
+	if peer := parseRelayPeer(&node); peer != companion {
+		t.Fatalf("parseRelayPeer = %s, want %s", peer, companion)
+	}
+}
+
 func TestRelayParseElectsFNAForIncomingCalls(t *testing.T) {
 	node := syntheticRelayNode()
 	children := node.GetChildren()

--- a/voip/relay_test.go
+++ b/voip/relay_test.go
@@ -1,0 +1,227 @@
+// Copyright (c) 2021 Tulir Asokan
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package voip
+
+import (
+	"bytes"
+	"testing"
+
+	waBinary "go.mau.fi/whatsmeow/binary"
+	"go.mau.fi/whatsmeow/types"
+)
+
+const voipSettingsSample = `{"encode":{"complexity":"5","frame_ms":"60","min_bitrate":"4200","use_mlow_codec_v1":"true"},"rc":{"dtx":"1","target_bitrate":"24000"}}`
+
+func TestVoipSettingsParse(t *testing.T) {
+	vs, err := parseVoipSettings([]byte(voipSettingsSample))
+	if err != nil {
+		t.Fatalf("parseVoipSettings: %v", err)
+	}
+	if !vs.UseMlowCodecV1 {
+		t.Error("UseMlowCodecV1 = false, want true (sample sets it true)")
+	}
+	if vs.FrameMs != 60 {
+		t.Errorf("FrameMs = %d, want 60", vs.FrameMs)
+	}
+	if vs.TargetBitrate != 24000 {
+		t.Errorf("TargetBitrate = %d, want 24000", vs.TargetBitrate)
+	}
+	if got := selectCallCodec(vs); got != types.CallCodecMLow {
+		t.Errorf("selectCallCodec = %v, want mlow", got)
+	}
+}
+
+func TestVoipSettingsOpus(t *testing.T) {
+	vs, err := parseVoipSettings([]byte(`{"encode":{"use_mlow_codec_v1":"false","frame_ms":"60"}}`))
+	if err != nil {
+		t.Fatalf("parseVoipSettings: %v", err)
+	}
+	if vs.UseMlowCodecV1 {
+		t.Error("UseMlowCodecV1 = true, want false")
+	}
+	if got := selectCallCodec(vs); got != types.CallCodecOpus {
+		t.Errorf("selectCallCodec = %v, want opus", got)
+	}
+}
+
+func TestVoipSettingsEmptyDefaultsToMlow(t *testing.T) {
+	vs, err := parseVoipSettings(nil)
+	if err != nil {
+		t.Fatalf("parseVoipSettings: %v", err)
+	}
+	if !vs.UseMlowCodecV1 {
+		t.Error("UseMlowCodecV1 = false, want true (empty blob defaults to mlow)")
+	}
+	if got := selectCallCodec(vs); got != types.CallCodecMLow {
+		t.Errorf("selectCallCodec = %v, want mlow", got)
+	}
+}
+
+func TestVoipSettingsMalformedJSONErrors(t *testing.T) {
+	if _, err := parseVoipSettings([]byte(`{not json`)); err == nil {
+		t.Error("parseVoipSettings(malformed) = nil error, want error")
+	}
+}
+
+func TestVoipSelectCallCodecNilDefaultsToMlow(t *testing.T) {
+	if got := selectCallCodec(nil); got != types.CallCodecMLow {
+		t.Errorf("selectCallCodec(nil) = %v, want mlow", got)
+	}
+}
+
+func syntheticRelayNode() waBinary.Node {
+	return waBinary.Node{
+		Tag: "relay",
+		Content: []waBinary.Node{
+			{Tag: "key", Content: []byte("relay-integrity-key")},
+			{Tag: "token", Attrs: waBinary.Attrs{"id": "0"}, Content: []byte("token-zero")},
+			{Tag: "token", Attrs: waBinary.Attrs{"id": "1"}, Content: []byte("token-one")},
+			{
+				Tag: "te2",
+				Attrs: waBinary.Attrs{
+					"relay_id":      "5",
+					"relay_name":    "gru1c02",
+					"token_id":      "0",
+					"auth_token_id": "1",
+					"is_fna":        "0",
+				},
+				Content: []byte{10, 0, 0, 1, 0x1f, 0x90}, // 10.0.0.1:8080
+			},
+		},
+	}
+}
+
+func TestRelayParseElectsEndpoint(t *testing.T) {
+	node := syntheticRelayNode()
+	ep := parseElectedRelay(&node, types.CallDirectionOutgoing)
+	if ep == nil {
+		t.Fatal("parseElectedRelay = nil, want a resolved endpoint")
+	}
+	if ep.RelayID != 5 {
+		t.Errorf("RelayID = %d, want 5", ep.RelayID)
+	}
+	if ep.RelayName != "gru1c02" {
+		t.Errorf("RelayName = %q, want gru1c02", ep.RelayName)
+	}
+	if ep.TokenID != 0 {
+		t.Errorf("TokenID = %d, want 0", ep.TokenID)
+	}
+	if ep.AuthTokenID != 1 {
+		t.Errorf("AuthTokenID = %d, want 1", ep.AuthTokenID)
+	}
+	if ep.IsFNA {
+		t.Error("IsFNA = true, want false")
+	}
+	if ep.IPv4 != "10.0.0.1" {
+		t.Errorf("IPv4 = %q, want 10.0.0.1", ep.IPv4)
+	}
+	if ep.Port != 8080 {
+		t.Errorf("Port = %d, want 8080", ep.Port)
+	}
+	if !bytes.Equal(ep.Key, []byte("relay-integrity-key")) {
+		t.Errorf("Key = %q, want relay-integrity-key", ep.Key)
+	}
+	if !bytes.Equal(ep.Token, []byte("token-zero")) {
+		t.Errorf("Token = %q, want token-zero", ep.Token)
+	}
+	if !bytes.Equal(ep.AuthToken, []byte("token-one")) {
+		t.Errorf("AuthToken = %q, want token-one", ep.AuthToken)
+	}
+}
+
+func TestRelayParseElectsFNAForIncomingCalls(t *testing.T) {
+	node := syntheticRelayNode()
+	children := node.GetChildren()
+	children = append(children, waBinary.Node{
+		Tag: "te2",
+		Attrs: waBinary.Attrs{
+			"relay_id": "8", "relay_name": "gru1c02-fna", "token_id": "0",
+			"auth_token_id": "0", "is_fna": "1",
+		},
+		Content: []byte{10, 0, 0, 2, 0x1f, 0x91},
+	})
+	node.Content = children
+
+	incoming := parseElectedRelay(&node, types.CallDirectionIncoming)
+	if incoming == nil || !incoming.IsFNA || incoming.RelayID != 8 {
+		t.Fatalf("incoming endpoint = %+v, want FNA relay 8", incoming)
+	}
+	outgoing := parseElectedRelay(&node, types.CallDirectionOutgoing)
+	if outgoing == nil || outgoing.IsFNA || outgoing.RelayID != 5 {
+		t.Fatalf("outgoing endpoint = %+v, want non-FNA relay 5", outgoing)
+	}
+}
+
+func TestRelayParseFindsNestedRelay(t *testing.T) {
+	relay := syntheticRelayNode()
+	offer := waBinary.Node{Tag: "offer", Content: []waBinary.Node{relay}}
+	ep := parseElectedRelay(&offer, types.CallDirectionOutgoing)
+	if ep == nil {
+		t.Fatal("parseElectedRelay = nil, want a resolved endpoint")
+	}
+	if ep.IPv4 != "10.0.0.1" || ep.Port != 8080 {
+		t.Errorf("endpoint = %+v, want 10.0.0.1:8080", ep)
+	}
+}
+
+func TestRelayParseNoRelayReturnsNil(t *testing.T) {
+	node := waBinary.Node{Tag: "offer"}
+	if ep := parseElectedRelay(&node, types.CallDirectionOutgoing); ep != nil {
+		t.Errorf("parseElectedRelay = %+v, want nil", ep)
+	}
+}
+
+func TestRelayParseTokenOutOfBoundsIsNil(t *testing.T) {
+	node := waBinary.Node{
+		Tag: "relay",
+		Content: []waBinary.Node{
+			{Tag: "key", Content: []byte("k")},
+			{
+				Tag: "te2",
+				Attrs: waBinary.Attrs{
+					"relay_id": "1", "token_id": "9", "auth_token_id": "9", "is_fna": "0",
+				},
+				Content: []byte{127, 0, 0, 1, 0x00, 0x50},
+			},
+		},
+	}
+	ep := parseElectedRelay(&node, types.CallDirectionOutgoing)
+	if ep == nil {
+		t.Fatal("parseElectedRelay = nil, want a resolved endpoint")
+	}
+	if ep.Token != nil {
+		t.Errorf("Token = %q, want nil (index 9 never populated)", ep.Token)
+	}
+	if ep.AuthToken != nil {
+		t.Errorf("AuthToken = %q, want nil (index 9 never populated)", ep.AuthToken)
+	}
+}
+
+func TestRelayParseNegativeTokenIDIsIgnored(t *testing.T) {
+	node := waBinary.Node{
+		Tag: "relay",
+		Content: []waBinary.Node{
+			{Tag: "key", Content: []byte("k")},
+			{Tag: "token", Attrs: waBinary.Attrs{"id": "-1"}, Content: []byte("evil")},
+			{Tag: "token", Attrs: waBinary.Attrs{"id": "0"}, Content: []byte("token-zero")},
+			{
+				Tag: "te2",
+				Attrs: waBinary.Attrs{
+					"relay_id": "1", "token_id": "0", "auth_token_id": "0", "is_fna": "0",
+				},
+				Content: []byte{127, 0, 0, 1, 0x00, 0x50},
+			},
+		},
+	}
+	ep := parseElectedRelay(&node, types.CallDirectionOutgoing)
+	if ep == nil {
+		t.Fatal("parseElectedRelay = nil, want a resolved endpoint")
+	}
+	if !bytes.Equal(ep.Token, []byte("token-zero")) {
+		t.Errorf("Token = %q, want token-zero (negative-id token must be dropped, not corrupt index 0)", ep.Token)
+	}
+}

--- a/voip/relay_test.go
+++ b/voip/relay_test.go
@@ -133,6 +133,29 @@ func TestRelayParseElectsEndpoint(t *testing.T) {
 	}
 }
 
+func TestRelayParseCopiesCredentials(t *testing.T) {
+	node := syntheticRelayNode()
+	ep := parseElectedRelay(&node, types.CallDirectionOutgoing)
+	if ep == nil {
+		t.Fatal("parseElectedRelay = nil, want a resolved endpoint")
+	}
+
+	ep.Key[0] = 'X'
+	ep.Token[0] = 'X'
+	ep.AuthToken[0] = 'X'
+
+	children := node.GetChildren()
+	if got := string(children[0].Content.([]byte)); got != "relay-integrity-key" {
+		t.Errorf("relay key source mutated through parsed endpoint: %q", got)
+	}
+	if got := string(children[1].Content.([]byte)); got != "token-zero" {
+		t.Errorf("relay token source mutated through parsed endpoint: %q", got)
+	}
+	if got := string(children[2].Content.([]byte)); got != "token-one" {
+		t.Errorf("relay auth token source mutated through parsed endpoint: %q", got)
+	}
+}
+
 func TestRelayParseResolvesElectedPeerDevice(t *testing.T) {
 	primary := types.NewJID("242653052539031", types.HiddenUserServer)
 	companion := primary

--- a/voip/stanza.go
+++ b/voip/stanza.go
@@ -1,0 +1,322 @@
+// Copyright (c) 2021 Tulir Asokan
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package voip implements WhatsApp call stanza construction and relay parsing.
+package voip
+
+import (
+	"bytes"
+	"strconv"
+
+	waBinary "go.mau.fi/whatsmeow/binary"
+	"go.mau.fi/whatsmeow/types"
+)
+
+var capabilityOffer = []byte{0x01, 0x05, 0xf7, 0x09, 0xe0, 0xbb, 0x13}
+
+var capabilityVideoOffer = []byte{0x01, 0x05, 0xf7, 0x09, 0xe0, 0xfa, 0x13}
+
+var capabilityPreaccept = []byte{0x01, 0x05, 0xf7, 0x09, 0xe0, 0xbb, 0x07}
+
+func encodeLatency(rttMs uint32) string {
+	return strconv.FormatUint(uint64(0x02000000+rttMs), 10)
+}
+
+type offerDeviceKey struct {
+	DeviceJID  types.JID
+	Ciphertext []byte
+	EncType    string
+}
+
+type offerParams struct {
+	CallID         string
+	To             types.JID
+	CallCreator    types.JID
+	DeviceKeys     []offerDeviceKey
+	PrivacyToken   []byte
+	Capability     []byte
+	DeviceIdentity []byte
+	Video          bool
+}
+
+func buildCallOffer(p *offerParams) waBinary.Node {
+	var children []waBinary.Node
+	if p.PrivacyToken != nil {
+		children = append(children, waBinary.Node{Tag: "privacy", Content: p.PrivacyToken})
+	}
+	children = append(children, audioOpus("8000"), audioOpus("16000"))
+	if p.Video {
+		children = append(children, callVideoOfferNode())
+	}
+	children = append(children, waBinary.Node{Tag: "net", Attrs: waBinary.Attrs{"medium": "3"}})
+	capability := p.Capability
+	if p.Video && bytes.Equal(capability, capabilityOffer) {
+		capability = capabilityVideoOffer
+	}
+	if capability != nil {
+		children = append(children, waBinary.Node{Tag: "capability", Attrs: waBinary.Attrs{"ver": "1"}, Content: capability})
+	}
+	if len(p.DeviceKeys) > 1 {
+		tos := make([]waBinary.Node, len(p.DeviceKeys))
+		for i, dk := range p.DeviceKeys {
+			tos[i] = waBinary.Node{Tag: "to", Attrs: waBinary.Attrs{"jid": dk.DeviceJID}, Content: []waBinary.Node{encNode(dk)}}
+		}
+		children = append(children, waBinary.Node{Tag: "destination", Content: tos})
+	} else if len(p.DeviceKeys) == 1 {
+		children = append(children, encNode(p.DeviceKeys[0]))
+	}
+	children = append(children, waBinary.Node{Tag: "encopt", Attrs: waBinary.Attrs{"keygen": "2"}})
+	if p.DeviceIdentity != nil {
+		children = append(children, waBinary.Node{Tag: "device-identity", Content: p.DeviceIdentity})
+	}
+	return callWrap(p.To, nil, offerAction("offer", p.CallID, p.CallCreator, children))
+}
+
+func encNode(dk offerDeviceKey) waBinary.Node {
+	return waBinary.Node{
+		Tag:     "enc",
+		Attrs:   waBinary.Attrs{"v": "2", "type": dk.EncType, "count": "0"},
+		Content: dk.Ciphertext,
+	}
+}
+
+type acceptParams struct {
+	CallID       string
+	To           types.JID
+	CallCreator  types.JID
+	AudioRates   []string
+	RelayTe      []byte
+	Rte          []byte
+	VoipSettings []byte
+	Capability   []byte
+	Metadata     waBinary.Attrs
+	Video        bool
+}
+
+func buildAccept(p *acceptParams) waBinary.Node {
+	children := make([]waBinary.Node, 0, len(p.AudioRates)+5)
+	for _, rate := range p.AudioRates {
+		children = append(children, audioOpus(rate))
+	}
+	if p.Video {
+		children = append(children, callVideoAcceptNode())
+	}
+	if p.RelayTe != nil {
+		children = append(children, waBinary.Node{Tag: "te", Attrs: waBinary.Attrs{"priority": "2"}, Content: p.RelayTe})
+	}
+	children = append(children, waBinary.Node{Tag: "net", Attrs: waBinary.Attrs{"medium": "2"}})
+	children = append(children, waBinary.Node{Tag: "encopt", Attrs: waBinary.Attrs{"keygen": "2"}})
+	if p.Capability != nil {
+		children = append(children, waBinary.Node{Tag: "capability", Attrs: waBinary.Attrs{"ver": "1"}, Content: p.Capability})
+	}
+	if p.Metadata != nil {
+		children = append(children, waBinary.Node{Tag: "metadata", Attrs: p.Metadata})
+	}
+	if p.Rte != nil {
+		children = append(children, waBinary.Node{Tag: "rte", Content: p.Rte})
+	}
+	if p.VoipSettings != nil {
+		children = append(children, waBinary.Node{Tag: "voip_settings", Attrs: waBinary.Attrs{"uncompressed": "1"}, Content: p.VoipSettings})
+	}
+	return callWrap(p.To, nil, offerAction("accept", p.CallID, p.CallCreator, children))
+}
+
+func audioOpus(rate string) waBinary.Node {
+	return waBinary.Node{Tag: "audio", Attrs: waBinary.Attrs{"enc": "opus", "rate": rate}}
+}
+
+func buildPreaccept(callID string, to, callCreator types.JID, wrapperID string, audioRates []string, video bool) waBinary.Node {
+	children := make([]waBinary.Node, 0, len(audioRates)+3)
+	for _, rate := range audioRates {
+		children = append(children, audioOpus(rate))
+	}
+	if video {
+		children = append(children, callVideoPreacceptNode())
+	}
+	children = append(children, waBinary.Node{Tag: "encopt", Attrs: waBinary.Attrs{"keygen": "2"}})
+	capability := capabilityPreaccept
+	if video {
+		capability = capabilityOffer
+	}
+	children = append(children, waBinary.Node{Tag: "capability", Attrs: waBinary.Attrs{"ver": "1"}, Content: capability})
+	return callWrap(to, &wrapperID, offerAction("preaccept", callID, callCreator, children))
+}
+
+func buildEagerPreaccept(callID string, to, callCreator types.JID, requestID string, video bool) waBinary.Node {
+	node := buildPreaccept(callID, to, callCreator, requestID, []string{"16000"}, video)
+	actions := node.GetChildren()
+	children := actions[0].GetChildren()
+	for i := range children {
+		if children[i].Tag == "capability" {
+			children[i].Content = capabilityOffer
+		}
+	}
+	actions[0].Content = children
+	node.Content = actions
+	return node
+}
+
+type transportParams struct {
+	CallID               string
+	To                   types.JID
+	CallCreator          types.JID
+	P2PCandRound         *string
+	TransportMessageType *string
+	RelayTe              []byte
+}
+
+func buildTransport(p *transportParams) waBinary.Node {
+	attrs := waBinary.Attrs{"call-id": p.CallID, "call-creator": p.CallCreator}
+	if p.P2PCandRound != nil {
+		attrs["p2p-cand-round"] = *p.P2PCandRound
+	}
+	if p.TransportMessageType != nil {
+		attrs["transport-message-type"] = *p.TransportMessageType
+	}
+	var children []waBinary.Node
+	if p.RelayTe != nil {
+		children = append(children, waBinary.Node{Tag: "te", Attrs: waBinary.Attrs{"priority": "1"}, Content: p.RelayTe})
+	}
+	netAttrs := waBinary.Attrs{"medium": "2"}
+	if p.TransportMessageType == nil || *p.TransportMessageType != "9" {
+		netAttrs["protocol"] = "0"
+	}
+	children = append(children, waBinary.Node{Tag: "net", Attrs: netAttrs})
+	return callWrap(p.To, nil, waBinary.Node{Tag: "transport", Attrs: attrs, Content: children})
+}
+
+type relayLatencyParams struct {
+	CallID       string
+	To           types.JID
+	CallCreator  types.JID
+	LatencyMs    uint32
+	RelayName    string
+	AddressBytes []byte
+	Devices      []types.JID
+}
+
+func buildRelayLatency(p *relayLatencyParams) waBinary.Node {
+	children := []waBinary.Node{{
+		Tag:     "te",
+		Attrs:   waBinary.Attrs{"latency": encodeLatency(p.LatencyMs), "relay_name": p.RelayName},
+		Content: p.AddressBytes,
+	}}
+	if len(p.Devices) > 0 {
+		children = append(children, destinationTo(p.Devices))
+	}
+	return callWrap(p.To, nil, offerAction("relaylatency", p.CallID, p.CallCreator, children))
+}
+
+func buildHeartbeat(callID string, callCreator types.JID, wrapperID string) waBinary.Node {
+	action := waBinary.Node{Tag: "heartbeat", Attrs: waBinary.Attrs{"call-id": callID, "call-creator": callCreator}}
+	return waBinary.Node{
+		Tag:     "call",
+		Attrs:   waBinary.Attrs{"to": callID + "@call", "id": wrapperID},
+		Content: []waBinary.Node{action},
+	}
+}
+
+type terminateParams struct {
+	CallID        string
+	To            types.JID
+	CallCreator   types.JID
+	Reason        *string
+	TargetDevices []types.JID
+}
+
+func buildTerminate(p *terminateParams) waBinary.Node {
+	attrs := waBinary.Attrs{"call-id": p.CallID, "call-creator": p.CallCreator}
+	if p.Reason != nil {
+		attrs["reason"] = *p.Reason
+	}
+	var content []waBinary.Node
+	if len(p.TargetDevices) > 0 {
+		content = []waBinary.Node{destinationTo(p.TargetDevices)}
+	}
+	return callWrap(p.To, nil, waBinary.Node{Tag: "terminate", Attrs: attrs, Content: content})
+}
+
+func buildMuteV2(callID string, to, callCreator types.JID, muteState string) waBinary.Node {
+	action := waBinary.Node{Tag: "mute_v2", Attrs: waBinary.Attrs{"call-id": callID, "call-creator": callCreator, "mute-state": muteState}}
+	return callWrap(to, nil, action)
+}
+
+func buildReject(callID string, to, callCreator types.JID) waBinary.Node {
+	action := waBinary.Node{Tag: "reject", Attrs: waBinary.Attrs{"call-id": callID, "call-creator": callCreator}}
+	return callWrap(to, nil, action)
+}
+
+func offerAction(tag, callID string, callCreator types.JID, children []waBinary.Node) waBinary.Node {
+	return waBinary.Node{
+		Tag:     tag,
+		Attrs:   waBinary.Attrs{"call-id": callID, "call-creator": callCreator},
+		Content: children,
+	}
+}
+
+func destinationTo(devices []types.JID) waBinary.Node {
+	tos := make([]waBinary.Node, len(devices))
+	for i, jid := range devices {
+		tos[i] = waBinary.Node{Tag: "to", Attrs: waBinary.Attrs{"jid": jid}}
+	}
+	return waBinary.Node{Tag: "destination", Content: tos}
+}
+
+func callWrap(to types.JID, id *string, action waBinary.Node) waBinary.Node {
+	attrs := waBinary.Attrs{"to": to}
+	if id != nil {
+		attrs["id"] = *id
+	}
+	return waBinary.Node{Tag: "call", Attrs: attrs, Content: []waBinary.Node{action}}
+}
+
+// DeviceKey is an encrypted call key addressed to one companion device.
+type DeviceKey = offerDeviceKey
+
+// OfferParams contains the wire fields needed to build a call offer.
+type OfferParams = offerParams
+
+// AcceptParams contains the wire fields needed to build a call accept.
+type AcceptParams = acceptParams
+
+// RelayLatencyParams contains one relay latency response.
+type RelayLatencyParams = relayLatencyParams
+
+// TerminateParams contains the wire fields needed to terminate a call.
+type TerminateParams = terminateParams
+
+// CapabilityOffer is the capability blob used in an audio call offer.
+var CapabilityOffer = capabilityOffer
+
+// BuildOffer builds an outgoing call offer stanza.
+func BuildOffer(p *OfferParams) waBinary.Node {
+	return buildCallOffer(p)
+}
+
+// BuildAccept builds a call acceptance stanza.
+func BuildAccept(p *AcceptParams) waBinary.Node {
+	return buildAccept(p)
+}
+
+// BuildEagerPreaccept builds the immediate preaccept sent for an incoming offer.
+func BuildEagerPreaccept(callID string, to, creator types.JID, requestID string, video bool) waBinary.Node {
+	return buildEagerPreaccept(callID, to, creator, requestID, video)
+}
+
+// BuildRelayLatency builds a relay latency response stanza.
+func BuildRelayLatency(p *RelayLatencyParams) waBinary.Node {
+	return buildRelayLatency(p)
+}
+
+// BuildTerminate builds a call termination stanza.
+func BuildTerminate(p *TerminateParams) waBinary.Node {
+	return buildTerminate(p)
+}
+
+// BuildMute builds a local mute state stanza.
+func BuildMute(callID string, to, creator types.JID, state string) waBinary.Node {
+	return buildMuteV2(callID, to, creator, state)
+}

--- a/voip/stanza_test.go
+++ b/voip/stanza_test.go
@@ -1,0 +1,267 @@
+// Copyright (c) 2021 Tulir Asokan
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package voip
+
+import (
+	"bytes"
+	"testing"
+
+	waBinary "go.mau.fi/whatsmeow/binary"
+	"go.mau.fi/whatsmeow/types"
+)
+
+func stanzaPeerJID() types.JID {
+	return types.JID{User: "214482127208608", Server: types.HiddenUserServer}
+}
+
+func stanzaCreatorJID() types.JID {
+	return types.JID{User: "243426515787784", Server: types.HiddenUserServer, Device: 19}
+}
+
+func stanzaContentNodes(t *testing.T, n waBinary.Node) []waBinary.Node {
+	t.Helper()
+	nodes, ok := n.Content.([]waBinary.Node)
+	if !ok {
+		t.Fatalf("node %q content is not []Node: %T", n.Tag, n.Content)
+	}
+	return nodes
+}
+
+func stanzaChildTags(t *testing.T, call waBinary.Node) []string {
+	t.Helper()
+	action := stanzaContentNodes(t, call)[0]
+	var tags []string
+	for _, c := range stanzaContentNodes(t, action) {
+		tags = append(tags, c.Tag)
+	}
+	return tags
+}
+
+func stanzaGetChild(t *testing.T, n waBinary.Node, tag string) (waBinary.Node, bool) {
+	t.Helper()
+	for _, c := range stanzaContentNodes(t, n) {
+		if c.Tag == tag {
+			return c, true
+		}
+	}
+	return waBinary.Node{}, false
+}
+
+func stanzaAttrString(n waBinary.Node, key string) (string, bool) {
+	v, ok := n.Attrs[key].(string)
+	return v, ok
+}
+
+func stanzaEqTags(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestOfferChildOrderIsLoadBearing(t *testing.T) {
+	peer, creator := stanzaPeerJID(), stanzaCreatorJID()
+	dk := offerDeviceKey{DeviceJID: peer, Ciphertext: []byte{1, 2, 3}, EncType: "pkmsg"}
+	call := buildCallOffer(&offerParams{
+		CallID: "CID", To: peer, CallCreator: creator,
+		DeviceKeys:   []offerDeviceKey{dk},
+		PrivacyToken: []byte{0xaa, 0xbb}, Capability: capabilityOffer, DeviceIdentity: []byte{0xcc},
+	})
+	want := []string{"privacy", "audio", "audio", "net", "capability", "enc", "encopt", "device-identity"}
+	if got := stanzaChildTags(t, call); !stanzaEqTags(got, want) {
+		t.Errorf("child tags = %v, want %v", got, want)
+	}
+	if call.Tag != "call" {
+		t.Errorf("outer tag = %q, want call", call.Tag)
+	}
+	offer := stanzaContentNodes(t, call)[0]
+	if offer.Tag != "offer" {
+		t.Errorf("action tag = %q, want offer", offer.Tag)
+	}
+	if id, _ := stanzaAttrString(offer, "call-id"); id != "CID" {
+		t.Errorf("call-id = %q, want CID", id)
+	}
+}
+
+func TestOfferMultiDeviceUsesDestination(t *testing.T) {
+	peer, creator := stanzaPeerJID(), stanzaCreatorJID()
+	keys := []offerDeviceKey{
+		{DeviceJID: peer, Ciphertext: []byte{1}, EncType: "pkmsg"},
+		{DeviceJID: creator, Ciphertext: []byte{2}, EncType: "msg"},
+	}
+	call := buildCallOffer(&offerParams{CallID: "CID", To: peer, CallCreator: creator, DeviceKeys: keys})
+	tags := stanzaChildTags(t, call)
+	hasDest, hasEnc := false, false
+	for _, tg := range tags {
+		if tg == "destination" {
+			hasDest = true
+		}
+		if tg == "enc" {
+			hasEnc = true
+		}
+	}
+	if !hasDest || hasEnc {
+		t.Errorf("tags = %v, want destination present and enc absent", tags)
+	}
+}
+
+func TestAcceptAndPreacceptShape(t *testing.T) {
+	peer, creator := stanzaPeerJID(), stanzaCreatorJID()
+	accept := buildAccept(&acceptParams{
+		CallID: "CID", To: peer, CallCreator: creator,
+		AudioRates: []string{"16000"}, RelayTe: make([]byte, 6), Capability: capabilityOffer,
+	})
+	if got := stanzaChildTags(t, accept); !stanzaEqTags(got, []string{"audio", "te", "net", "encopt", "capability"}) {
+		t.Errorf("accept tags = %v", got)
+	}
+	pre := buildPreaccept("CID", peer, creator, "abcd1234", []string{"8000", "16000"}, false)
+	if got := stanzaChildTags(t, pre); !stanzaEqTags(got, []string{"audio", "audio", "encopt", "capability"}) {
+		t.Errorf("preaccept tags = %v", got)
+	}
+	if id, _ := stanzaAttrString(pre, "id"); id != "abcd1234" {
+		t.Errorf("preaccept id = %q, want abcd1234", id)
+	}
+}
+
+func TestTransportNetProtocolRule(t *testing.T) {
+	peer, creator := stanzaPeerJID(), stanzaCreatorJID()
+	round, t1type := "1", "1"
+	t1 := buildTransport(&transportParams{
+		CallID: "CID", To: peer, CallCreator: creator,
+		P2PCandRound: &round, TransportMessageType: &t1type, RelayTe: make([]byte, 6),
+	})
+	action := stanzaContentNodes(t, t1)[0]
+	if mt, _ := stanzaAttrString(action, "transport-message-type"); mt != "1" {
+		t.Errorf("transport-message-type = %q, want 1", mt)
+	}
+	net1, ok := stanzaGetChild(t, action, "net")
+	if !ok {
+		t.Fatal("net child missing")
+	}
+	if proto, _ := stanzaAttrString(net1, "protocol"); proto != "0" {
+		t.Errorf("net protocol = %q, want 0", proto)
+	}
+
+	t9type := "9"
+	t9 := buildTransport(&transportParams{CallID: "CID", To: peer, CallCreator: creator, TransportMessageType: &t9type})
+	net9, _ := stanzaGetChild(t, stanzaContentNodes(t, t9)[0], "net")
+	if _, has := net9.Attrs["protocol"]; has {
+		t.Error("type 9 net must not carry a protocol attr")
+	}
+}
+
+func TestRelayLatencyEncodingAndHeartbeat(t *testing.T) {
+	if got := encodeLatency(45); got != "33554477" {
+		t.Errorf("encodeLatency(45) = %q, want 33554477", got)
+	}
+	peer, creator := stanzaPeerJID(), stanzaCreatorJID()
+	rl := buildRelayLatency(&relayLatencyParams{
+		CallID: "CID", To: peer, CallCreator: creator,
+		LatencyMs: 45, RelayName: "gru1c02", AddressBytes: []byte{1, 2, 3, 4, 5, 6}, Devices: []types.JID{peer},
+	})
+	action := stanzaContentNodes(t, rl)[0]
+	te, ok := stanzaGetChild(t, action, "te")
+	if !ok {
+		t.Fatal("te child missing")
+	}
+	if lat, _ := stanzaAttrString(te, "latency"); lat != "33554477" {
+		t.Errorf("te latency = %q", lat)
+	}
+	if rn, _ := stanzaAttrString(te, "relay_name"); rn != "gru1c02" {
+		t.Errorf("te relay_name = %q", rn)
+	}
+	if _, ok := stanzaGetChild(t, action, "destination"); !ok {
+		t.Error("destination missing")
+	}
+
+	hb := buildHeartbeat("CALLID", creator, "DEADBEEF")
+	if to, _ := stanzaAttrString(hb, "to"); to != "CALLID@call" {
+		t.Errorf("heartbeat to = %q, want CALLID@call", to)
+	}
+	if id, _ := stanzaAttrString(hb, "id"); id != "DEADBEEF" {
+		t.Errorf("heartbeat id = %q, want DEADBEEF", id)
+	}
+}
+
+func TestTerminateWithTargets(t *testing.T) {
+	peer, creator := stanzaPeerJID(), stanzaCreatorJID()
+	reason := "accepted_elsewhere"
+	term := buildTerminate(&terminateParams{
+		CallID: "CID", To: peer, CallCreator: creator, Reason: &reason, TargetDevices: []types.JID{peer},
+	})
+	action := stanzaContentNodes(t, term)[0]
+	if r, _ := stanzaAttrString(action, "reason"); r != "accepted_elsewhere" {
+		t.Errorf("reason = %q", r)
+	}
+	if _, ok := stanzaGetChild(t, action, "destination"); !ok {
+		t.Error("destination missing")
+	}
+}
+
+func TestBuildEagerPreacceptCarriesCapabilityOffer(t *testing.T) {
+	peer, creator := stanzaPeerJID(), stanzaCreatorJID()
+	pre := buildEagerPreaccept("CID", peer, creator, "requestid1", false)
+
+	if pre.Tag != "call" {
+		t.Errorf("outer tag = %q, want call", pre.Tag)
+	}
+	if to, _ := pre.Attrs["to"].(types.JID); to != peer {
+		t.Errorf("to = %v, want %v", to, peer)
+	}
+	if id, _ := stanzaAttrString(pre, "id"); id != "requestid1" {
+		t.Errorf("id = %q, want requestid1", id)
+	}
+
+	action := stanzaContentNodes(t, pre)[0]
+	if action.Tag != "preaccept" {
+		t.Fatalf("action tag = %q, want preaccept", action.Tag)
+	}
+	if cid, _ := stanzaAttrString(action, "call-id"); cid != "CID" {
+		t.Errorf("call-id = %q, want CID", cid)
+	}
+	if got := stanzaChildTags(t, pre); !stanzaEqTags(got, []string{"audio", "encopt", "capability"}) {
+		t.Errorf("preaccept tags = %v, want [audio encopt capability]", got)
+	}
+
+	cap, ok := stanzaGetChild(t, action, "capability")
+	if !ok {
+		t.Fatal("capability child missing")
+	}
+	got, ok := cap.Content.([]byte)
+	if !ok {
+		t.Fatalf("capability content is not []byte: %T", cap.Content)
+	}
+	if !bytes.Equal(got, capabilityOffer) {
+		t.Errorf("capability content = %x, want capabilityOffer %x (not capabilityPreaccept %x)", got, capabilityOffer, capabilityPreaccept)
+	}
+}
+
+func TestRejectAndMuteV2(t *testing.T) {
+	peer, creator := stanzaPeerJID(), stanzaCreatorJID()
+	rej := buildReject("CID", peer, creator)
+	action := stanzaContentNodes(t, rej)[0]
+	if action.Tag != "reject" {
+		t.Errorf("action tag = %q, want reject", action.Tag)
+	}
+	if id, _ := stanzaAttrString(action, "call-id"); id != "CID" {
+		t.Errorf("call-id = %q, want CID", id)
+	}
+
+	mute := buildMuteV2("CID", peer, creator, "1")
+	maction := stanzaContentNodes(t, mute)[0]
+	if maction.Tag != "mute_v2" {
+		t.Errorf("action tag = %q, want mute_v2", maction.Tag)
+	}
+	if ms, _ := stanzaAttrString(maction, "mute-state"); ms != "1" {
+		t.Errorf("mute-state = %q, want 1", ms)
+	}
+}

--- a/voip/video.go
+++ b/voip/video.go
@@ -1,0 +1,110 @@
+// Copyright (c) 2021 Tulir Asokan
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package voip
+
+import (
+	"strconv"
+
+	waBinary "go.mau.fi/whatsmeow/binary"
+	"go.mau.fi/whatsmeow/types"
+)
+
+const (
+	videoDecH264  = "H264"
+	videoDecReply = "H264,AV1"
+)
+
+func buildCallVideoState(callID string, to, creator types.JID, wrapperID string, state types.CallVideoState, orientation *int) waBinary.Node {
+	attrs := waBinary.Attrs{
+		"call-id":      callID,
+		"call-creator": creator,
+		"state":        strconv.Itoa(int(state)),
+	}
+	switch state {
+	case types.CallVideoStateUpgradeRequestV2:
+		attrs["dec"] = videoDecH264
+		attrs["voip_settings"] = "video"
+	case types.CallVideoStateUpgradeAccept:
+		attrs["dec"] = videoDecReply
+	}
+	if orientation != nil {
+		attrs["device_orientation"] = strconv.Itoa(*orientation)
+	}
+	return waBinary.Node{
+		Tag:   "call",
+		Attrs: waBinary.Attrs{"to": to, "id": wrapperID},
+		Content: []waBinary.Node{{
+			Tag:   "video",
+			Attrs: attrs,
+		}},
+	}
+}
+
+func buildCallVideoAck(original *waBinary.Node) (waBinary.Node, bool) {
+	if original == nil {
+		return waBinary.Node{}, false
+	}
+	ag := original.AttrGetter()
+	id := ag.String("id")
+	from := ag.JID("from")
+	if id == "" || from.IsEmpty() {
+		return waBinary.Node{}, false
+	}
+	attrs := waBinary.Attrs{"class": "call", "id": id, "to": from, "type": "video"}
+	if participant := ag.JID("participant"); !participant.IsEmpty() && participant != from {
+		attrs["participant"] = participant
+	}
+	if recipient := ag.JID("recipient"); !recipient.IsEmpty() {
+		attrs["recipient"] = recipient
+	}
+	return waBinary.Node{Tag: "ack", Attrs: attrs}, true
+}
+
+func callVideoOfferNode() waBinary.Node {
+	return waBinary.Node{Tag: "video", Attrs: waBinary.Attrs{
+		"enc":                "h.264",
+		"dec":                videoDecH264,
+		"screen_width":       "1920",
+		"screen_height":      "1080",
+		"device_orientation": "0",
+	}}
+}
+
+func callVideoAcceptNode() waBinary.Node {
+	return waBinary.Node{Tag: "video", Attrs: waBinary.Attrs{
+		"dec":                videoDecH264,
+		"device_orientation": "0",
+	}}
+}
+
+func callVideoPreacceptNode() waBinary.Node {
+	return waBinary.Node{Tag: "video", Attrs: waBinary.Attrs{
+		"dec":                videoDecH264,
+		"device_orientation": "0",
+		"screen_width":       "0",
+		"screen_height":      "0",
+	}}
+}
+
+func callOfferHasVideo(offer *waBinary.Node) bool {
+	return childByTag(offer, "video") != nil
+}
+
+// BuildVideoState builds one independent local video-flow transition.
+func BuildVideoState(callID string, to, creator types.JID, wrapperID string, state types.CallVideoState, orientation *int) waBinary.Node {
+	return buildCallVideoState(callID, to, creator, wrapperID, state, orientation)
+}
+
+// BuildVideoAck builds the typed acknowledgement required by a video stanza.
+func BuildVideoAck(original *waBinary.Node) (waBinary.Node, bool) {
+	return buildCallVideoAck(original)
+}
+
+// OfferHasVideo reports whether a call offer contains a video capability.
+func OfferHasVideo(offer *waBinary.Node) bool {
+	return callOfferHasVideo(offer)
+}

--- a/voip/video_test.go
+++ b/voip/video_test.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2021 Tulir Asokan
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package voip
+
+import (
+	"testing"
+
+	waBinary "go.mau.fi/whatsmeow/binary"
+	"go.mau.fi/whatsmeow/types"
+)
+
+func TestCallVideoOfferShape(t *testing.T) {
+	peer, creator := stanzaPeerJID(), stanzaCreatorJID()
+	call := buildCallOffer(&offerParams{
+		CallID: "CID", To: peer, CallCreator: creator, Video: true,
+		Capability: capabilityOffer,
+		DeviceKeys: []offerDeviceKey{{DeviceJID: peer, Ciphertext: []byte{1}, EncType: "msg"}},
+	})
+	want := []string{"audio", "audio", "video", "net", "capability", "enc", "encopt"}
+	if got := stanzaChildTags(t, call); !stanzaEqTags(got, want) {
+		t.Fatalf("video offer tags = %v, want %v", got, want)
+	}
+	offer := stanzaContentNodes(t, call)[0]
+	video, ok := stanzaGetChild(t, offer, "video")
+	if !ok {
+		t.Fatal("video offer is missing video child")
+	}
+	if video.AttrGetter().String("enc") != "h.264" || video.AttrGetter().String("dec") != "H264" {
+		t.Fatalf("video offer codecs = %v", video.Attrs)
+	}
+	capability, _ := stanzaGetChild(t, offer, "capability")
+	if got := capability.Content.([]byte); string(got) != string(capabilityVideoOffer) {
+		t.Fatalf("video capability = %x, want %x", got, capabilityVideoOffer)
+	}
+}
+
+func TestCallVideoAcceptAndPreacceptShapes(t *testing.T) {
+	peer, creator := stanzaPeerJID(), stanzaCreatorJID()
+	accept := buildAccept(&acceptParams{CallID: "CID", To: peer, CallCreator: creator, AudioRates: []string{"16000"}, Video: true})
+	if got, want := stanzaChildTags(t, accept), []string{"audio", "video", "net", "encopt"}; !stanzaEqTags(got, want) {
+		t.Fatalf("video accept tags = %v, want %v", got, want)
+	}
+	preaccept := buildEagerPreaccept("CID", peer, creator, "wrapper", true)
+	if got, want := stanzaChildTags(t, preaccept), []string{"audio", "video", "encopt", "capability"}; !stanzaEqTags(got, want) {
+		t.Fatalf("video preaccept tags = %v, want %v", got, want)
+	}
+}
+
+func TestCallVideoTransitionShapes(t *testing.T) {
+	peer, creator := stanzaPeerJID(), stanzaCreatorJID()
+	orientation := 3
+	request := buildCallVideoState("CID", peer, creator, "request", types.CallVideoStateUpgradeRequestV2, &orientation)
+	video := stanzaContentNodes(t, request)[0]
+	if got := video.AttrGetter().String("state"); got != "11" {
+		t.Fatalf("request state = %q, want 11", got)
+	}
+	if got := video.AttrGetter().String("dec"); got != "H264" {
+		t.Fatalf("request dec = %q, want H264", got)
+	}
+	if got := video.AttrGetter().String("voip_settings"); got != "video" {
+		t.Fatalf("request voip_settings = %q, want video", got)
+	}
+	if got := video.AttrGetter().String("device_orientation"); got != "3" {
+		t.Fatalf("request orientation = %q, want 3", got)
+	}
+
+	accept := buildCallVideoState("CID", peer, creator, "accept", types.CallVideoStateUpgradeAccept, nil)
+	video = stanzaContentNodes(t, accept)[0]
+	if got := video.AttrGetter().String("dec"); got != "H264,AV1" {
+		t.Fatalf("accept dec = %q, want H264,AV1", got)
+	}
+}
+
+func TestCallVideoAckPreservesRouting(t *testing.T) {
+	from := types.JID{User: "123", Server: types.HiddenUserServer, Device: 7}
+	recipient := types.JID{User: "456", Server: types.HiddenUserServer}
+	original := waBinary.Node{Tag: "call", Attrs: waBinary.Attrs{
+		"id": "wrapper", "from": from, "participant": from, "recipient": recipient,
+	}}
+	ack, ok := buildCallVideoAck(&original)
+	if !ok {
+		t.Fatal("buildCallVideoAck rejected routable stanza")
+	}
+	if ack.AttrGetter().String("type") != "video" || ack.AttrGetter().JID("to") != from {
+		t.Fatalf("video ack attrs = %v", ack.Attrs)
+	}
+	if ack.AttrGetter().JID("recipient") != recipient {
+		t.Fatalf("video ack recipient = %s, want %s", ack.AttrGetter().JID("recipient"), recipient)
+	}
+}


### PR DESCRIPTION
## Summary

This is a focused 1:1 slice of the work in #1201, intended to make review and downstream integration easier before group-call features are considered.

It includes:

- first-class 1:1 offer, accept, reject, hangup, and mute signaling;
- call-key encryption/decryption and relay election;
- typed `CallMediaReady` / `CallMediaStop` events for an external RTP/SRTP media backend;
- propagation of the relay-selected peer device;
- defensive copies of relay credentials before they cross the media-handoff API boundary.

The media transport itself remains intentionally out of scope: RTP/SRTP, codec implementation, packetization, and audio I/O belong to the external media backend.

## Why

The full #1201 branch currently includes substantial group-call, video, call-link, and rekeying work. This focused branch lets maintainers review and merge the 1:1 control-plane contract independently, while preserving #1201 as the broader reference.

## Validation

- `go test ./...`
- `go vet ./...`
- `go test -race .`
- `git diff --check`
- `notifications-service` tests with this branch injected through a local `replace` directive

Related to #1201.