### PR TITLE
sqlstore: batch the mass insert paths into single queries

### DIFF
--- a/store/sqlstore/lidmap.go
+++ b/store/sqlstore/lidmap.go
@@ -45,8 +45,9 @@ func NewCachedLIDMap(db *dbutil.Database) *CachedLIDMap {
 }
 
 const (
-	deleteExistingLIDMappingQuery = `DELETE FROM whatsmeow_lid_map WHERE (lid<>$1 AND pn=$2)`
-	putLIDMappingQuery            = `
+	deleteExistingLIDMappingQuery  = `DELETE FROM whatsmeow_lid_map WHERE (lid<>$1 AND pn=$2)`
+	deleteExistingLIDMappingsQuery = `DELETE FROM whatsmeow_lid_map WHERE pn IN (%s) OR lid IN (%s)`
+	putLIDMappingQuery             = `
 		INSERT INTO whatsmeow_lid_map (lid, pn)
 		VALUES ($1, $2)
 		ON CONFLICT (lid) DO UPDATE SET pn=excluded.pn WHERE whatsmeow_lid_map.pn<>excluded.pn
@@ -54,6 +55,12 @@ const (
 	getLIDForPNQuery       = `SELECT lid FROM whatsmeow_lid_map WHERE pn=$1`
 	getPNForLIDQuery       = `SELECT pn FROM whatsmeow_lid_map WHERE lid=$1`
 	getAllLIDMappingsQuery = `SELECT lid, pn FROM whatsmeow_lid_map`
+)
+
+const lidMappingBatchSize = 400
+
+var putLIDMappingsMassInsertBuilder = dbutil.NewMassInsertBuilder[store.LIDMapping, [0]any](
+	putLIDMappingQuery, "($%d, $%d)",
 )
 
 var convertLIDRow = dbutil.ConvertRowFn[store.LIDMapping](func(rows dbutil.Scannable) (store.LIDMapping, error) {
@@ -230,15 +237,78 @@ func (s *CachedLIDMap) PutManyLIDMappings(ctx context.Context, mappings []store.
 	if len(mappings) == 0 {
 		return nil
 	}
-	return s.db.DoTxn(ctx, nil, func(ctx context.Context) error {
-		for _, mapping := range mappings {
-			err := s.unlockedPutLIDMapping(ctx, mapping.LID, mapping.PN)
+	inserts := dropSupersededLIDMappings(mappings)
+	err := s.db.DoTxn(ctx, nil, func(ctx context.Context) error {
+		for chunk := range slices.Chunk(mappings, lidMappingBatchSize) {
+			err := s.deleteExistingLIDMappings(ctx, chunk)
+			if err != nil {
+				return err
+			}
+		}
+		for chunk := range slices.Chunk(inserts, lidMappingBatchSize) {
+			query, vars := putLIDMappingsMassInsertBuilder.Build([0]any{}, chunk)
+			_, err := s.db.Exec(ctx, query, vars...)
 			if err != nil {
 				return err
 			}
 		}
 		return nil
 	})
+	if err != nil {
+		return err
+	}
+	for _, mapping := range mappings {
+		s.unlockedUpdateLIDCache(mapping.LID.User, mapping.PN.User)
+	}
+	return nil
+}
+
+// dropSupersededLIDMappings drops entries that a later entry in the list overrides by reusing either
+// the LID or the PN. A single mass insert can't apply two rows that conflict on the primary key or on
+// the unique PN column, while the per-row path this replaces would simply have overwritten the older
+// entry, so the overridden entries have to be removed before building the insert query.
+func dropSupersededLIDMappings(mappings []store.LIDMapping) []store.LIDMapping {
+	latestByLID := make(map[string]int, len(mappings))
+	latestByPN := make(map[string]int, len(mappings))
+	superseded := make([]bool, len(mappings))
+	for i, mapping := range mappings {
+		if prev, ok := latestByLID[mapping.LID.User]; ok {
+			superseded[prev] = true
+			delete(latestByPN, mappings[prev].PN.User)
+		}
+		if prev, ok := latestByPN[mapping.PN.User]; ok {
+			superseded[prev] = true
+			delete(latestByLID, mappings[prev].LID.User)
+		}
+		latestByLID[mapping.LID.User] = i
+		latestByPN[mapping.PN.User] = i
+	}
+	inserts := make([]store.LIDMapping, 0, len(mappings))
+	for i, mapping := range mappings {
+		if !superseded[i] {
+			inserts = append(inserts, mapping)
+		}
+	}
+	return inserts
+}
+
+// deleteExistingLIDMappings removes every row holding one of the given LIDs or PNs. Clearing both
+// columns is what makes the mass insert that follows equivalent to upserting the mappings one by one:
+// it can't hit the unique constraint on the PN column, and mappings that only appear as the old half
+// of a reassignment are dropped instead of being left behind pointing at the wrong side.
+func (s *CachedLIDMap) deleteExistingLIDMappings(ctx context.Context, mappings []store.LIDMapping) error {
+	pnPlaceholders := make([]string, len(mappings))
+	lidPlaceholders := make([]string, len(mappings))
+	vars := make([]any, len(mappings)*2)
+	for i, mapping := range mappings {
+		pnPlaceholders[i] = fmt.Sprintf("$%d", i+1)
+		lidPlaceholders[i] = fmt.Sprintf("$%d", len(mappings)+i+1)
+		vars[i] = mapping.PN.User
+		vars[len(mappings)+i] = mapping.LID.User
+	}
+	query := fmt.Sprintf(deleteExistingLIDMappingsQuery, strings.Join(pnPlaceholders, ","), strings.Join(lidPlaceholders, ","))
+	_, err := s.db.Exec(ctx, query, vars...)
+	return err
 }
 
 func (s *CachedLIDMap) unlockedPutLIDMapping(ctx context.Context, lid, pn types.JID) error {
@@ -253,15 +323,19 @@ func (s *CachedLIDMap) unlockedPutLIDMapping(ctx context.Context, lid, pn types.
 	if err != nil {
 		return err
 	}
-	oldLID := s.pnToLIDCache[pn.User]
-	oldPN := s.lidToPNCache[lid.User]
-	s.pnToLIDCache[pn.User] = lid.User
-	s.lidToPNCache[lid.User] = pn.User
-	if oldPN != "" && oldPN != pn.User && s.pnToLIDCache[oldPN] == lid.User {
+	s.unlockedUpdateLIDCache(lid.User, pn.User)
+	return nil
+}
+
+func (s *CachedLIDMap) unlockedUpdateLIDCache(lid, pn string) {
+	oldLID := s.pnToLIDCache[pn]
+	oldPN := s.lidToPNCache[lid]
+	s.pnToLIDCache[pn] = lid
+	s.lidToPNCache[lid] = pn
+	if oldPN != "" && oldPN != pn && s.pnToLIDCache[oldPN] == lid {
 		delete(s.pnToLIDCache, oldPN)
 	}
-	if oldLID != "" && oldLID != lid.User && s.lidToPNCache[oldLID] == pn.User {
+	if oldLID != "" && oldLID != lid && s.lidToPNCache[oldLID] == pn {
 		delete(s.lidToPNCache, oldLID)
 	}
-	return nil
 }

--- a/store/sqlstore/store.go
+++ b/store/sqlstore/store.go
@@ -166,6 +166,14 @@ type addressSessionTuple struct {
 	Session []byte
 }
 
+func (ast addressSessionTuple) GetMassInsertValues() [2]any {
+	return [...]any{ast.Address, ast.Session}
+}
+
+var putSessionsMassInsertBuilder = dbutil.NewMassInsertBuilder[addressSessionTuple, [1]any](
+	putSessionQuery, "($1, $%d, $%d)",
+)
+
 var sessionScanner = dbutil.ConvertRowFn[addressSessionTuple](func(row dbutil.Scannable) (out addressSessionTuple, err error) {
 	err = row.Scan(&out.Address, &out.Session)
 	return
@@ -204,10 +212,20 @@ func (s *SQLStore) GetManySessions(ctx context.Context, addresses []string) (map
 	return result, nil
 }
 
+const sessionBatchSize = 400
+
 func (s *SQLStore) PutManySessions(ctx context.Context, sessions map[string][]byte) error {
+	if len(sessions) == 0 {
+		return nil
+	}
+	tuples := make([]addressSessionTuple, 0, len(sessions))
+	for addr, sess := range sessions {
+		tuples = append(tuples, addressSessionTuple{Address: addr, Session: sess})
+	}
 	return s.db.DoTxn(ctx, nil, func(ctx context.Context) error {
-		for addr, sess := range sessions {
-			err := s.PutSession(ctx, addr, sess)
+		for slice := range slices.Chunk(tuples, sessionBatchSize) {
+			query, vars := putSessionsMassInsertBuilder.Build([1]any{s.JID}, slice)
+			_, err := s.db.Exec(ctx, query, vars...)
 			if err != nil {
 				return err
 			}
@@ -890,13 +908,20 @@ const (
 	`
 )
 
-func (s *SQLStore) PutMessageSecrets(ctx context.Context, inserts []store.MessageSecretInsert) (err error) {
+var putMsgSecretsMassInsertBuilder = dbutil.NewMassInsertBuilder[store.MessageSecretInsert, [1]any](
+	putMsgSecret, "($1, $%d, $%d, $%d, $%d)",
+)
+
+const msgSecretBatchSize = 200
+
+func (s *SQLStore) PutMessageSecrets(ctx context.Context, inserts []store.MessageSecretInsert) error {
 	if len(inserts) == 0 {
 		return nil
 	}
 	return s.db.DoTxn(ctx, nil, func(ctx context.Context) error {
-		for _, insert := range inserts {
-			_, err = s.db.Exec(ctx, putMsgSecret, s.JID, insert.Chat.ToNonAD(), insert.Sender.ToNonAD(), insert.ID, insert.Secret)
+		for slice := range slices.Chunk(inserts, msgSecretBatchSize) {
+			query, vars := putMsgSecretsMassInsertBuilder.Build([1]any{s.JID}, slice)
+			_, err := s.db.Exec(ctx, query, vars...)
 			if err != nil {
 				return err
 			}

--- a/store/store.go
+++ b/store/store.go
@@ -130,6 +130,10 @@ type MessageSecretInsert struct {
 	Secret []byte
 }
 
+func (msi MessageSecretInsert) GetMassInsertValues() [4]any {
+	return [...]any{msi.Chat.ToNonAD(), msi.Sender.ToNonAD(), msi.ID, msi.Secret}
+}
+
 type MsgSecretStore interface {
 	PutMessageSecrets(ctx context.Context, inserts []MessageSecretInsert) error
 	PutMessageSecret(ctx context.Context, chat, sender types.JID, id types.MessageID, secret []byte) error


### PR DESCRIPTION
PutManyLIDMappings, PutManySessions and PutMessageSecrets each ran one statement per row inside their transaction. PutManyLIDMappings is the worst: a DELETE and an upsert per mapping while holding the LID cache write lock, so one GetJoinedGroups call collecting mappings for every member of every group blocks GetLIDForPN/GetPNForLID, and with them incoming message handling, for the whole round-trip storm. That's [https://github.com/tulir/whatsmeow/issues/1004](https://github.com/tulir/whatsmeow/issues/1004). All three now build one statement per chunk with dbutil's MassInsertBuilder, like PutAllContactNames already does.
Based on [https://github.com/tulir/whatsmeow/pull/1101](https://github.com/tulir/whatsmeow/pull/1101) by @AlejoGarat, with these fixes:
- The DELETE step is batched too; leaving it per-row would keep most of the stall.
- Both the LID and the PN of every mapping in the batch are cleared before inserting, which is what makes one mass insert equivalent to upserting the mappings one at a time.
- Entries that a later entry in the same batch overrides are dropped, since a single INSERT can't apply two rows conflicting on lid or on pn (Postgres raises on that).
- The per-row cache bookkeeping is kept, including the stale reverse-entry cleanup on reassignment that the batched path had lost, and now runs after the transaction commits.
- Batch sizes stay under SQLite's 999 bind parameter limit.
The cache lock is still held for the whole call; narrowing it means the cache and the DB stop relying on the lock to stay in sync, which is a separate change.
Happy to close this if @AlejoGarat wants to take the fixes into #1101.
Verified with go build, go vet, go test -race ./... and staticcheck. Old and new implementations were compared on SQLite and Postgres 16 over several thousand randomized batches of conflicting mappings and end up with the same rows and the same cache contents.
- I have read and followed the contributing guidelines at [https://docs.mau.fi/bridges/general/contributing.html](https://docs.mau.fi/bridges/general/contributing.html)