### PR TITLE
sqlstore: skip the PN to LID migration transaction when it is a no-op

### DIFF
--- a/store/sqlstore/store.go
+++ b/store/sqlstore/store.go
@@ -143,6 +143,17 @@ const (
 		WHERE our_jid=$1 AND sender_id LIKE $2 || ':%'
 		ON CONFLICT (our_jid, chat_id, sender_id) DO UPDATE SET sender_key=excluded.sender_key
 	`
+	// Existence check for the rows the PN->LID migration would touch, using the
+	// same LIKE prefix predicates as the migration itself. An explicit >=/< range
+	// over $2||':' and $2||';' would let the primary key index do the work, but it
+	// only matches the same rows under a binary collation: locale collations
+	// (ICU, glibc) ignore ':' at the primary weight, so 'pn:0' sorts after 'pn;'
+	// and the range matches nothing at all.
+	hasPNRowsToMigrateQuery = `
+		SELECT EXISTS(SELECT 1 FROM whatsmeow_sessions WHERE our_jid=$1 AND their_id LIKE $2 || ':%')
+			OR EXISTS(SELECT 1 FROM whatsmeow_identity_keys WHERE our_jid=$1 AND their_id LIKE $2 || ':%')
+			OR EXISTS(SELECT 1 FROM whatsmeow_sender_keys WHERE our_jid=$1 AND sender_id LIKE $2 || ':%')
+	`
 )
 
 func (s *SQLStore) GetSession(ctx context.Context, address string) (session []byte, err error) {
@@ -250,9 +261,21 @@ func (s *SQLStore) MigratePNToLID(ctx context.Context, pn, lid types.JID) error 
 	if !s.migratedPNSessionsCache.Add(pnSignal) {
 		return nil
 	}
-	var sessionsUpdated, identityKeysUpdated, senderKeysUpdated int64
 	lidSignal := lid.SignalAddressUser()
-	err := s.db.DoTxn(ctx, nil, func(ctx context.Context) error {
+	// migratedPNSessionsCache only lives in memory, so after a restart the first
+	// send to each recipient gets here even when the store was migrated long ago.
+	// Opening the transaction unconditionally costs one write transaction per
+	// recipient, which is very noticeable when sending to a lot of them.
+	var hasPNRows bool
+	err := s.db.QueryRow(ctx, hasPNRowsToMigrateQuery, s.JID, pnSignal).Scan(&hasPNRows)
+	if err != nil {
+		s.log.Warnf("Failed to check for rows to migrate from %s: %v", pnSignal, err)
+	} else if !hasPNRows {
+		s.log.Debugf("Nothing to migrate from %s to %s", pnSignal, lidSignal)
+		return nil
+	}
+	var sessionsUpdated, identityKeysUpdated, senderKeysUpdated int64
+	err = s.db.DoTxn(ctx, nil, func(ctx context.Context) error {
 		res, err := s.db.Exec(ctx, migratePNToLIDSessionsQuery, s.JID, pnSignal, lidSignal)
 		if err != nil {
 			return fmt.Errorf("failed to migrate sessions: %w", err)


### PR DESCRIPTION
Checks whether any PN-addressed row exists before opening the migration transaction in MigratePNToLID and returns early when there's nothing to move. migratedPNSessionsCache only lives in memory, so after a restart the first send to every recipient runs the six-statement write transaction again even on a store that was fully migrated long ago.
Based on [https://github.com/tulir/whatsmeow/pull/1218](https://github.com/tulir/whatsmeow/pull/1218) by @Elimeshi1, with two differences:
- That PR does the pre-check with their_id >= $2||':' AND their_id < $2||';' so it can hit the primary key. That's only equivalent to the LIKE prefix under a binary collation. Locale collations ignore : at the primary weight, so pn:0 sorts after pn; and the range matches nothing. I reproduced it on a Postgres database created with LOCALE_PROVIDER icu ICU_LOCALE 'en': the range version reports nothing to migrate for every recipient and silently leaves every session at its PN address, while the same code passes on C.UTF-8 and SQLite. This version reuses the migration's own LIKE predicates for the check, so it can't disagree with the statements it's guarding.
- whatsmeow_sender_keys is checked too. message.go deletes an identity and a session together on a retry receipt without touching sender keys, so an orphaned PN-addressed sender key can outlive both.
Happy to close this if @Elimeshi1 prefers to take the LIKE-based check into #1218 instead.
Verified with go build, go vet, go test -race ./... and staticcheck; the collation behaviour was checked against Postgres 16 (ICU and C.UTF-8) and SQLite.
- I have read and followed the contributing guidelines at [https://docs.mau.fi/bridges/general/contributing.html](https://docs.mau.fi/bridges/general/contributing.html)