### PR TITLE
store/sqlstore: key app state mutation MACs by index instead of version

### DIFF
--- a/store/sqlstore/store.go
+++ b/store/sqlstore/store.go
@@ -480,9 +480,10 @@ const (
 	getAppStateVersionQuery                 = `SELECT version, hash FROM whatsmeow_app_state_version WHERE jid=$1 AND name=$2`
 	deleteAppStateVersionQuery              = `DELETE FROM whatsmeow_app_state_version WHERE jid=$1 AND name=$2`
 	putAppStateMutationMACsQuery            = `INSERT INTO whatsmeow_app_state_mutation_macs (jid, name, version, index_mac, value_mac) VALUES `
+	putAppStateMutationMACsUpsert           = ` ON CONFLICT (jid, name, index_mac) DO UPDATE SET version=excluded.version, value_mac=excluded.value_mac`
 	deleteAppStateMutationMACsQueryPostgres = `DELETE FROM whatsmeow_app_state_mutation_macs WHERE jid=$1 AND name=$2 AND index_mac=ANY($3::bytea[])`
 	deleteAppStateMutationMACsQueryGeneric  = `DELETE FROM whatsmeow_app_state_mutation_macs WHERE jid=$1 AND name=$2 AND index_mac IN `
-	getAppStateMutationMACQuery             = `SELECT value_mac FROM whatsmeow_app_state_mutation_macs WHERE jid=$1 AND name=$2 AND index_mac=$3 ORDER BY version DESC LIMIT 1`
+	getAppStateMutationMACQuery             = `SELECT value_mac FROM whatsmeow_app_state_mutation_macs WHERE jid=$1 AND name=$2 AND index_mac=$3`
 )
 
 func (s *SQLStore) PutAppStateVersion(ctx context.Context, name string, version uint64, hash [128]byte) error {
@@ -531,16 +532,39 @@ func (s *SQLStore) putAppStateMutationMACs(ctx context.Context, name string, ver
 		values[baseIndex+1] = mutation.ValueMAC
 		queryParts[i] = fmt.Sprintf(placeholderSyntax, baseIndex+1, baseIndex+2)
 	}
-	_, err := s.db.Exec(ctx, putAppStateMutationMACsQuery+strings.Join(queryParts, ","), values...)
+	_, err := s.db.Exec(ctx, putAppStateMutationMACsQuery+strings.Join(queryParts, ",")+putAppStateMutationMACsUpsert, values...)
 	return err
 }
 
 const mutationBatchSize = 400
 
+// dedupeMutationMACs keeps only the last MAC for each index. A single patch can set the same
+// index twice, and the upsert in putAppStateMutationMACs can't touch the same row twice in one
+// statement (Postgres rejects it outright).
+func dedupeMutationMACs(mutations []store.AppStateMutationMAC) []store.AppStateMutationMAC {
+	indices := make(map[[32]byte]int, len(mutations))
+	out := make([]store.AppStateMutationMAC, 0, len(mutations))
+	for _, mutation := range mutations {
+		if len(mutation.IndexMAC) != 32 {
+			out = append(out, mutation)
+			continue
+		}
+		key := *(*[32]byte)(mutation.IndexMAC)
+		if i, ok := indices[key]; ok {
+			out[i] = mutation
+			continue
+		}
+		indices[key] = len(out)
+		out = append(out, mutation)
+	}
+	return out
+}
+
 func (s *SQLStore) PutAppStateMutationMACs(ctx context.Context, name string, version uint64, mutations []store.AppStateMutationMAC) error {
 	if len(mutations) == 0 {
 		return nil
 	}
+	mutations = dedupeMutationMACs(mutations)
 	return s.db.DoTxn(ctx, nil, func(ctx context.Context) error {
 		for slice := range slices.Chunk(mutations, mutationBatchSize) {
 			err := s.putAppStateMutationMACs(ctx, name, version, slice)

--- a/store/sqlstore/upgrades/00-latest-schema.sql
+++ b/store/sqlstore/upgrades/00-latest-schema.sql
@@ -1,4 +1,4 @@
--- v0 -> v15 (compatible with v8+): Latest schema
+-- v0 -> v16 (compatible with v8+): Latest schema
 CREATE TABLE whatsmeow_device (
 	jid TEXT PRIMARY KEY,
 	lid TEXT,
@@ -95,7 +95,7 @@ CREATE TABLE whatsmeow_app_state_mutation_macs (
 	index_mac bytea          CHECK ( length(index_mac) = 32 ),
 	value_mac bytea NOT NULL CHECK ( length(value_mac) = 32 ),
 
-	PRIMARY KEY (jid, name, version, index_mac),
+	PRIMARY KEY (jid, name, index_mac),
 	FOREIGN KEY (jid, name) REFERENCES whatsmeow_app_state_version(jid, name) ON DELETE CASCADE ON UPDATE CASCADE
 );
 

--- a/store/sqlstore/upgrades/16-app-state-mutation-mac-index.sql
+++ b/store/sqlstore/upgrades/16-app-state-mutation-mac-index.sql
@@ -1,0 +1,32 @@
+-- v16 (compatible with v8+): Only keep the latest MAC for each app state mutation index
+-- transaction: sqlite-fkey-off
+-- only: postgres until "end only"
+DELETE FROM whatsmeow_app_state_mutation_macs AS old
+USING whatsmeow_app_state_mutation_macs AS new
+WHERE old.jid = new.jid
+  AND old.name = new.name
+  AND old.index_mac = new.index_mac
+  AND old.version < new.version;
+ALTER TABLE whatsmeow_app_state_mutation_macs DROP CONSTRAINT whatsmeow_app_state_mutation_macs_pkey;
+ALTER TABLE whatsmeow_app_state_mutation_macs ADD PRIMARY KEY (jid, name, index_mac);
+-- end only postgres
+-- only: sqlite until "end only"
+CREATE TABLE whatsmeow_app_state_mutation_macs_v16 (
+	jid       TEXT,
+	name      TEXT,
+	version   BIGINT,
+	index_mac bytea          CHECK ( length(index_mac) = 32 ),
+	value_mac bytea NOT NULL CHECK ( length(value_mac) = 32 ),
+
+	PRIMARY KEY (jid, name, index_mac),
+	FOREIGN KEY (jid, name) REFERENCES whatsmeow_app_state_version(jid, name) ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO whatsmeow_app_state_mutation_macs_v16 (jid, name, version, index_mac, value_mac)
+SELECT jid, name, version, index_mac, value_mac
+FROM (
+	SELECT *, ROW_NUMBER() OVER (PARTITION BY jid, name, index_mac ORDER BY version DESC) AS rn
+	FROM whatsmeow_app_state_mutation_macs
+) WHERE rn = 1;
+DROP TABLE whatsmeow_app_state_mutation_macs;
+ALTER TABLE whatsmeow_app_state_mutation_macs_v16 RENAME TO whatsmeow_app_state_mutation_macs;
+-- end only sqlite


### PR DESCRIPTION
`whatsmeow_app_state_mutation_macs` is only ever read as a map from `index_mac` to the **current** `value_mac` — `updateHash` needs the previous SET value so the LTHash can subtract it. But the primary key is `(jid, name, version, index_mac)` and `putAppStateMutationMACsQuery` is a plain `INSERT`, so every patch that re-sets an index appends another row and nothing ever removes the superseded one. `DeleteAppStateMutationMACs` only runs for indexes that were explicitly REMOVEd.

Full syncs and `ProcessRecovery` do clear the table (`DeleteAppStateVersion` + `ON DELETE CASCADE`, which I verified fires), but on a long-lived session they are rare.

### What it looks like in practice

One session with ~48k contacts, SQLite, after a few months:

| | |
|---|---|
| rows in `whatsmeow_app_state_mutation_macs` | 4,379,305 |
| distinct `index_mac` | 102,835 |
| superseded | **97.65%** |
| space | 550MB table + 468MB autoindex = **1.02GB of a 1.7GB file** |

Where the rows come from:

* **86 patches carried the account's entire contact list** — 48,022 mutations each, 100% index overlap between consecutive ones. Those alone are 3,765,707 rows (86%).
* 41 indexes are re-set in almost every patch — another 586,559 rows.

A second, smaller session on the same host: 747,309 rows for 40,456 indexes.

### It is also a read cliff

`getAppStateMutationMACQuery` filters on `index_mac`, which is the *fourth* column of the primary key, so the only usable prefix is `(jid, name)`:

```
SEARCH whatsmeow_app_state_mutation_macs USING INDEX
       sqlite_autoindex_whatsmeow_app_state_mutation_macs_1 (jid=? AND name=?)
```

Every lookup scans the collection backwards until it hits the index:

| | |
|---|---|
| index written in the newest patch | 6ms |
| average over 50 random indexes | **422ms** |
| miss (index not in the table) | **1.4s** |

`validatePatch` calls it once per mutation, so one of those 48k-mutation patches issues 48,022 such lookups.

### The change

Make the table what the code already treats it as:

* primary key → `(jid, name, index_mac)`, so a lookup is a single seek and `ORDER BY version DESC LIMIT 1` is gone;
* insert → `ON CONFLICT (jid, name, index_mac) DO UPDATE SET version=excluded.version, value_mac=excluded.value_mac`;
* `dedupeMutationMACs` keeps the last MAC per index inside one batch. A patch can SET the same index twice, and a multi-row upsert cannot touch the same row twice — Postgres rejects it outright. (The old plain `INSERT` would have hit the primary key in that case, so this closes a latent failure too.)
* upgrade v16 keeps the newest row per index: `DELETE ... USING` plus a primary key swap on Postgres, a table rebuild on SQLite.

`version` is kept as a plain column; nothing reads it, but it is useful when looking at the table by hand.

### Verification

Against a synthetic v15 database driven through `sqlstore.New`: the upgrade runs, the primary key is replaced, only the newest MAC survives, a re-SET updates in place, and duplicate indexes in one batch collapse to the last one.

On a copy of the production database above, keeping only the newest row per index and running `VACUUM`:

| | before | after |
|---|---|---|
| file | 1.67GB | **682MB** |
| table + index | 1018MB | 21.7MB |
| 50 random lookups | 21.1s | **0.75s** |

Row-for-row diff against the expected winner set (`ROW_NUMBER() OVER (PARTITION BY jid, name, index_mac ORDER BY version DESC) = 1`) was empty in both directions.

One caveat worth mentioning in case anyone hits it: the SQLite upgrade frees the pages but does not shrink the file, so an existing bloated database still needs a manual `VACUUM` to hand the space back to the filesystem.
