### PR TITLE
fix: handle PairPhone passkey handoff notifications

### DIFF
--- a/pair-code.go
+++ b/pair-code.go
@@ -166,7 +166,11 @@ func (cli *Client) handleCodePairNotification(ctx context.Context, parentNode *w
 	if string(linkCodePairingRef) != linkCache.pairingRef {
 		return fmt.Errorf("pairing ref mismatch in code pair notification")
 	}
-	wrappedPrimaryEphemeralPub, ok := node.GetChildByTag("link_code_pairing_wrapped_primary_ephemeral_pub").Content.([]byte)
+	wrappedPrimaryEphemeralPubNode, ok := node.GetOptionalChildByTag("link_code_pairing_wrapped_primary_ephemeral_pub")
+	if !ok {
+		return nil
+	}
+	wrappedPrimaryEphemeralPub, ok := wrappedPrimaryEphemeralPubNode.Content.([]byte)
 	if !ok {
 		return &ElementMissingError{
 			Tag: "link_code_pairing_wrapped_primary_ephemeral_pub",

--- a/pair-code_test.go
+++ b/pair-code_test.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 Tulir Asokan
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package whatsmeow
+
+import (
+	"context"
+	"testing"
+
+	waBinary "go.mau.fi/whatsmeow/binary"
+)
+
+func TestHandleCodePairNotificationPasskeyHandoff(t *testing.T) {
+	cli := &Client{}
+	cli.phoneLinkingCache.Store(&phoneLinkingCache{pairingRef: "pairing-ref"})
+	node := &waBinary.Node{Content: []waBinary.Node{{
+		Tag: "link_code_companion_reg",
+		Content: []waBinary.Node{{
+			Tag:     "link_code_pairing_ref",
+			Content: []byte("pairing-ref"),
+		}},
+	}}}
+
+	err := cli.handleCodePairNotification(context.Background(), node)
+	if err != nil {
+		t.Fatalf("expected passkey handoff precursor to be accepted, got %v", err)
+	}
+}
+
+func TestHandleCodePairNotificationMissingWrappedPrimaryKeyValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		cachedRef   string
+		notifiedRef string
+		wantError   string
+	}{
+		{
+			name:        "no pending pairing",
+			notifiedRef: "pairing-ref",
+			wantError:   "received code pair notification without a pending pairing",
+		},
+		{
+			name:        "pairing ref mismatch",
+			cachedRef:   "pairing-ref",
+			notifiedRef: "different-ref",
+			wantError:   "pairing ref mismatch in code pair notification",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cli := &Client{}
+			if test.cachedRef != "" {
+				cli.phoneLinkingCache.Store(&phoneLinkingCache{pairingRef: test.cachedRef})
+			}
+			node := &waBinary.Node{Content: []waBinary.Node{{
+				Tag: "link_code_companion_reg",
+				Content: []waBinary.Node{{
+					Tag:     "link_code_pairing_ref",
+					Content: []byte(test.notifiedRef),
+				}},
+			}}}
+
+			err := cli.handleCodePairNotification(context.Background(), node)
+			if err == nil || err.Error() != test.wantError {
+				t.Fatalf("expected error %q, got %v", test.wantError, err)
+			}
+		})
+	}
+}
+
+func TestHandleCodePairNotificationRejectsShortWrappedPrimaryKey(t *testing.T) {
+	cli := &Client{}
+	cli.phoneLinkingCache.Store(&phoneLinkingCache{pairingRef: "pairing-ref"})
+	node := &waBinary.Node{Content: []waBinary.Node{{
+		Tag: "link_code_companion_reg",
+		Content: []waBinary.Node{
+			{
+				Tag:     "link_code_pairing_ref",
+				Content: []byte("pairing-ref"),
+			},
+			{
+				Tag:     "link_code_pairing_wrapped_primary_ephemeral_pub",
+				Content: make([]byte, 79),
+			},
+		},
+	}}}
+
+	err := cli.handleCodePairNotification(context.Background(), node)
+	if err == nil || err.Error() != "unexpected length of link_code_pairing_wrapped_primary_ephemeral_pub: 79" {
+		t.Fatalf("expected wrapped primary key length error, got %v", err)
+	}
+}


### PR DESCRIPTION
Update `handleCodePairNotification` in `pair-code.go` to distinguish a notification for the active pairing reference that lacks the legacy wrapped-primary key from a complete legacy code-pair challenge. Treat the matched-reference, missing-key form as a passkey handoff precursor: do not attempt the legacy key-bundle response, and leave the connection ready for the existing passkey notification handler to emit `PairPasskeyRequest`. Continue rejecting notifications with no pending phone pairing or a mismatched reference, and preserve all length, identity-key, and cryptographic validation when the wrapped-primary key is present.

`Client.PairPhone` can receive a `link_code_companion_reg` notification after the phone accepts the code and performs passkey or biometric verification, but that notification may omit `link_code_pairing_wrapped_primary_ephemeral_pub`. The current `handleCodePairNotification` path assumes every matching registration notification is the legacy code-pair cryptographic challenge and logs an element-missing failure. The separate `passkey_prologue_request` route already exists, so this premature failure should not prevent or obscure the handoff into the passkey flow. The reported case is intermittent and most visible for an account's first successful companion-device pairing.

A notification for the pending pairing reference without `link_code_pairing_wrapped_primary_ephemeral_pub` is accepted as a handoff precursor and does not attempt the legacy `companion_finish` path.
A missing-key notification with no pending phone pairing still returns the existing pending-pairing error.
A missing-key notification whose pairing reference differs from the cached reference still returns the pairing-reference mismatch error rather than being mistaken for a handoff.
A legacy notification that includes a wrapped-primary key shorter than 80 bytes still returns the existing length error, proving the handoff handling does not weaken malformed-challenge validation.

### Checklist

* [ ] I have read and followed the contributing guidelines at <https://docs.mau.fi/bridges/general/contributing.html>

Fixes #1233
