### PR TITLE
client: unblock queue senders when the connection dies

### DIFF
--- a/client.go
+++ b/client.go
@@ -831,13 +831,13 @@ func (cli *Client) RemoveEventHandlers() {
 	cli.eventHandlersLock.Unlock()
 }
 
-func (cli *Client) makeFrameHandler(queue chan *waBinary.Node) func(ctx context.Context, data []byte) {
+func (cli *Client) makeFrameHandler(connCtx context.Context, queue chan *waBinary.Node) func(ctx context.Context, data []byte) {
 	return func(ctx context.Context, data []byte) {
-		cli.handleFrame(ctx, data, queue)
+		cli.handleFrame(ctx, connCtx, data, queue)
 	}
 }
 
-func (cli *Client) handleFrame(ctx context.Context, data []byte, queue chan *waBinary.Node) {
+func (cli *Client) handleFrame(ctx, connCtx context.Context, data []byte, queue chan *waBinary.Node) {
 	decompressed, err := waBinary.Unpack(data)
 	if err != nil {
 		cli.Log.Warnf("Failed to decompress frame: %v", err)
@@ -868,6 +868,11 @@ func (cli *Client) handleFrame(ctx context.Context, data []byte, queue chan *waB
 				select {
 				case queue <- node:
 				case <-ctx.Done():
+				case <-connCtx.Done():
+					// The queue's consumer exits with the connection, so once the
+					// connection is gone nothing will ever drain the queue. Without
+					// this escape the sender would block forever, leaking one
+					// goroutine (and its node) per overflowed frame.
 				}
 			}()
 		}

--- a/handshake.go
+++ b/handshake.go
@@ -120,7 +120,7 @@ func (cli *Client) doHandshake(ctx context.Context, fs *socket.FrameSocket, ephe
 	}
 
 	queue := make(chan *waBinary.Node, handlerQueueSize)
-	ns, err := nh.Finish(ctx, fs, cli.makeFrameHandler(queue), cli.onDisconnect)
+	ns, err := nh.Finish(ctx, fs, cli.makeFrameHandler(fs.Context(), queue), cli.onDisconnect)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create noise socket: %w", err)
 	}

--- a/internals.go
+++ b/internals.go
@@ -159,12 +159,12 @@ func (int *DangerousInternalClient) UnlockedDisconnect() {
 	int.c.unlockedDisconnect()
 }
 
-func (int *DangerousInternalClient) MakeFrameHandler(queue chan *waBinary.Node) func(context.Context, []byte) {
-	return int.c.makeFrameHandler(queue)
+func (int *DangerousInternalClient) MakeFrameHandler(connCtx context.Context, queue chan *waBinary.Node) func(context.Context, []byte) {
+	return int.c.makeFrameHandler(connCtx, queue)
 }
 
-func (int *DangerousInternalClient) HandleFrame(ctx context.Context, data []byte, queue chan *waBinary.Node) {
-	int.c.handleFrame(ctx, data, queue)
+func (int *DangerousInternalClient) HandleFrame(ctx, connCtx context.Context, data []byte, queue chan *waBinary.Node) {
+	int.c.handleFrame(ctx, connCtx, data, queue)
 }
 
 func (int *DangerousInternalClient) HandlerQueueLoop(evtCtx, connCtx context.Context, queue chan *waBinary.Node) {


### PR DESCRIPTION
Since the handler queue became per-connection (4fa3462), its only consumer — `handlerQueueLoop` — exits when the connection's context is done. The queue-full fallback in `handleFrame`, however, parks a goroutine on `queue <- node` whose only escape is the frame handler context: that's the ctx passed to `Connect`, so for long-running clients it effectively never fires.

Once the connection dies, its queue has no consumer and is never drained again, so every parked sender blocks forever — one leaked goroutine (plus its retained node) per overflowed frame, accumulating across reconnects for the lifetime of the process. Clients with many sessions and busy inbound traffic accumulate these quickly.

**Fix:** give the fallback an escape on the connection's own context (`fs.Context()`), so parked senders exit when the connection goes away. Dropping the node at that point matches the intent of the per-connection queue — nodes from a dead connection shouldn't be handled by the next one.

Related observation from the same plumbing, not addressed here: anything buffered-but-unprocessed in the queue at connection death (including a `success` that the consumer didn't get to) is now silently dropped, whereas the old shared queue would process it late on the next connection. If a `success` is lost this way the client stays `IsConnected() == true` / `IsLoggedIn() == false` until the server closes the socket, with keepalives still passing. Happy to file that separately with more detail if useful.