### PR TITLE
sqlstore: delete a single identity with the equality query

### DIFF
--- a/store/sqlstore/store.go
+++ b/store/sqlstore/store.go
@@ -90,7 +90,7 @@ func (s *SQLStore) DeleteAllIdentities(ctx context.Context, phone string) error 
 }
 
 func (s *SQLStore) DeleteIdentity(ctx context.Context, address string) error {
-	_, err := s.db.Exec(ctx, deleteAllIdentitiesQuery, s.JID, address)
+	_, err := s.db.Exec(ctx, deleteIdentityQuery, s.JID, address)
 	return err
 }
 


### PR DESCRIPTION
DeleteIdentity was passing a full address to deleteAllIdentitiesQuery, which matches with LIKE. That works by accident for the addresses whatsmeow generates, but the address is a pattern there: % or _ in it deletes other rows, a prefix match deletes every device of that user, and the pattern scan can't use the (our_jid, their_id) primary key. deleteIdentityQuery already exists for exactly this and was unused, so this just switches to it.
[https://github.com/tulir/whatsmeow/pull/1091](https://github.com/tulir/whatsmeow/pull/1091) by @tovmeod contains this same one-line fix, but the rest of that PR rewrites the LIKE prefix scans into their_id >= $2||':' AND their_id < $2||';' ranges, and that's only equivalent under a binary collation. On a Postgres database created with LOCALE_PROVIDER icu ICU_LOCALE 'en' the range matches nothing, so MigratePNToLID migrates and deletes no rows and every session silently stays at its PN address, while the same code passes on C.UTF-8 and SQLite. So only the safe part is submitted here. Happy to close this if @tovmeod would rather trim #1091 down to it.
Verified with go build, go vet, go test -race ./... and staticcheck.
- I have read and followed the contributing guidelines at [https://docs.mau.fi/bridges/general/contributing.html](https://docs.mau.fi/bridges/general/contributing.html)