### PR TITLE
call: expose the call stanza's own id in call events

### DIFF
--- a/call.go
+++ b/call.go
@@ -30,6 +30,7 @@ func (cli *Client) handleCallEvent(ctx context.Context, node *waBinary.Node) {
 		CallCreator: cag.JID("call-creator"),
 		CallID:      cag.String("call-id"),
 		GroupJID:    cag.OptionalJIDOrEmpty("group-jid"),
+		StanzaID:    ag.String("id"),
 	}
 	if basicMeta.CallCreator.Server == types.HiddenUserServer {
 		basicMeta.CallCreatorAlt = cag.OptionalJIDOrEmpty("caller_pn")

--- a/types/call.go
+++ b/types/call.go
@@ -15,6 +15,9 @@ type BasicCallMeta struct {
 	CallCreatorAlt JID
 	CallID         string
 	GroupJID       JID
+	// StanzaID is the ID attribute of the <call> stanza itself, which is
+	// different from CallID (the ID of the call the stanza is about).
+	StanzaID string
 }
 
 type CallRemoteMeta struct {


### PR DESCRIPTION
Adds BasicCallMeta.StanzaID and fills it from the outer <call> node's id attribute. The parser only kept the child node's call-id, so there was no way to correlate a dispatched call event with the stanza it came from or with the ack sent for it, which is what [https://github.com/tulir/whatsmeow/issues/1231](https://github.com/tulir/whatsmeow/issues/1231) asks for.
Every call event embeds BasicCallMeta and the struct is built once in handleCallEvent, so this covers all call event types. Purely additive.
Verified with go build, go vet, go test -race ./... and staticcheck.
- I have read and followed the contributing guidelines at [https://docs.mau.fi/bridges/general/contributing.html](https://docs.mau.fi/bridges/general/contributing.html)