### PR TITLE
client: lock signal sessions between encrypt and decrypt

### DIFF
--- a/message.go
+++ b/message.go
@@ -576,6 +576,11 @@ func (cli *Client) decryptDM(ctx context.Context, child *waBinary.Node, from typ
 		return nil, nil, fmt.Errorf("message content is not a byte slice")
 	}
 
+	// Without the lock, concurrent sends to the same address could overwrite
+	// this decrypt's ratchet advance (and vice versa).
+	unlockSession := cli.Store.LockSession(from.SignalAddress().String())
+	defer unlockSession()
+
 	builder := session.NewBuilderFromSignal(cli.Store, from.SignalAddress(), pbSerializer)
 	cipher := session.NewCipher(builder, from.SignalAddress())
 	var plaintext []byte

--- a/message.go
+++ b/message.go
@@ -307,6 +307,13 @@ func (cli *Client) handlePlaintextMessage(ctx context.Context, info *types.Messa
 }
 
 func (cli *Client) migrateSessionStore(ctx context.Context, pn, lid types.JID) {
+	// Rewriting the session rows is another read-modify-write of the records
+	// that encrypting and decrypting take these locks for.
+	unlockSessions := cli.Store.LockSessions([]string{
+		pn.SignalAddress().String(),
+		lid.SignalAddress().String(),
+	})
+	defer unlockSessions()
 	err := cli.Store.Sessions.MigratePNToLID(ctx, pn, lid)
 	if err != nil {
 		cli.Log.Errorf("Failed to migrate signal store from %s to %s: %v", pn, lid, err)

--- a/retry.go
+++ b/retry.go
@@ -346,9 +346,9 @@ func (cli *Client) handleRetryReceipt(ctx context.Context, receipt *events.Recei
 				encryptionIdentity = lidForPN
 			}
 		}
-		encrypted, includeDeviceIdentity, err = cli.encryptMessageForDevice(ctx, plaintext, encryptionIdentity, bundle, encAttrs, nil)
+		encrypted, includeDeviceIdentity, err = cli.encryptMessageForDeviceLocked(ctx, plaintext, encryptionIdentity, bundle, encAttrs, nil)
 	} else {
-		encrypted, err = cli.encryptMessageForDeviceV3(ctx, &waMsgTransport.MessageTransport_Payload{
+		encrypted, err = cli.encryptMessageForDeviceV3Locked(ctx, &waMsgTransport.MessageTransport_Payload{
 			ApplicationPayload: &waCommon.SubProtocol{
 				Payload: plaintext,
 				Version: proto.Int32(FBMessageApplicationVersion),

--- a/send.go
+++ b/send.go
@@ -1341,6 +1341,7 @@ func (cli *Client) encryptMessageForDevices(
 		if err != nil {
 			return nil, false, fmt.Errorf("failed to prefetch sessions: %w", err)
 		}
+		dropBundlesForExistingSessions(bundles, existingSessions, sessionAddressToJID)
 	}
 
 	for _, jid := range allDevices {
@@ -1373,6 +1374,22 @@ func (cli *Client) encryptMessageForDevices(
 		return nil, false, fmt.Errorf("failed to save cached sessions: %w", err)
 	}
 	return participantNodes, includeIdentity, nil
+}
+
+// dropBundlesForExistingSessions removes the prekey bundles fetched for
+// addresses that gained a session while the session locks were released.
+// Processing a bundle creates a fresh session, which would throw away the
+// ratchet state the other side just established.
+func dropBundlesForExistingSessions(
+	bundles map[types.JID]*prekey.Bundle,
+	existingSessions map[string]bool,
+	sessionAddressToJID map[string]types.JID,
+) {
+	for addr, exists := range existingSessions {
+		if exists {
+			delete(bundles, sessionAddressToJID[addr])
+		}
+	}
 }
 
 func (cli *Client) encryptMessageForDeviceAndWrap(

--- a/send.go
+++ b/send.go
@@ -1093,7 +1093,7 @@ func (cli *Client) preparePeerMessageNode(
 		}
 	}
 	start = time.Now()
-	encrypted, isPreKey, err := cli.encryptMessageForDevice(ctx, plaintext, encryptionIdentity, nil, nil, nil)
+	encrypted, isPreKey, err := cli.encryptMessageForDeviceLocked(ctx, plaintext, encryptionIdentity, nil, nil, nil)
 	timings.PeerEncrypt = time.Since(start)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encrypt peer message for %s: %v", to, err)
@@ -1312,6 +1312,11 @@ func (cli *Client) encryptMessageForDevices(
 		sessionAddressToJID[addr] = jid
 	}
 
+	// The decrypt path does its own read-modify-write of the same session
+	// rows; without the lock, either side's ratchet advance can be lost.
+	unlockSessions := cli.Store.LockSessions(sessionAddresses)
+	defer func() { unlockSessions() }()
+	baseCtx := ctx
 	existingSessions, ctx, err := cli.Store.WithCachedSessions(ctx, sessionAddresses)
 	if err != nil {
 		return nil, false, fmt.Errorf("failed to prefetch sessions: %w", err)
@@ -1322,7 +1327,21 @@ func (cli *Client) encryptMessageForDevices(
 			retryDevices = append(retryDevices, sessionAddressToJID[addr])
 		}
 	}
-	bundles := cli.fetchPreKeysNoError(ctx, retryDevices)
+	var bundles map[types.JID]*prekey.Bundle
+	if len(retryDevices) > 0 {
+		// Don't hold the session locks across the network round trip. The
+		// sessions may change while unlocked, so re-read them after
+		// re-locking, otherwise PutCachedSessions would overwrite concurrent
+		// ratchet advances.
+		unlockSessions()
+		unlockSessions = func() {}
+		bundles = cli.fetchPreKeysNoError(baseCtx, retryDevices)
+		unlockSessions = cli.Store.LockSessions(sessionAddresses)
+		existingSessions, ctx, err = cli.Store.WithCachedSessions(baseCtx, sessionAddresses)
+		if err != nil {
+			return nil, false, fmt.Errorf("failed to prefetch sessions: %w", err)
+		}
+	}
 
 	for _, jid := range allDevices {
 		plaintext := msgPlaintext
@@ -1382,6 +1401,21 @@ func copyAttrs(from, to waBinary.Attrs) {
 	for k, v := range from {
 		to[k] = v
 	}
+}
+
+// encryptMessageForDeviceLocked is encryptMessageForDevice for callers that
+// aren't already holding the session lock for the target address.
+func (cli *Client) encryptMessageForDeviceLocked(
+	ctx context.Context,
+	plaintext []byte,
+	to types.JID,
+	bundle *prekey.Bundle,
+	extraAttrs waBinary.Attrs,
+	existingSessions map[string]bool,
+) (*waBinary.Node, bool, error) {
+	unlockSession := cli.Store.LockSession(to.SignalAddress().String())
+	defer unlockSession()
+	return cli.encryptMessageForDevice(ctx, plaintext, to, bundle, extraAttrs, existingSessions)
 }
 
 func (cli *Client) encryptMessageForDevice(

--- a/send_test.go
+++ b/send_test.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 Tulir Asokan
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package whatsmeow
+
+import (
+	"testing"
+
+	"go.mau.fi/libsignal/keys/prekey"
+
+	"go.mau.fi/whatsmeow/types"
+)
+
+func TestDropBundlesForExistingSessions(t *testing.T) {
+	gained := types.JID{User: "1", Device: 0, Server: types.DefaultUserServer}
+	missing := types.JID{User: "2", Device: 0, Server: types.DefaultUserServer}
+	sessionAddressToJID := map[string]types.JID{
+		gained.SignalAddress().String():  gained,
+		missing.SignalAddress().String(): missing,
+	}
+	bundles := map[types.JID]*prekey.Bundle{
+		gained:  {},
+		missing: {},
+	}
+	existingSessions := map[string]bool{
+		gained.SignalAddress().String():  true,
+		missing.SignalAddress().String(): false,
+	}
+
+	dropBundlesForExistingSessions(bundles, existingSessions, sessionAddressToJID)
+
+	if _, ok := bundles[gained]; ok {
+		t.Error("bundle for an address that gained a session while unlocked wasn't dropped")
+	}
+	if _, ok := bundles[missing]; !ok {
+		t.Error("bundle for an address that still has no session was dropped")
+	}
+}

--- a/sendfb.go
+++ b/sendfb.go
@@ -558,10 +558,11 @@ func (cli *Client) encryptMessageForDevicesV3(
 		unlockSessions = func() {}
 		bundles = cli.fetchPreKeysNoError(baseCtx, retryDevices)
 		unlockSessions = cli.Store.LockSessions(sessionAddresses)
-		_, ctx, err = cli.Store.WithCachedSessions(baseCtx, sessionAddresses)
+		existingSessions, ctx, err = cli.Store.WithCachedSessions(baseCtx, sessionAddresses)
 		if err != nil {
 			return nil, fmt.Errorf("failed to prefetch sessions: %w", err)
 		}
+		dropBundlesForExistingSessions(bundles, existingSessions, sessionAddressToJID)
 	}
 
 	for _, jid := range allDevices {

--- a/sendfb.go
+++ b/sendfb.go
@@ -558,7 +558,7 @@ func (cli *Client) encryptMessageForDevicesV3(
 		unlockSessions = func() {}
 		bundles = cli.fetchPreKeysNoError(baseCtx, retryDevices)
 		unlockSessions = cli.Store.LockSessions(sessionAddresses)
-		existingSessions, ctx, err = cli.Store.WithCachedSessions(baseCtx, sessionAddresses)
+		_, ctx, err = cli.Store.WithCachedSessions(baseCtx, sessionAddresses)
 		if err != nil {
 			return nil, fmt.Errorf("failed to prefetch sessions: %w", err)
 		}

--- a/sendfb.go
+++ b/sendfb.go
@@ -537,6 +537,10 @@ func (cli *Client) encryptMessageForDevicesV3(
 		sessionAddresses = append(sessionAddresses, addr)
 		sessionAddressToJID[addr] = jid
 	}
+	// See encryptMessageForDevices for the locking rationale.
+	unlockSessions := cli.Store.LockSessions(sessionAddresses)
+	defer func() { unlockSessions() }()
+	baseCtx := ctx
 	existingSessions, ctx, err := cli.Store.WithCachedSessions(ctx, sessionAddresses)
 	if err != nil {
 		return nil, fmt.Errorf("failed to prefetch sessions: %w", err)
@@ -547,7 +551,18 @@ func (cli *Client) encryptMessageForDevicesV3(
 			retryDevices = append(retryDevices, sessionAddressToJID[addr])
 		}
 	}
-	bundles := cli.fetchPreKeysNoError(ctx, retryDevices)
+	var bundles map[types.JID]*prekey.Bundle
+	if len(retryDevices) > 0 {
+		// See encryptMessageForDevices.
+		unlockSessions()
+		unlockSessions = func() {}
+		bundles = cli.fetchPreKeysNoError(baseCtx, retryDevices)
+		unlockSessions = cli.Store.LockSessions(sessionAddresses)
+		existingSessions, ctx, err = cli.Store.WithCachedSessions(baseCtx, sessionAddresses)
+		if err != nil {
+			return nil, fmt.Errorf("failed to prefetch sessions: %w", err)
+		}
+	}
 
 	for _, jid := range allDevices {
 		if jid == ownID {
@@ -593,6 +608,22 @@ func (cli *Client) encryptMessageForDeviceAndWrapV3(
 		Attrs:   waBinary.Attrs{"jid": to},
 		Content: []waBinary.Node{*node},
 	}, nil
+}
+
+// encryptMessageForDeviceV3Locked is encryptMessageForDeviceV3 for callers
+// that aren't already holding the session lock for the target address.
+func (cli *Client) encryptMessageForDeviceV3Locked(
+	ctx context.Context,
+	payload *waMsgTransport.MessageTransport_Payload,
+	skdm *waMsgTransport.MessageTransport_Protocol_Ancillary_SenderKeyDistributionMessage,
+	dsm *waMsgTransport.MessageTransport_Protocol_Integral_DeviceSentMessage,
+	to types.JID,
+	bundle *prekey.Bundle,
+	extraAttrs waBinary.Attrs,
+) (*waBinary.Node, error) {
+	unlockSession := cli.Store.LockSession(to.SignalAddress().String())
+	defer unlockSession()
+	return cli.encryptMessageForDeviceV3(ctx, payload, skdm, dsm, to, bundle, extraAttrs)
 }
 
 func (cli *Client) encryptMessageForDeviceV3(

--- a/store/sessionlock.go
+++ b/store/sessionlock.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Tulir Asokan
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package store
+
+import (
+	"slices"
+	"sync"
+)
+
+// Mutexes are never evicted; the map grows with the number of distinct
+// addresses, which is negligible next to the session data itself.
+func (device *Device) sessionLock(address string) *sync.Mutex {
+	val, _ := device.sessionLocks.LoadOrStore(address, &sync.Mutex{})
+	return val.(*sync.Mutex)
+}
+
+// LockSession acquires the lock for the session record of the given signal
+// address and returns the function that releases it. Both encrypting and
+// decrypting do a read-modify-write of the whole record, so they must hold
+// this lock to avoid losing each other's ratchet advances.
+func (device *Device) LockSession(address string) func() {
+	lock := device.sessionLock(address)
+	lock.Lock()
+	return lock.Unlock
+}
+
+// LockSessions acquires the session locks for all given addresses,
+// deduplicated and in sorted order to prevent deadlocks between concurrent
+// multi-address lockers. The returned function releases all locks.
+func (device *Device) LockSessions(addresses []string) func() {
+	if len(addresses) == 0 {
+		return func() {}
+	}
+	sorted := slices.Clone(addresses)
+	slices.Sort(sorted)
+	sorted = slices.Compact(sorted)
+	locks := make([]*sync.Mutex, len(sorted))
+	for i, addr := range sorted {
+		locks[i] = device.sessionLock(addr)
+		locks[i].Lock()
+	}
+	return func() {
+		for i := len(locks) - 1; i >= 0; i-- {
+			locks[i].Unlock()
+		}
+	}
+}

--- a/store/sessionlock.go
+++ b/store/sessionlock.go
@@ -11,8 +11,8 @@ import (
 	"sync"
 )
 
-// Mutexes are never evicted; the map grows with the number of distinct
-// addresses, which is negligible next to the session data itself.
+// Mutexes are never evicted: the map keeps one entry per distinct signal
+// address the process has locked, for the lifetime of the process.
 func (device *Device) sessionLock(address string) *sync.Mutex {
 	val, _ := device.sessionLocks.LoadOrStore(address, &sync.Mutex{})
 	return val.(*sync.Mutex)
@@ -31,6 +31,11 @@ func (device *Device) LockSession(address string) func() {
 // LockSessions acquires the session locks for all given addresses,
 // deduplicated and in sorted order to prevent deadlocks between concurrent
 // multi-address lockers. The returned function releases all locks.
+//
+// Sorting only makes concurrent calls safe against each other, so no caller
+// may hold a session lock while acquiring more: every path that locks several
+// addresses (including the PN->LID session migration) must acquire them in one
+// call and release before locking anything else.
 func (device *Device) LockSessions(addresses []string) func() {
 	if len(addresses) == 0 {
 		return func() {}

--- a/store/sessionlock_test.go
+++ b/store/sessionlock_test.go
@@ -86,6 +86,37 @@ func TestLockSessionIsExclusive(t *testing.T) {
 	}
 }
 
+func TestLockSessionAndLockSessionsShareTheSameMutex(t *testing.T) {
+	// The session migration locks a pair of addresses with LockSessions while
+	// decrypting locks a single one with LockSession; they must exclude each
+	// other for the address they have in common.
+	var device Device
+	counter := 0
+	mustNotBlock(t, "mixed LockSession and LockSessions", func() {
+		var wg sync.WaitGroup
+		for i := range 8 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for range 100 {
+					var unlock func()
+					if i%2 == 0 {
+						unlock = device.LockSession("a.0")
+					} else {
+						unlock = device.LockSessions([]string{"a.0", "b.0"})
+					}
+					counter++
+					unlock()
+				}
+			}()
+		}
+		wg.Wait()
+	})
+	if counter != 800 {
+		t.Errorf("expected 800 increments, got %d", counter)
+	}
+}
+
 func TestLockSessionsIsExclusive(t *testing.T) {
 	var device Device
 	counters := map[string]int{"a.0": 0, "b.0": 0}

--- a/store/sessionlock_test.go
+++ b/store/sessionlock_test.go
@@ -1,0 +1,113 @@
+// Copyright (c) 2026 Tulir Asokan
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package store
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func mustNotBlock(t *testing.T, name string, fn func()) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		fn()
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("%s deadlocked", name)
+	}
+}
+
+func TestLockSessionsDeduplicatesAddresses(t *testing.T) {
+	var device Device
+	mustNotBlock(t, "LockSessions with duplicate addresses", func() {
+		device.LockSessions([]string{"a.0", "b.0", "a.0"})()
+	})
+}
+
+func TestLockSessionsEmpty(t *testing.T) {
+	var device Device
+	device.LockSessions(nil)()
+}
+
+func TestLockSessionsOverlappingSetsDontDeadlock(t *testing.T) {
+	var device Device
+	// Different input orders must still be acquired in the same global order.
+	sets := [][]string{
+		{"a.0", "b.0", "c.0"},
+		{"c.0", "b.0", "a.0"},
+		{"b.0", "d.0"},
+		{"d.0", "a.0"},
+	}
+	mustNotBlock(t, "concurrent overlapping LockSessions", func() {
+		var wg sync.WaitGroup
+		for _, addresses := range sets {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for range 200 {
+					unlock := device.LockSessions(addresses)
+					unlock()
+				}
+			}()
+		}
+		wg.Wait()
+	})
+}
+
+func TestLockSessionIsExclusive(t *testing.T) {
+	var device Device
+	counter := 0
+	mustNotBlock(t, "concurrent LockSession", func() {
+		var wg sync.WaitGroup
+		for range 8 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for range 100 {
+					unlock := device.LockSession("a.0")
+					counter++
+					unlock()
+				}
+			}()
+		}
+		wg.Wait()
+	})
+	if counter != 800 {
+		t.Errorf("expected 800 increments, got %d", counter)
+	}
+}
+
+func TestLockSessionsIsExclusive(t *testing.T) {
+	var device Device
+	counters := map[string]int{"a.0": 0, "b.0": 0}
+	mustNotBlock(t, "concurrent LockSessions", func() {
+		var wg sync.WaitGroup
+		for range 8 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for range 100 {
+					unlock := device.LockSessions([]string{"b.0", "a.0"})
+					counters["a.0"]++
+					counters["b.0"]++
+					unlock()
+				}
+			}()
+		}
+		wg.Wait()
+	})
+	for addr, count := range counters {
+		if count != 800 {
+			t.Errorf("expected 800 increments for %s, got %d", addr, count)
+		}
+	}
+}

--- a/store/store.go
+++ b/store/store.go
@@ -10,6 +10,7 @@ package store
 import (
 	"context"
 	"errors"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -252,6 +253,10 @@ type Device struct {
 	EventBuffer   EventBuffer
 	LIDs          LIDStore
 	Container     DeviceContainer
+
+	// Per-address signal session locks, see LockSession.
+	// Zero value is ready to use; never copy a Device after first use.
+	sessionLocks sync.Map
 }
 
 func (device *Device) GetJID() types.JID {


### PR DESCRIPTION
Adds per-signal-address mutexes on store.Device and takes them around every session read-modify-write. Encrypt and decrypt both rewrite the same session record, but nothing serialized them: messageSendLock only guards sends against other sends and handleRetryReceipt doesn't take it at all. A send racing an inbound decrypt for the same address loses one side's ratchet advance, which shows up as "received message with old counter" and as messages the server accepts but the recipient never gets, usually right after a fresh device link. That's [https://github.com/tulir/whatsmeow/issues/1095](https://github.com/tulir/whatsmeow/issues/1095).
Based on [https://github.com/tulir/whatsmeow/pull/1168](https://github.com/tulir/whatsmeow/pull/1168) by @jlucaso1, with these fixes on top:
- The single-address unlock in retry.go and send.go wasn't deferred, so a libsignal panic leaked the mutex for that address forever. Both are deferred now.
- migrateSessionStore runs under both addresses' locks. MigratePNToLID rewrites the same whatsmeow_sessions rows that decryptDM and encryptMessageForDevices lock for, and none of the three call sites held anything during it. The pair is acquired in one sorted call before anything else is locked, which keeps the global ordering LockSessions relies on; that ordering is now documented on LockSessions.
- Prekey bundles are dropped for addresses that gained a session while the locks were released for the prekey fetch. Both multi-device encrypt paths re-read the sessions after re-locking but kept the bundles, so encryptMessageForDevice would ProcessBundle over a session another goroutine had just created and reset it.
- A dead existingSessions reassignment in the V3 path (staticcheck SA4006, also present in #1168) is removed.
- Tests for the lock helpers and the send path.
Happy to close this if @jlucaso1 wants to take the fixes into #1168.
Verified with go build, go vet, go test -race ./... and staticcheck.
- I have read and followed the contributing guidelines at [https://docs.mau.fi/bridges/general/contributing.html](https://docs.mau.fi/bridges/general/contributing.html)