### PR TITLE
message, retry: include error code in retry receipt

### DIFF
--- a/internals.go
+++ b/internals.go
@@ -695,8 +695,8 @@ func (int *DangerousInternalClient) ClearDelayedMessageRequests() {
 	int.c.clearDelayedMessageRequests()
 }
 
-func (int *DangerousInternalClient) SendRetryReceipt(ctx context.Context, node *waBinary.Node, info *types.MessageInfo, forceIncludeIdentity bool) {
-	int.c.sendRetryReceipt(ctx, node, info, forceIncludeIdentity)
+func (int *DangerousInternalClient) SendRetryReceipt(ctx context.Context, node *waBinary.Node, info *types.MessageInfo, forceIncludeIdentity bool, errorCode int) {
+	int.c.sendRetryReceipt(ctx, node, info, forceIncludeIdentity, errorCode)
 }
 
 func (int *DangerousInternalClient) SendNewsletter(ctx context.Context, to types.JID, id types.MessageID, message *waE2E.Message, mediaID string, timings *MessageDebugTimings) ([]byte, error) {

--- a/message.go
+++ b/message.go
@@ -412,16 +412,17 @@ func (cli *Client) decryptMessages(ctx context.Context, info *types.MessageInfo,
 				return
 			}
 			isUnavailable := encType == "skmsg" && !containsDirectMsg && errors.Is(err, signalerror.ErrNoSenderKeyForUser)
+			retryReason := getRetryReasonFromError(err)
 			if encType == "msmsg" {
 				cli.backgroundIfAsyncAck(func() {
 					cli.sendAck(ctx, node, NackMissingMessageSecret)
 				})
 			} else if cli.SynchronousAck {
-				cli.sendRetryReceipt(ctx, node, info, isUnavailable)
+				cli.sendRetryReceipt(ctx, node, info, isUnavailable, retryReason)
 				// TODO this probably isn't supposed to ack
 				cli.sendAck(ctx, node, 0)
 			} else {
-				go cli.sendRetryReceipt(context.WithoutCancel(ctx), node, info, isUnavailable)
+				go cli.sendRetryReceipt(context.WithoutCancel(ctx), node, info, isUnavailable, retryReason)
 				go cli.sendAck(ctx, node, 0)
 			}
 			cli.dispatchEvent(&events.UndecryptableMessage{

--- a/retry.go
+++ b/retry.go
@@ -20,6 +20,7 @@ import (
 	"go.mau.fi/libsignal/groups"
 	"go.mau.fi/libsignal/keys/prekey"
 	"go.mau.fi/libsignal/protocol"
+	"go.mau.fi/libsignal/signalerror"
 	"google.golang.org/protobuf/proto"
 
 	waBinary "go.mau.fi/whatsmeow/binary"
@@ -464,8 +465,53 @@ func (cli *Client) clearDelayedMessageRequests() {
 	}
 }
 
+// Retry reasons are sent to the server in the error attribute of retry receipts
+// to tell it why the message couldn't be decrypted.
+const (
+	RetryReasonUnknownError = iota
+	RetryReasonSignalErrorNoSession
+	RetryReasonSignalErrorInvalidKey
+	RetryReasonSignalErrorInvalidKeyID
+	RetryReasonSignalErrorInvalidMessage
+	RetryReasonSignalErrorInvalidSignature
+	RetryReasonSignalErrorFutureMessage
+	RetryReasonSignalErrorBadMac
+	RetryReasonSignalErrorInvalidSession
+	RetryReasonSignalErrorInvalidMsgKey
+	RetryReasonBadBroadcastEphemeralSetting
+	RetryReasonUnknownCompanionNoPrekey
+	RetryReasonAdvFailure
+	RetryReasonStatusRevokeDelay
+)
+
+func getRetryReasonFromError(err error) int {
+	switch {
+	case errors.Is(err, signalerror.ErrBadMAC):
+		return RetryReasonSignalErrorBadMac
+	case errors.Is(err, signalerror.ErrNoSessionForUser),
+		errors.Is(err, signalerror.ErrNoSenderKeyForUser):
+		return RetryReasonSignalErrorNoSession
+	case errors.Is(err, signalerror.ErrWrongMessageVersion),
+		errors.Is(err, signalerror.ErrOldMessageVersion),
+		errors.Is(err, signalerror.ErrUnknownMessageVersion),
+		errors.Is(err, signalerror.ErrIncompleteMessage):
+		return RetryReasonSignalErrorInvalidMessage
+	case errors.Is(err, signalerror.ErrInvalidSignature),
+		errors.Is(err, signalerror.ErrSenderKeyStateVerificationFailed):
+		return RetryReasonSignalErrorInvalidSignature
+	case errors.Is(err, signalerror.ErrNoSignedPreKey):
+		return RetryReasonSignalErrorInvalidKey
+	case errors.Is(err, signalerror.ErrNoSenderKeyStateForID):
+		return RetryReasonSignalErrorInvalidKeyID
+	case errors.Is(err, signalerror.ErrTooFarIntoFuture):
+		return RetryReasonSignalErrorFutureMessage
+	default:
+		return RetryReasonUnknownError
+	}
+}
+
 // sendRetryReceipt sends a retry receipt for an incoming message.
-func (cli *Client) sendRetryReceipt(ctx context.Context, node *waBinary.Node, info *types.MessageInfo, forceIncludeIdentity bool) {
+func (cli *Client) sendRetryReceipt(ctx context.Context, node *waBinary.Node, info *types.MessageInfo, forceIncludeIdentity bool, errorCode int) {
 	id, _ := node.Attrs["id"].(string)
 	children := node.GetChildren()
 	var retryCountInMsg int
@@ -501,16 +547,23 @@ func (cli *Client) sendRetryReceipt(ctx context.Context, node *waBinary.Node, in
 	if info.Type == "peer_msg" && info.IsFromMe {
 		attrs["category"] = "peer"
 	}
+
+	retryAttrs := waBinary.Attrs{
+		"count": retryCount,
+		"id":    id,
+		"t":     node.Attrs["t"],
+		"v":     1,
+	}
+
+	if errorCode != 0 {
+		retryAttrs["error"] = errorCode
+	}
+
 	payload := waBinary.Node{
 		Tag:   "receipt",
 		Attrs: attrs,
 		Content: []waBinary.Node{
-			{Tag: "retry", Attrs: waBinary.Attrs{
-				"count": retryCount,
-				"id":    id,
-				"t":     node.Attrs["t"],
-				"v":     1,
-			}},
+			{Tag: "retry", Attrs: retryAttrs},
 			{Tag: "registration", Content: registrationIDBytes[:]},
 		},
 	}

--- a/retry_test.go
+++ b/retry_test.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 Tulir Asokan
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package whatsmeow
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"go.mau.fi/libsignal/signalerror"
+)
+
+func TestGetRetryReasonFromError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{"nil", nil, RetryReasonUnknownError},
+		{"unrelated", errors.New("something else"), RetryReasonUnknownError},
+		{"bad mac", signalerror.ErrBadMAC, RetryReasonSignalErrorBadMac},
+		{"no session", signalerror.ErrNoSessionForUser, RetryReasonSignalErrorNoSession},
+		{"no sender key", signalerror.ErrNoSenderKeyForUser, RetryReasonSignalErrorNoSession},
+		{"wrong version", signalerror.ErrWrongMessageVersion, RetryReasonSignalErrorInvalidMessage},
+		{"old version", signalerror.ErrOldMessageVersion, RetryReasonSignalErrorInvalidMessage},
+		{"unknown version", signalerror.ErrUnknownMessageVersion, RetryReasonSignalErrorInvalidMessage},
+		{"incomplete message", signalerror.ErrIncompleteMessage, RetryReasonSignalErrorInvalidMessage},
+		{"invalid signature", signalerror.ErrInvalidSignature, RetryReasonSignalErrorInvalidSignature},
+		{"sender key verification", signalerror.ErrSenderKeyStateVerificationFailed, RetryReasonSignalErrorInvalidSignature},
+		{"no signed prekey", signalerror.ErrNoSignedPreKey, RetryReasonSignalErrorInvalidKey},
+		{"no sender key state", signalerror.ErrNoSenderKeyStateForID, RetryReasonSignalErrorInvalidKeyID},
+		{"too far into future", signalerror.ErrTooFarIntoFuture, RetryReasonSignalErrorFutureMessage},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := getRetryReasonFromError(test.err); got != test.want {
+				t.Errorf("getRetryReasonFromError(%v) = %d, want %d", test.err, got, test.want)
+			}
+			if test.err == nil {
+				return
+			}
+			wrapped := fmt.Errorf("failed to decrypt message: %w", test.err)
+			if got := getRetryReasonFromError(wrapped); got != test.want {
+				t.Errorf("getRetryReasonFromError(%v) = %d, want %d", wrapped, got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Classifies the decryption error and sends it as the error attribute of the retry receipt, so the server knows why the message couldn't be decrypted.
Based on [https://github.com/tulir/whatsmeow/pull/956](https://github.com/tulir/whatsmeow/pull/956) by @purpshell, with one fix: several cases in getRetryReasonFromError had empty bodies where comma-combined cases were meant, so ErrNoSessionForUser, the three message version errors and ErrInvalidSignature fell through to the unknown reason every time. The reason list is a const block now instead of mutable package vars, and there's a test covering the mapping.
Happy to close this if @purpshell wants to fix the switch in #956 instead.
Verified with go build, go vet, go test -race ./... and staticcheck.
- I have read and followed the contributing guidelines at [https://docs.mau.fi/bridges/general/contributing.html](https://docs.mau.fi/bridges/general/contributing.html)