### PR TITLE
send: add BuildReply helper for quoting messages

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -111,6 +111,8 @@ var (
 	ErrRecipientADJID           = errors.New("message recipient must be a user JID with no device part")
 	ErrServerReturnedError      = errors.New("server returned error")
 	ErrInvalidInlineBotID       = errors.New("invalid inline bot ID")
+	// ErrUnsupportedReplyType is returned by Client.BuildReply when the reply content has no field that accepts a ContextInfo (e.g. reactions, protocol messages).
+	ErrUnsupportedReplyType = errors.New("reply content type has no ContextInfo field")
 )
 
 type DownloadHTTPError struct {

--- a/send.go
+++ b/send.go
@@ -28,6 +28,7 @@ import (
 	"go.mau.fi/libsignal/signalerror"
 	"go.mau.fi/util/random"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	waBinary "go.mau.fi/whatsmeow/binary"
 	"go.mau.fi/whatsmeow/proto/waAICommon"
@@ -613,6 +614,189 @@ func (cli *Client) BuildEdit(chat types.JID, id types.MessageID, newContent *waE
 			},
 		},
 	}
+}
+
+// BuildReply wraps replyContent so that it quotes the message identified by quotedInfo and quotedMsg.
+// The built message can be sent normally using Client.SendMessage.
+//
+// quotedMsg is embedded as a stripped copy (principal content only, no nested quote chain), matching
+// what official WhatsApp clients do. Plain Conversation reply content is promoted to ExtendedTextMessage,
+// and any ContextInfo already set on replyContent (mentions, forwarding flags) is preserved.
+//
+// The returned message is a copy: neither quotedMsg nor replyContent is modified.
+//
+// Returns ErrUnsupportedReplyType if replyContent has no field that accepts a ContextInfo.
+//
+//	reply, err := cli.BuildReply(&evt.Info, evt.Message, &waE2E.Message{
+//		Conversation: proto.String("answering"),
+//	})
+func (cli *Client) BuildReply(quotedInfo *types.MessageInfo, quotedMsg, replyContent *waE2E.Message) (*waE2E.Message, error) {
+	if quotedInfo == nil || quotedMsg == nil || replyContent == nil {
+		return nil, errors.New("BuildReply: quotedInfo, quotedMsg and replyContent must all be non-nil")
+	}
+	reply := proto.Clone(replyContent).(*waE2E.Message)
+	if reply.Conversation != nil && reply.ExtendedTextMessage == nil {
+		text := reply.GetConversation()
+		reply.Conversation = nil
+		reply.ExtendedTextMessage = &waE2E.ExtendedTextMessage{Text: proto.String(text)}
+	}
+	ci := &waE2E.ContextInfo{
+		StanzaID:      proto.String(quotedInfo.ID),
+		Participant:   proto.String(cli.replyParticipant(quotedInfo).String()),
+		QuotedMessage: stripQuotedMessage(quotedMsg),
+	}
+	if err := attachQuotedContext(reply, ci); err != nil {
+		return nil, err
+	}
+	return reply, nil
+}
+
+func (cli *Client) replyParticipant(info *types.MessageInfo) types.JID {
+	if info.IsFromMe {
+		if info.Sender.Server == types.HiddenUserServer {
+			return cli.getOwnLID().ToNonAD()
+		}
+		return cli.getOwnID().ToNonAD()
+	}
+	return info.Sender.ToNonAD()
+}
+
+func stripQuotedMessage(msg *waE2E.Message) *waE2E.Message {
+	switch {
+	case msg.Conversation != nil:
+		return &waE2E.Message{Conversation: proto.String(msg.GetConversation())}
+	case msg.ExtendedTextMessage != nil:
+		et := clearNestedQuote(proto.Clone(msg.ExtendedTextMessage).(*waE2E.ExtendedTextMessage))
+		if extendedTextOnlyHasText(et) {
+			return &waE2E.Message{Conversation: proto.String(et.GetText())}
+		}
+		return &waE2E.Message{ExtendedTextMessage: et}
+	case msg.ImageMessage != nil:
+		return &waE2E.Message{ImageMessage: clearNestedQuote(proto.Clone(msg.ImageMessage).(*waE2E.ImageMessage))}
+	case msg.VideoMessage != nil:
+		return &waE2E.Message{VideoMessage: clearNestedQuote(proto.Clone(msg.VideoMessage).(*waE2E.VideoMessage))}
+	case msg.AudioMessage != nil:
+		return &waE2E.Message{AudioMessage: clearNestedQuote(proto.Clone(msg.AudioMessage).(*waE2E.AudioMessage))}
+	case msg.DocumentMessage != nil:
+		return &waE2E.Message{DocumentMessage: clearNestedQuote(proto.Clone(msg.DocumentMessage).(*waE2E.DocumentMessage))}
+	case msg.StickerMessage != nil:
+		return &waE2E.Message{StickerMessage: clearNestedQuote(proto.Clone(msg.StickerMessage).(*waE2E.StickerMessage))}
+	case msg.LocationMessage != nil:
+		return &waE2E.Message{LocationMessage: clearNestedQuote(proto.Clone(msg.LocationMessage).(*waE2E.LocationMessage))}
+	case msg.LiveLocationMessage != nil:
+		return &waE2E.Message{LiveLocationMessage: clearNestedQuote(proto.Clone(msg.LiveLocationMessage).(*waE2E.LiveLocationMessage))}
+	case msg.ContactMessage != nil:
+		return &waE2E.Message{ContactMessage: clearNestedQuote(proto.Clone(msg.ContactMessage).(*waE2E.ContactMessage))}
+	case msg.ContactsArrayMessage != nil:
+		return &waE2E.Message{ContactsArrayMessage: clearNestedQuote(proto.Clone(msg.ContactsArrayMessage).(*waE2E.ContactsArrayMessage))}
+	case msg.PollCreationMessage != nil:
+		return &waE2E.Message{PollCreationMessage: clearNestedQuote(proto.Clone(msg.PollCreationMessage).(*waE2E.PollCreationMessage))}
+	case msg.ButtonsMessage != nil:
+		return &waE2E.Message{ButtonsMessage: clearNestedQuote(proto.Clone(msg.ButtonsMessage).(*waE2E.ButtonsMessage))}
+	case msg.ListMessage != nil:
+		return &waE2E.Message{ListMessage: clearNestedQuote(proto.Clone(msg.ListMessage).(*waE2E.ListMessage))}
+	case msg.InteractiveMessage != nil:
+		return &waE2E.Message{InteractiveMessage: clearNestedQuote(proto.Clone(msg.InteractiveMessage).(*waE2E.InteractiveMessage))}
+	case msg.GroupInviteMessage != nil:
+		return &waE2E.Message{GroupInviteMessage: clearNestedQuote(proto.Clone(msg.GroupInviteMessage).(*waE2E.GroupInviteMessage))}
+	case msg.ProductMessage != nil:
+		return &waE2E.Message{ProductMessage: clearNestedQuote(proto.Clone(msg.ProductMessage).(*waE2E.ProductMessage))}
+	default:
+		return stripUnknownQuotedMessage(msg)
+	}
+}
+
+// stripUnknownQuotedMessage gives message types that stripQuotedMessage doesn't know about the same
+// treatment as the enumerated ones: the top-level MessageContextInfo (which carries the original
+// message secret) is dropped and the nested quote of whichever submessage holds a ContextInfo is cleared.
+func stripUnknownQuotedMessage(msg *waE2E.Message) *waE2E.Message {
+	stripped := proto.Clone(msg).(*waE2E.Message)
+	stripped.MessageContextInfo = nil
+	stripped.ProtoReflect().Range(func(fd protoreflect.FieldDescriptor, val protoreflect.Value) bool {
+		if fd.Kind() != protoreflect.MessageKind || fd.IsList() || fd.IsMap() {
+			return true
+		}
+		if sub, ok := val.Message().Interface().(interface {
+			GetContextInfo() *waE2E.ContextInfo
+		}); ok {
+			clearNestedQuote(sub)
+		}
+		return true
+	})
+	return stripped
+}
+
+func clearNestedQuote[T interface{ GetContextInfo() *waE2E.ContextInfo }](sub T) T {
+	if ci := sub.GetContextInfo(); ci != nil {
+		ci.QuotedMessage = nil
+	}
+	return sub
+}
+
+func extendedTextOnlyHasText(et *waE2E.ExtendedTextMessage) bool {
+	if et == nil || et.Text == nil {
+		return false
+	}
+	cp := proto.Clone(et).(*waE2E.ExtendedTextMessage)
+	cp.Text = nil
+	cp.ContextInfo = nil
+	return proto.Equal(cp, &waE2E.ExtendedTextMessage{})
+}
+
+func attachQuotedContext(msg *waE2E.Message, ci *waE2E.ContextInfo) error {
+	switch {
+	case msg.ExtendedTextMessage != nil:
+		msg.ExtendedTextMessage.ContextInfo = mergeQuotedCtx(msg.ExtendedTextMessage.ContextInfo, ci)
+	case msg.ImageMessage != nil:
+		msg.ImageMessage.ContextInfo = mergeQuotedCtx(msg.ImageMessage.ContextInfo, ci)
+	case msg.VideoMessage != nil:
+		msg.VideoMessage.ContextInfo = mergeQuotedCtx(msg.VideoMessage.ContextInfo, ci)
+	case msg.AudioMessage != nil:
+		msg.AudioMessage.ContextInfo = mergeQuotedCtx(msg.AudioMessage.ContextInfo, ci)
+	case msg.DocumentMessage != nil:
+		msg.DocumentMessage.ContextInfo = mergeQuotedCtx(msg.DocumentMessage.ContextInfo, ci)
+	case msg.StickerMessage != nil:
+		msg.StickerMessage.ContextInfo = mergeQuotedCtx(msg.StickerMessage.ContextInfo, ci)
+	case msg.LocationMessage != nil:
+		msg.LocationMessage.ContextInfo = mergeQuotedCtx(msg.LocationMessage.ContextInfo, ci)
+	case msg.LiveLocationMessage != nil:
+		msg.LiveLocationMessage.ContextInfo = mergeQuotedCtx(msg.LiveLocationMessage.ContextInfo, ci)
+	case msg.ContactMessage != nil:
+		msg.ContactMessage.ContextInfo = mergeQuotedCtx(msg.ContactMessage.ContextInfo, ci)
+	case msg.ContactsArrayMessage != nil:
+		msg.ContactsArrayMessage.ContextInfo = mergeQuotedCtx(msg.ContactsArrayMessage.ContextInfo, ci)
+	case msg.PollCreationMessage != nil:
+		msg.PollCreationMessage.ContextInfo = mergeQuotedCtx(msg.PollCreationMessage.ContextInfo, ci)
+	case msg.ButtonsMessage != nil:
+		msg.ButtonsMessage.ContextInfo = mergeQuotedCtx(msg.ButtonsMessage.ContextInfo, ci)
+	case msg.ListMessage != nil:
+		msg.ListMessage.ContextInfo = mergeQuotedCtx(msg.ListMessage.ContextInfo, ci)
+	case msg.InteractiveMessage != nil:
+		msg.InteractiveMessage.ContextInfo = mergeQuotedCtx(msg.InteractiveMessage.ContextInfo, ci)
+	case msg.GroupInviteMessage != nil:
+		msg.GroupInviteMessage.ContextInfo = mergeQuotedCtx(msg.GroupInviteMessage.ContextInfo, ci)
+	case msg.ProductMessage != nil:
+		msg.ProductMessage.ContextInfo = mergeQuotedCtx(msg.ProductMessage.ContextInfo, ci)
+	default:
+		return ErrUnsupportedReplyType
+	}
+	return nil
+}
+
+func mergeQuotedCtx(existing, incoming *waE2E.ContextInfo) *waE2E.ContextInfo {
+	if existing == nil {
+		return incoming
+	}
+	if existing.StanzaID == nil {
+		existing.StanzaID = incoming.StanzaID
+	}
+	if existing.Participant == nil {
+		existing.Participant = incoming.Participant
+	}
+	if existing.QuotedMessage == nil {
+		existing.QuotedMessage = incoming.QuotedMessage
+	}
+	return existing
 }
 
 const (

--- a/send.go
+++ b/send.go
@@ -621,7 +621,8 @@ func (cli *Client) BuildEdit(chat types.JID, id types.MessageID, newContent *waE
 //
 // quotedMsg is embedded as a stripped copy (principal content only, no nested quote chain), matching
 // what official WhatsApp clients do. Plain Conversation reply content is promoted to ExtendedTextMessage,
-// and any ContextInfo already set on replyContent (mentions, forwarding flags) is preserved.
+// and any ContextInfo already set on replyContent (mentions, forwarding flags) is preserved, except for
+// the quote fields themselves, which always point at quotedInfo/quotedMsg.
 //
 // The returned message is a copy: neither quotedMsg nor replyContent is modified.
 //
@@ -709,21 +710,30 @@ func stripQuotedMessage(msg *waE2E.Message) *waE2E.Message {
 // stripUnknownQuotedMessage gives message types that stripQuotedMessage doesn't know about the same
 // treatment as the enumerated ones: the top-level MessageContextInfo (which carries the original
 // message secret) is dropped and the nested quote of whichever submessage holds a ContextInfo is cleared.
+// FutureProofMessage wrappers (view once, ephemeral, document with caption, ...) are unwrapped, so the
+// message they carry is stripped too.
 func stripUnknownQuotedMessage(msg *waE2E.Message) *waE2E.Message {
 	stripped := proto.Clone(msg).(*waE2E.Message)
-	stripped.MessageContextInfo = nil
-	stripped.ProtoReflect().Range(func(fd protoreflect.FieldDescriptor, val protoreflect.Value) bool {
+	stripQuoteChain(stripped)
+	return stripped
+}
+
+func stripQuoteChain(msg *waE2E.Message) {
+	msg.MessageContextInfo = nil
+	msg.ProtoReflect().Range(func(fd protoreflect.FieldDescriptor, val protoreflect.Value) bool {
 		if fd.Kind() != protoreflect.MessageKind || fd.IsList() || fd.IsMap() {
 			return true
 		}
-		if sub, ok := val.Message().Interface().(interface {
-			GetContextInfo() *waE2E.ContextInfo
-		}); ok {
+		switch sub := val.Message().Interface().(type) {
+		case *waE2E.FutureProofMessage:
+			if sub.Message != nil {
+				stripQuoteChain(sub.Message)
+			}
+		case interface{ GetContextInfo() *waE2E.ContextInfo }:
 			clearNestedQuote(sub)
 		}
 		return true
 	})
-	return stripped
 }
 
 func clearNestedQuote[T interface{ GetContextInfo() *waE2E.ContextInfo }](sub T) T {
@@ -745,12 +755,26 @@ func extendedTextOnlyHasText(et *waE2E.ExtendedTextMessage) bool {
 
 func attachQuotedContext(msg *waE2E.Message, ci *waE2E.ContextInfo) error {
 	switch {
+	case msg.ViewOnceMessage.GetMessage() != nil:
+		return attachQuotedContext(msg.ViewOnceMessage.Message, ci)
+	case msg.ViewOnceMessageV2.GetMessage() != nil:
+		return attachQuotedContext(msg.ViewOnceMessageV2.Message, ci)
+	case msg.ViewOnceMessageV2Extension.GetMessage() != nil:
+		return attachQuotedContext(msg.ViewOnceMessageV2Extension.Message, ci)
+	case msg.LottieStickerMessage.GetMessage() != nil:
+		return attachQuotedContext(msg.LottieStickerMessage.Message, ci)
+	case msg.EphemeralMessage.GetMessage() != nil:
+		return attachQuotedContext(msg.EphemeralMessage.Message, ci)
+	case msg.DocumentWithCaptionMessage.GetMessage() != nil:
+		return attachQuotedContext(msg.DocumentWithCaptionMessage.Message, ci)
 	case msg.ExtendedTextMessage != nil:
 		msg.ExtendedTextMessage.ContextInfo = mergeQuotedCtx(msg.ExtendedTextMessage.ContextInfo, ci)
 	case msg.ImageMessage != nil:
 		msg.ImageMessage.ContextInfo = mergeQuotedCtx(msg.ImageMessage.ContextInfo, ci)
 	case msg.VideoMessage != nil:
 		msg.VideoMessage.ContextInfo = mergeQuotedCtx(msg.VideoMessage.ContextInfo, ci)
+	case msg.PtvMessage != nil:
+		msg.PtvMessage.ContextInfo = mergeQuotedCtx(msg.PtvMessage.ContextInfo, ci)
 	case msg.AudioMessage != nil:
 		msg.AudioMessage.ContextInfo = mergeQuotedCtx(msg.AudioMessage.ContextInfo, ci)
 	case msg.DocumentMessage != nil:
@@ -767,6 +791,12 @@ func attachQuotedContext(msg *waE2E.Message, ci *waE2E.ContextInfo) error {
 		msg.ContactsArrayMessage.ContextInfo = mergeQuotedCtx(msg.ContactsArrayMessage.ContextInfo, ci)
 	case msg.PollCreationMessage != nil:
 		msg.PollCreationMessage.ContextInfo = mergeQuotedCtx(msg.PollCreationMessage.ContextInfo, ci)
+	case msg.PollCreationMessageV2 != nil:
+		msg.PollCreationMessageV2.ContextInfo = mergeQuotedCtx(msg.PollCreationMessageV2.ContextInfo, ci)
+	case msg.PollCreationMessageV3 != nil:
+		msg.PollCreationMessageV3.ContextInfo = mergeQuotedCtx(msg.PollCreationMessageV3.ContextInfo, ci)
+	case msg.EventMessage != nil:
+		msg.EventMessage.ContextInfo = mergeQuotedCtx(msg.EventMessage.ContextInfo, ci)
 	case msg.ButtonsMessage != nil:
 		msg.ButtonsMessage.ContextInfo = mergeQuotedCtx(msg.ButtonsMessage.ContextInfo, ci)
 	case msg.ListMessage != nil:
@@ -783,18 +813,18 @@ func attachQuotedContext(msg *waE2E.Message, ci *waE2E.ContextInfo) error {
 	return nil
 }
 
+// mergeQuotedCtx keeps the unrelated parts of an existing ContextInfo (mentions, forwarding flags,
+// disappearing message settings, ...) but always replaces the quote itself, so building a reply out of
+// content that already quoted something points the new quote at the message actually being replied to.
 func mergeQuotedCtx(existing, incoming *waE2E.ContextInfo) *waE2E.ContextInfo {
 	if existing == nil {
 		return incoming
 	}
-	if existing.StanzaID == nil {
-		existing.StanzaID = incoming.StanzaID
-	}
-	if existing.Participant == nil {
-		existing.Participant = incoming.Participant
-	}
-	if existing.QuotedMessage == nil {
-		existing.QuotedMessage = incoming.QuotedMessage
+	existing.StanzaID = incoming.StanzaID
+	existing.Participant = incoming.Participant
+	existing.QuotedMessage = incoming.QuotedMessage
+	if incoming.RemoteJID != nil {
+		existing.RemoteJID = incoming.RemoteJID
 	}
 	return existing
 }

--- a/send_test.go
+++ b/send_test.go
@@ -1,0 +1,143 @@
+// Copyright (c) 2026 Tulir Asokan
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package whatsmeow
+
+import (
+	"errors"
+	"testing"
+
+	"google.golang.org/protobuf/proto"
+
+	"go.mau.fi/whatsmeow/proto/waE2E"
+	"go.mau.fi/whatsmeow/store"
+	"go.mau.fi/whatsmeow/types"
+)
+
+func nestedQuote() *waE2E.Message {
+	return &waE2E.Message{Conversation: proto.String("the message being quoted by the quoted message")}
+}
+
+func TestStripQuotedMessageKnownType(t *testing.T) {
+	original := &waE2E.Message{
+		ImageMessage: &waE2E.ImageMessage{
+			Caption: proto.String("hi"),
+			ContextInfo: &waE2E.ContextInfo{
+				StanzaID:      proto.String("OLDER"),
+				QuotedMessage: nestedQuote(),
+			},
+		},
+		MessageContextInfo: &waE2E.MessageContextInfo{MessageSecret: []byte("secret")},
+	}
+	stripped := stripQuotedMessage(original)
+	if stripped.MessageContextInfo != nil {
+		t.Error("stripped message still has MessageContextInfo")
+	}
+	if stripped.GetImageMessage().GetContextInfo().GetQuotedMessage() != nil {
+		t.Error("stripped message still has a nested quote")
+	}
+	if stripped.GetImageMessage().GetCaption() != "hi" {
+		t.Error("stripped message lost the image caption")
+	}
+	if original.MessageContextInfo == nil || original.GetImageMessage().GetContextInfo().GetQuotedMessage() == nil {
+		t.Error("stripQuotedMessage mutated the input message")
+	}
+}
+
+func TestStripQuotedMessageUnknownType(t *testing.T) {
+	original := &waE2E.Message{
+		EventMessage: &waE2E.EventMessage{
+			Name: proto.String("party"),
+			ContextInfo: &waE2E.ContextInfo{
+				StanzaID:      proto.String("OLDER"),
+				QuotedMessage: nestedQuote(),
+			},
+		},
+		MessageContextInfo: &waE2E.MessageContextInfo{MessageSecret: []byte("secret")},
+	}
+	stripped := stripQuotedMessage(original)
+	if stripped.MessageContextInfo != nil {
+		t.Error("stripped message still has MessageContextInfo")
+	}
+	if stripped.GetEventMessage().GetContextInfo().GetQuotedMessage() != nil {
+		t.Error("stripped message still has a nested quote")
+	}
+	if stripped.GetEventMessage().GetName() != "party" {
+		t.Error("stripped message lost the event name")
+	}
+	if stripped.GetEventMessage().GetContextInfo().GetStanzaID() != "OLDER" {
+		t.Error("stripped message lost the rest of the context info")
+	}
+	if original.MessageContextInfo == nil || original.GetEventMessage().GetContextInfo().GetQuotedMessage() == nil {
+		t.Error("stripQuotedMessage mutated the input message")
+	}
+}
+
+func TestStripQuotedMessageExtendedTextWithoutExtras(t *testing.T) {
+	stripped := stripQuotedMessage(&waE2E.Message{
+		ExtendedTextMessage: &waE2E.ExtendedTextMessage{
+			Text:        proto.String("meow"),
+			ContextInfo: &waE2E.ContextInfo{QuotedMessage: nestedQuote()},
+		},
+	})
+	if stripped.GetConversation() != "meow" {
+		t.Errorf("expected plain conversation, got %s", stripped.String())
+	}
+}
+
+func TestBuildReplyDoesNotMutateInput(t *testing.T) {
+	cli := &Client{Store: &store.Device{}}
+	quotedInfo := &types.MessageInfo{
+		ID: "QUOTED",
+		MessageSource: types.MessageSource{
+			Chat:   types.NewJID("12345", types.GroupServer),
+			Sender: types.NewJID("67890", types.DefaultUserServer),
+		},
+	}
+	quotedMsg := &waE2E.Message{
+		Conversation:       proto.String("original"),
+		MessageContextInfo: &waE2E.MessageContextInfo{MessageSecret: []byte("secret")},
+	}
+	replyContent := &waE2E.Message{Conversation: proto.String("answering")}
+	reply, err := cli.BuildReply(quotedInfo, quotedMsg, replyContent)
+	if err != nil {
+		t.Fatalf("BuildReply returned an error: %v", err)
+	}
+	if replyContent.GetConversation() != "answering" || replyContent.ExtendedTextMessage != nil {
+		t.Error("BuildReply mutated the reply content it was given")
+	}
+	if quotedMsg.MessageContextInfo == nil {
+		t.Error("BuildReply mutated the quoted message it was given")
+	}
+	ctxInfo := reply.GetExtendedTextMessage().GetContextInfo()
+	if reply.GetExtendedTextMessage().GetText() != "answering" {
+		t.Error("reply lost its text")
+	}
+	if ctxInfo.GetStanzaID() != "QUOTED" {
+		t.Errorf("unexpected stanza ID %s", ctxInfo.GetStanzaID())
+	}
+	if ctxInfo.GetParticipant() != "67890@s.whatsapp.net" {
+		t.Errorf("unexpected participant %s", ctxInfo.GetParticipant())
+	}
+	if ctxInfo.GetQuotedMessage().GetConversation() != "original" {
+		t.Error("reply doesn't quote the original message")
+	}
+	if ctxInfo.GetQuotedMessage().MessageContextInfo != nil {
+		t.Error("quoted message still has MessageContextInfo")
+	}
+}
+
+func TestBuildReplyUnsupportedType(t *testing.T) {
+	cli := &Client{Store: &store.Device{}}
+	_, err := cli.BuildReply(
+		&types.MessageInfo{ID: "QUOTED"},
+		&waE2E.Message{Conversation: proto.String("original")},
+		&waE2E.Message{ReactionMessage: &waE2E.ReactionMessage{Text: proto.String("🐈️")}},
+	)
+	if !errors.Is(err, ErrUnsupportedReplyType) {
+		t.Errorf("expected ErrUnsupportedReplyType, got %v", err)
+	}
+}

--- a/send_test.go
+++ b/send_test.go
@@ -130,6 +130,132 @@ func TestBuildReplyDoesNotMutateInput(t *testing.T) {
 	}
 }
 
+func TestStripQuotedMessageWrappedType(t *testing.T) {
+	original := &waE2E.Message{
+		ViewOnceMessageV2: &waE2E.FutureProofMessage{
+			Message: &waE2E.Message{
+				ImageMessage: &waE2E.ImageMessage{
+					Caption: proto.String("hi"),
+					ContextInfo: &waE2E.ContextInfo{
+						StanzaID:      proto.String("OLDER"),
+						QuotedMessage: nestedQuote(),
+					},
+				},
+				MessageContextInfo: &waE2E.MessageContextInfo{MessageSecret: []byte("inner secret")},
+			},
+		},
+		MessageContextInfo: &waE2E.MessageContextInfo{MessageSecret: []byte("secret")},
+	}
+	stripped := stripQuotedMessage(original)
+	inner := stripped.GetViewOnceMessageV2().GetMessage()
+	if stripped.MessageContextInfo != nil {
+		t.Error("stripped message still has MessageContextInfo")
+	}
+	if inner.MessageContextInfo != nil {
+		t.Error("wrapped message still has MessageContextInfo")
+	}
+	if inner.GetImageMessage().GetContextInfo().GetQuotedMessage() != nil {
+		t.Error("wrapped message still has a nested quote")
+	}
+	if inner.GetImageMessage().GetCaption() != "hi" {
+		t.Error("wrapped message lost the image caption")
+	}
+	if original.GetViewOnceMessageV2().GetMessage().MessageContextInfo == nil {
+		t.Error("stripQuotedMessage mutated the input message")
+	}
+}
+
+func TestBuildReplyToEventMessage(t *testing.T) {
+	cli := &Client{Store: &store.Device{}}
+	reply, err := cli.BuildReply(
+		&types.MessageInfo{
+			ID:            "QUOTED",
+			MessageSource: types.MessageSource{Sender: types.NewJID("67890", types.DefaultUserServer)},
+		},
+		&waE2E.Message{Conversation: proto.String("original")},
+		&waE2E.Message{EventMessage: &waE2E.EventMessage{Name: proto.String("party")}},
+	)
+	if err != nil {
+		t.Fatalf("BuildReply returned an error: %v", err)
+	}
+	ctxInfo := reply.GetEventMessage().GetContextInfo()
+	if ctxInfo.GetStanzaID() != "QUOTED" {
+		t.Errorf("unexpected stanza ID %s", ctxInfo.GetStanzaID())
+	}
+	if ctxInfo.GetQuotedMessage().GetConversation() != "original" {
+		t.Error("reply doesn't quote the original message")
+	}
+}
+
+func TestBuildReplyWithWrappedContent(t *testing.T) {
+	cli := &Client{Store: &store.Device{}}
+	reply, err := cli.BuildReply(
+		&types.MessageInfo{
+			ID:            "QUOTED",
+			MessageSource: types.MessageSource{Sender: types.NewJID("67890", types.DefaultUserServer)},
+		},
+		&waE2E.Message{Conversation: proto.String("original")},
+		&waE2E.Message{ViewOnceMessageV2: &waE2E.FutureProofMessage{
+			Message: &waE2E.Message{ImageMessage: &waE2E.ImageMessage{Caption: proto.String("look")}},
+		}},
+	)
+	if err != nil {
+		t.Fatalf("BuildReply returned an error: %v", err)
+	}
+	ctxInfo := reply.GetViewOnceMessageV2().GetMessage().GetImageMessage().GetContextInfo()
+	if ctxInfo.GetStanzaID() != "QUOTED" {
+		t.Errorf("unexpected stanza ID %s", ctxInfo.GetStanzaID())
+	}
+	if ctxInfo.GetQuotedMessage().GetConversation() != "original" {
+		t.Error("reply doesn't quote the original message")
+	}
+}
+
+func TestBuildReplyReplacesExistingQuote(t *testing.T) {
+	cli := &Client{Store: &store.Device{}}
+	replyContent := &waE2E.Message{ExtendedTextMessage: &waE2E.ExtendedTextMessage{
+		Text: proto.String("answering"),
+		ContextInfo: &waE2E.ContextInfo{
+			StanzaID:        proto.String("SOMETHING ELSE"),
+			Participant:     proto.String("11111@s.whatsapp.net"),
+			QuotedMessage:   &waE2E.Message{Conversation: proto.String("some other message")},
+			MentionedJID:    []string{"22222@s.whatsapp.net"},
+			IsForwarded:     proto.Bool(true),
+			ForwardingScore: proto.Uint32(3),
+		},
+	}}
+	reply, err := cli.BuildReply(
+		&types.MessageInfo{
+			ID:            "QUOTED",
+			MessageSource: types.MessageSource{Sender: types.NewJID("67890", types.DefaultUserServer)},
+		},
+		&waE2E.Message{Conversation: proto.String("original")},
+		replyContent,
+	)
+	if err != nil {
+		t.Fatalf("BuildReply returned an error: %v", err)
+	}
+	ctxInfo := reply.GetExtendedTextMessage().GetContextInfo()
+	if ctxInfo.GetStanzaID() != "QUOTED" {
+		t.Errorf("unexpected stanza ID %s", ctxInfo.GetStanzaID())
+	}
+	if ctxInfo.GetParticipant() != "67890@s.whatsapp.net" {
+		t.Errorf("unexpected participant %s", ctxInfo.GetParticipant())
+	}
+	if ctxInfo.GetQuotedMessage().GetConversation() != "original" {
+		t.Error("reply still quotes the message it quoted before")
+	}
+	if !ctxInfo.GetIsForwarded() || ctxInfo.GetForwardingScore() != 3 {
+		t.Error("reply lost the forwarding info it already had")
+	}
+	if len(ctxInfo.GetMentionedJID()) != 1 {
+		t.Error("reply lost the mentions it already had")
+	}
+	if replyContent.GetExtendedTextMessage().GetContextInfo().GetStanzaID() != "SOMETHING ELSE" {
+		t.Error("BuildReply mutated the reply content it was given")
+	}
+}
+
 func TestBuildReplyUnsupportedType(t *testing.T) {
 	cli := &Client{Store: &store.Device{}}
 	_, err := cli.BuildReply(


### PR DESCRIPTION
Adds BuildReply so callers stop hand-rolling the ContextInfo/QuotedMessage dance. It takes the quoted message's info and content plus the reply content, promotes a plain Conversation reply to ExtendedTextMessage, and attaches the quote context to whichever field of the reply accepts a ContextInfo, merging with any ContextInfo the caller already set.
Based on [https://github.com/tulir/whatsmeow/pull/1147](https://github.com/tulir/whatsmeow/pull/1147) by @jobasfernandes, with these changes:
- The stripQuotedMessage fallback returned a full clone of the quoted message, keeping its MessageContextInfo (which can carry the message secret) and any nested quote chain. It now drops MessageContextInfo and clears the nested quote through protoreflect, and unwraps FutureProofMessage wrappers (view once, ephemeral, document with caption, lottie sticker) to strip the message inside, since those don't have GetContextInfo and were leaking the chain.
- Inputs are worked on via proto.Clone instead of being mutated and returned.
- Re-quoting content that already carried a quote now replaces StanzaID/Participant/QuotedMessage instead of keeping the stale one; mentions and forwarding info in the existing ContextInfo are still kept.
- Event, PTV, v2/v3 poll and the FutureProofMessage wrappers are supported as reply content; anything else returns ErrUnsupportedReplyType.
- Tests for strip behaviour on known and unknown types, the no-mutation guarantee and the unsupported type error.
Happy to close this if @jobasfernandes prefers to fold these into #1147.
Verified with go build, go vet, go test -race ./... and staticcheck.
- I have read and followed the contributing guidelines at [https://docs.mau.fi/bridges/general/contributing.html](https://docs.mau.fi/bridges/general/contributing.html)