### PR TITLE
group: make SetGroupDescription delegate to SetGroupTopic

### DIFF
--- a/group.go
+++ b/group.go
@@ -1086,17 +1086,9 @@ func (cli *Client) SetGroupMemberAddMode(ctx context.Context, jid types.JID, mod
 }
 
 // SetGroupDescription updates the group description.
+//
+// Deprecated: use Client.SetGroupTopic instead, which allows specifying the previous and new
+// description IDs. This method is equivalent to calling it with both IDs left empty.
 func (cli *Client) SetGroupDescription(ctx context.Context, jid types.JID, description string) error {
-	content := waBinary.Node{
-		Tag: "description",
-		Content: []waBinary.Node{
-			{
-				Tag:     "body",
-				Content: []byte(description),
-			},
-		},
-	}
-
-	_, err := cli.sendGroupIQ(ctx, iqSet, jid, content)
-	return err
+	return cli.SetGroupTopic(ctx, jid, "", "", description)
 }


### PR DESCRIPTION
SetGroupDescription sent a bare <description><body> node with no id, prev or delete attributes, so clearing a description didn't work and updates weren't chained to the previous description ID. SetGroupTopic already does all of that, so this makes SetGroupDescription delegate to it and marks it deprecated. Signature and behaviour for callers stay the same.
Motivated by [https://github.com/tulir/whatsmeow/pull/851](https://github.com/tulir/whatsmeow/pull/851) by @xTudoS, which fixes the same bug by duplicating the logic (and pulls proto changes into the diff, and omits the id attribute on delete, unlike SetGroupTopic). Happy to close this one if @xTudoS would rather fold the delegation into that PR.
Verified with go build, go vet, go test -race ./... and staticcheck.
- I have read and followed the contributing guidelines at [https://docs.mau.fi/bridges/general/contributing.html](https://docs.mau.fi/bridges/general/contributing.html)