### PR TITLE
send: emit the <biz> node for InteractiveMessage so native-flow buttons render

### DIFF
--- a/send.go
+++ b/send.go
@@ -1005,6 +1005,10 @@ func getButtonTypeFromMessage(msg *waE2E.Message) string {
 		return "list_response"
 	case msg.InteractiveResponseMessage != nil:
 		return "interactive_response"
+	case msg.InteractiveMessage != nil:
+		// Native-flow (InteractiveMessage) buttons need a <biz> node too, or the
+		// server accepts the message but no client renders it (silent non-delivery).
+		return "interactive"
 	default:
 		return ""
 	}
@@ -1025,6 +1029,10 @@ func getButtonAttributes(msg *waE2E.Message) waBinary.Attrs {
 			"v":    "2",
 			"type": strings.ToLower(waE2E.ListMessage_ListType_name[int32(msg.ListMessage.GetListType())]),
 		}
+	case msg.InteractiveMessage != nil:
+		// "native_flow"/"1" are the fixed values the server expects for the
+		// <interactive> child of <biz>; there is no per-message variant to derive.
+		return waBinary.Attrs{"type": "native_flow", "v": "1"}
 	default:
 		return waBinary.Attrs{}
 	}
@@ -1148,16 +1156,76 @@ func (cli *Client) getMessageContent(
 		content = append(content, *extraParams.additionalNodes...)
 	}
 
-	if buttonType := getButtonTypeFromMessage(message); buttonType != "" {
-		content = append(content, waBinary.Node{
-			Tag: "biz",
-			Content: []waBinary.Node{{
-				Tag:   buttonType,
-				Attrs: getButtonAttributes(message),
-			}},
-		})
+	if bizNode := getBizNode(message); bizNode != nil {
+		content = append(content, *bizNode)
 	}
 	return content
+}
+
+// getBizNode builds the <biz> node that accompanies button/interactive
+// messages. Native-flow (InteractiveMessage) buttons need the full shape
+// observed from official clients — a bare <interactive> child is silently
+// accepted by the server but not delivered to any client. Every other
+// button type keeps the original bare <biz><TYPE .../></biz> shape.
+func getBizNode(msg *waE2E.Message) *waBinary.Node {
+	buttonType := getButtonTypeFromMessage(msg)
+	if buttonType == "" {
+		return nil
+	}
+	if interactiveMsg := unwrapInteractiveMessage(msg); interactiveMsg != nil {
+		decisionID := hex.EncodeToString(random.Bytes(20))
+		return &waBinary.Node{
+			Tag: "biz",
+			Attrs: waBinary.Attrs{
+				"actual_actors":   "2",
+				"host_storage":    "2",
+				"privacy_mode_ts": strconv.FormatInt(time.Now().Unix(), 10),
+			},
+			Content: []waBinary.Node{
+				{
+					Tag:   "interactive",
+					Attrs: getButtonAttributes(msg),
+					Content: []waBinary.Node{{
+						Tag:   "native_flow",
+						Attrs: waBinary.Attrs{"v": "9", "name": "mixed"},
+					}},
+				},
+				{
+					Tag:   "quality_control",
+					Attrs: waBinary.Attrs{"decision_id": decisionID, "source_type": "third_party"},
+					Content: []waBinary.Node{{
+						Tag:   "decision_source",
+						Attrs: waBinary.Attrs{"value": "df"},
+					}},
+				},
+			},
+		}
+	}
+	return &waBinary.Node{
+		Tag: "biz",
+		Content: []waBinary.Node{{
+			Tag:   buttonType,
+			Attrs: getButtonAttributes(msg),
+		}},
+	}
+}
+
+// unwrapInteractiveMessage returns the InteractiveMessage carried by msg,
+// looking through the same view-once/ephemeral wrappers as
+// getButtonTypeFromMessage, or nil if msg does not carry one.
+func unwrapInteractiveMessage(msg *waE2E.Message) *waE2E.InteractiveMessage {
+	switch {
+	case msg.ViewOnceMessage != nil:
+		return unwrapInteractiveMessage(msg.ViewOnceMessage.Message)
+	case msg.ViewOnceMessageV2 != nil:
+		return unwrapInteractiveMessage(msg.ViewOnceMessageV2.Message)
+	case msg.EphemeralMessage != nil:
+		return unwrapInteractiveMessage(msg.EphemeralMessage.Message)
+	case msg.InteractiveMessage != nil:
+		return msg.InteractiveMessage
+	default:
+		return nil
+	}
 }
 
 func (cli *Client) prepareMessageNode(


### PR DESCRIPTION
`getButtonTypeFromMessage` has cases for `ButtonsMessage`, `ListMessage` and `InteractiveResponseMessage`, but not for `InteractiveMessage`. `prepareMessageNode` gates the entire `<biz>` node on that function returning a non-empty string, so a native-flow interactive message currently goes out with no `<biz>` node at all. The server accepts the stanza and no client renders the buttons, so the send reports success and delivers nothing visible.

I hit this trying to send quick-reply buttons from a linked-device session, and wanted to write down what actually happens on the wire since the failure is silent.

Measured, sending to a real device and reading the acks:

| what goes out | what comes back |
|---|---|
| no `<biz>` node (current behaviour) | accepted, nothing renders |
| `<biz><buttons/></biz>` (legacy `ButtonsMessage`) | `<ack error="405">` |
| `<biz><interactive type="native_flow" v="1"/></biz>` | `<ack error="479">`, not delivered |
| the shape in this PR | delivered, renders, taps come back as `InteractiveResponseMessage` |

So a bare `<interactive>` child is not enough. The shape that works is:

```
<biz actual_actors="2" host_storage="2" privacy_mode_ts="<unix>">
  <interactive type="native_flow" v="1">
    <native_flow v="9" name="mixed"/>
  </interactive>
  <quality_control decision_id="<20 random bytes hex>" source_type="third_party">
    <decision_source value="df"/>
  </quality_control>
</biz>
```

Worth noting the payload itself is inside `<enc>`, so none of this is about the protobuf. The server is judging the plaintext node, which is why the proto being well-formed made no difference.

I took the node shape from the `itsliaaa/baileys` fork, which derives it from observed official client traffic. I can't claim to know what `actual_actors`, `host_storage` or the `quality_control` block mean to the server, only that this combination is accepted and the previous two are not. Happy to change anything you'd rather see done differently, including dropping the values you're not comfortable hardcoding.

`getBizNode` replaces the inline construction because the old shape couldn't express it: `<biz>` needs its own attributes, `<interactive>` needs children, and `<quality_control>` is a sibling.

Every other button type keeps the node it produced before, byte for byte. Verified by dumping the nodes:

```
BUTTONS: <biz><buttons/></biz>
LIST:    <biz><list type="unknown" v="2"/></biz>
```

`decision_id` is 20 bytes from `random.Bytes` (crypto/rand) per message; `privacy_mode_ts` is unix seconds.

`go build`, `go vet` and `staticcheck` are clean. There's no test for it because the package has no test suite to hang one on, so I verified against a real account and device instead. Also confirmed a native-flow message wrapped in view-once still resolves, since the new cases sit after the unwrapping ones.

This has been running in production on my own gateway for a few hours: buttons deliver, render, and taps route back with their ids intact.
