### PR TITLE
group: parse membership request notifications

### DIFF
--- a/group.go
+++ b/group.go
@@ -823,7 +823,7 @@ func parseParticipantList(node *waBinary.Node) (participants []types.JID, lidPai
 	participants = make([]types.JID, 0, len(children))
 	for _, child := range children {
 		jid, ok := child.Attrs["jid"].(types.JID)
-		if child.Tag != "participant" || !ok {
+		if (child.Tag != "participant" && child.Tag != "membership_approval_request") || !ok {
 			continue
 		}
 		participants = append(participants, jid)
@@ -844,6 +844,20 @@ func parseParticipantList(node *waBinary.Node) (participants []types.JID, lidPai
 				})
 			}
 		}
+	}
+	return
+}
+
+// membershipRequestFallback returns the notification sender as the single membership requester.
+// Membership request notifications about a single user don't always repeat that user in a child
+// node, they only have it in the notification's own participant attribute.
+func membershipRequestFallback(sender, senderPN *types.JID) (participants []types.JID, lidPairs []store.LIDMapping) {
+	if sender == nil || sender.IsEmpty() {
+		return
+	}
+	participants = []types.JID{*sender}
+	if sender.Server == types.HiddenUserServer && senderPN != nil && !senderPN.IsEmpty() {
+		lidPairs = []store.LIDMapping{{LID: *sender, PN: *senderPN}}
 	}
 	return
 }
@@ -994,6 +1008,23 @@ func (cli *Client) parseGroupChange(node *waBinary.Node) (*events.GroupInfo, []s
 			evt.Suspended = true
 		case "unsuspended":
 			evt.Unsuspended = true
+		case "created_membership_requests":
+			if method := cag.OptionalString("request_method"); method != "" {
+				evt.MembershipRequestMethod = method
+			}
+			requesters, requestPairs := parseParticipantList(&child)
+			if len(requesters) == 0 {
+				requesters, requestPairs = membershipRequestFallback(evt.Sender, evt.SenderPN)
+			}
+			evt.MembershipRequestsCreated = append(evt.MembershipRequestsCreated, requesters...)
+			lidPairs = append(lidPairs, requestPairs...)
+		case "deleted_membership_requests", "revoked_membership_requests":
+			requesters, requestPairs := parseParticipantList(&child)
+			if len(requesters) == 0 {
+				requesters, requestPairs = membershipRequestFallback(evt.Sender, evt.SenderPN)
+			}
+			evt.MembershipRequestsRevoked = append(evt.MembershipRequestsRevoked, requesters...)
+			lidPairs = append(lidPairs, requestPairs...)
 		default:
 			evt.UnknownChanges = append(evt.UnknownChanges, &child)
 		}

--- a/group.go
+++ b/group.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 
 	waBinary "go.mau.fi/whatsmeow/binary"
 	"go.mau.fi/whatsmeow/store"
@@ -818,12 +819,12 @@ func parseGroupLinkTargetNode(groupNode *waBinary.Node) (types.GroupLinkTarget, 
 	}, ag.Error()
 }
 
-func parseParticipantList(node *waBinary.Node) (participants []types.JID, lidPairs []store.LIDMapping) {
+func parseParticipantList(node *waBinary.Node, extraTags ...string) (participants []types.JID, lidPairs []store.LIDMapping) {
 	children := node.GetChildren()
 	participants = make([]types.JID, 0, len(children))
 	for _, child := range children {
 		jid, ok := child.Attrs["jid"].(types.JID)
-		if (child.Tag != "participant" && child.Tag != "membership_approval_request") || !ok {
+		if !ok || (child.Tag != "participant" && !slices.Contains(extraTags, child.Tag)) {
 			continue
 		}
 		participants = append(participants, jid)
@@ -850,9 +851,11 @@ func parseParticipantList(node *waBinary.Node) (participants []types.JID, lidPai
 
 // membershipRequestFallback returns the notification sender as the single membership requester.
 // Membership request notifications about a single user don't always repeat that user in a child
-// node, they only have it in the notification's own participant attribute.
-func membershipRequestFallback(sender, senderPN *types.JID) (participants []types.JID, lidPairs []store.LIDMapping) {
-	if sender == nil || sender.IsEmpty() {
+// node, they only have it in the notification's own participant attribute. The sender is only the
+// requester for self-made requests: with request_method=non_admin_add the sender is the member who
+// added someone else.
+func membershipRequestFallback(sender, senderPN *types.JID, requestMethod string) (participants []types.JID, lidPairs []store.LIDMapping) {
+	if sender == nil || sender.IsEmpty() || (requestMethod != "" && requestMethod != "invite_link") {
 		return
 	}
 	participants = []types.JID{*sender}
@@ -1009,19 +1012,20 @@ func (cli *Client) parseGroupChange(node *waBinary.Node) (*events.GroupInfo, []s
 		case "unsuspended":
 			evt.Unsuspended = true
 		case "created_membership_requests":
-			if method := cag.OptionalString("request_method"); method != "" {
+			method := cag.OptionalString("request_method")
+			if method != "" {
 				evt.MembershipRequestMethod = method
 			}
-			requesters, requestPairs := parseParticipantList(&child)
+			requesters, requestPairs := parseParticipantList(&child, "membership_approval_request")
 			if len(requesters) == 0 {
-				requesters, requestPairs = membershipRequestFallback(evt.Sender, evt.SenderPN)
+				requesters, requestPairs = membershipRequestFallback(evt.Sender, evt.SenderPN, method)
 			}
 			evt.MembershipRequestsCreated = append(evt.MembershipRequestsCreated, requesters...)
 			lidPairs = append(lidPairs, requestPairs...)
 		case "deleted_membership_requests", "revoked_membership_requests":
-			requesters, requestPairs := parseParticipantList(&child)
+			requesters, requestPairs := parseParticipantList(&child, "membership_approval_request")
 			if len(requesters) == 0 {
-				requesters, requestPairs = membershipRequestFallback(evt.Sender, evt.SenderPN)
+				requesters, requestPairs = membershipRequestFallback(evt.Sender, evt.SenderPN, cag.OptionalString("request_method"))
 			}
 			evt.MembershipRequestsRevoked = append(evt.MembershipRequestsRevoked, requesters...)
 			lidPairs = append(lidPairs, requestPairs...)

--- a/types/events/events.go
+++ b/types/events/events.go
@@ -515,10 +515,15 @@ type GroupInfo struct {
 	Join  []types.JID // Users who joined or were added the group
 	Leave []types.JID // Users who left or were removed from the group
 
-	Promote        []types.JID // Users who were promoted to admins
-	Demote         []types.JID // Users who were demoted to normal users
-	Suspended      bool        // whether the group is suspended
-	Unsuspended    bool        // whether the group is unsuspended
+	Promote     []types.JID // Users who were promoted to admins
+	Demote      []types.JID // Users who were demoted to normal users
+	Suspended   bool        // whether the group is suspended
+	Unsuspended bool        // whether the group is unsuspended
+
+	MembershipRequestsCreated []types.JID // Users who created a membership request
+	MembershipRequestsRevoked []types.JID // Users whose membership request was revoked
+	MembershipRequestMethod   string      // How the membership request was created (invite_link, non_admin_add, etc.)
+
 	UnknownChanges []*waBinary.Node
 }
 


### PR DESCRIPTION
created_membership_requests and deleted/revoked_membership_requests notifications fell through to GroupInfo.UnknownChanges, so there was no way to react to a join request without polling GetGroupRequestParticipants. This adds MembershipRequestsCreated, MembershipRequestsRevoked and MembershipRequestMethod to events.GroupInfo and fills them from the notification, LID mappings included.
Based on [https://github.com/tulir/whatsmeow/pull/998](https://github.com/tulir/whatsmeow/pull/998) by @guilhermejansen, which no longer builds against main (undefined: strings). Differences:
- Instead of duplicating parseParticipantList into a near-identical parseMembershipRequestParticipants, parseParticipantList takes the extra accepted child tags as an opt-in argument, so only the membership request notifications pick up membership_approval_request children and add/remove/promote/demote are unaffected.
- The TrimSpace is dropped; OptionalString already returns "" when absent.
- The fallback to the notification sender as the requester only applies when request_method is empty or invite_link. For non_admin_add the sender is the member who added someone else, which would have put the wrong JID in MembershipRequestsCreated.
Happy to close this if @guilhermejansen prefers to rebase #998 with these changes.
Verified with go build, go vet, go test -race ./... and staticcheck.
- I have read and followed the contributing guidelines at [https://docs.mau.fi/bridges/general/contributing.html](https://docs.mau.fi/bridges/general/contributing.html)