### PR TITLE
store: add GetManyPNsForLIDs to LIDStore

### DIFF
--- a/store/noop.go
+++ b/store/noop.go
@@ -281,6 +281,10 @@ func (n *NoopStore) GetManyLIDsForPNs(ctx context.Context, pns []types.JID) (map
 	return nil, n.Error
 }
 
+func (n *NoopStore) GetManyPNsForLIDs(ctx context.Context, lids []types.JID) (map[types.JID]types.JID, error) {
+	return nil, n.Error
+}
+
 func (n *NoopStore) GetPNForLID(ctx context.Context, lid types.JID) (types.JID, error) {
 	return types.JID{}, n.Error
 }

--- a/store/sqlstore/lidmap.go
+++ b/store/sqlstore/lidmap.go
@@ -194,6 +194,65 @@ func (s *CachedLIDMap) GetManyLIDsForPNs(ctx context.Context, pns []types.JID) (
 	return result, err
 }
 
+func (s *CachedLIDMap) GetManyPNsForLIDs(ctx context.Context, lids []types.JID) (map[types.JID]types.JID, error) {
+	if len(lids) == 0 {
+		return nil, nil
+	}
+
+	result := make(map[types.JID]types.JID, len(lids))
+
+	s.lidCacheLock.RLock()
+	missingLIDs := make([]string, 0, len(lids))
+	missingLIDDevices := make(map[string][]types.JID)
+	for _, lid := range lids {
+		if lid.Server != types.HiddenUserServer {
+			continue
+		}
+		if pnUser, ok := s.lidToPNCache[lid.User]; ok && pnUser != "" {
+			result[lid] = types.JID{User: pnUser, Device: lid.Device, Server: types.DefaultUserServer}
+		} else if !s.cacheFilled {
+			missingLIDs = append(missingLIDs, lid.User)
+			missingLIDDevices[lid.User] = append(missingLIDDevices[lid.User], lid)
+		}
+	}
+	s.lidCacheLock.RUnlock()
+
+	if len(missingLIDs) == 0 {
+		return result, nil
+	}
+
+	s.lidCacheLock.Lock()
+	defer s.lidCacheLock.Unlock()
+
+	var res dbutil.RowIter[store.LIDMapping]
+	if s.db.Dialect == dbutil.Postgres && PostgresArrayWrapper != nil {
+		res = convertLIDRow.NewRowIter(s.db.Query(
+			ctx,
+			`SELECT lid, pn FROM whatsmeow_lid_map WHERE lid = ANY($1)`,
+			PostgresArrayWrapper(missingLIDs),
+		))
+	} else {
+		placeholders := make([]string, len(missingLIDs))
+		for i := range missingLIDs {
+			placeholders[i] = fmt.Sprintf("$%d", i+1)
+		}
+		res = convertLIDRow.NewRowIter(s.db.Query(
+			ctx,
+			fmt.Sprintf(`SELECT lid, pn FROM whatsmeow_lid_map WHERE lid IN (%s)`, strings.Join(placeholders, ",")),
+			exslices.CastToAny(missingLIDs)...,
+		))
+	}
+	err := s.scanManyLids(res, func(lid, pn string) {
+		for _, dev := range missingLIDDevices[lid] {
+			pnDev := dev
+			pnDev.Server = types.DefaultUserServer
+			pnDev.User = pn
+			result[dev] = pnDev
+		}
+	})
+	return result, err
+}
+
 func (s *CachedLIDMap) PutLIDMapping(ctx context.Context, lid, pn types.JID) error {
 	if lid.Server != types.HiddenUserServer || pn.Server != types.DefaultUserServer {
 		return fmt.Errorf("invalid PutLIDMapping call %s/%s", lid, pn)

--- a/store/sqlstore/lidmap.go
+++ b/store/sqlstore/lidmap.go
@@ -194,7 +194,7 @@ func (s *CachedLIDMap) GetManyLIDsForPNs(ctx context.Context, pns []types.JID) (
 	return result, err
 }
 
-const lidMappingBatchSize = 300
+const lidLookupBatchSize = 300
 
 func (s *CachedLIDMap) GetManyPNsForLIDs(ctx context.Context, lids []types.JID) (map[types.JID]types.JID, error) {
 	if len(lids) == 0 {
@@ -234,7 +234,7 @@ func (s *CachedLIDMap) GetManyPNsForLIDs(ctx context.Context, lids []types.JID) 
 			result[dev] = pnDev
 		}
 	}
-	for chunk := range slices.Chunk(missingLIDs, lidMappingBatchSize) {
+	for chunk := range slices.Chunk(missingLIDs, lidLookupBatchSize) {
 		var res dbutil.RowIter[store.LIDMapping]
 		if s.db.Dialect == dbutil.Postgres && PostgresArrayWrapper != nil {
 			res = convertLIDRow.NewRowIter(s.db.Query(

--- a/store/sqlstore/lidmap.go
+++ b/store/sqlstore/lidmap.go
@@ -194,6 +194,8 @@ func (s *CachedLIDMap) GetManyLIDsForPNs(ctx context.Context, pns []types.JID) (
 	return result, err
 }
 
+const lidMappingBatchSize = 300
+
 func (s *CachedLIDMap) GetManyPNsForLIDs(ctx context.Context, lids []types.JID) (map[types.JID]types.JID, error) {
 	if len(lids) == 0 {
 		return nil, nil
@@ -224,33 +226,39 @@ func (s *CachedLIDMap) GetManyPNsForLIDs(ctx context.Context, lids []types.JID) 
 	s.lidCacheLock.Lock()
 	defer s.lidCacheLock.Unlock()
 
-	var res dbutil.RowIter[store.LIDMapping]
-	if s.db.Dialect == dbutil.Postgres && PostgresArrayWrapper != nil {
-		res = convertLIDRow.NewRowIter(s.db.Query(
-			ctx,
-			`SELECT lid, pn FROM whatsmeow_lid_map WHERE lid = ANY($1)`,
-			PostgresArrayWrapper(missingLIDs),
-		))
-	} else {
-		placeholders := make([]string, len(missingLIDs))
-		for i := range missingLIDs {
-			placeholders[i] = fmt.Sprintf("$%d", i+1)
-		}
-		res = convertLIDRow.NewRowIter(s.db.Query(
-			ctx,
-			fmt.Sprintf(`SELECT lid, pn FROM whatsmeow_lid_map WHERE lid IN (%s)`, strings.Join(placeholders, ",")),
-			exslices.CastToAny(missingLIDs)...,
-		))
-	}
-	err := s.scanManyLids(res, func(lid, pn string) {
+	addToResult := func(lid, pn string) {
 		for _, dev := range missingLIDDevices[lid] {
 			pnDev := dev
 			pnDev.Server = types.DefaultUserServer
 			pnDev.User = pn
 			result[dev] = pnDev
 		}
-	})
-	return result, err
+	}
+	for chunk := range slices.Chunk(missingLIDs, lidMappingBatchSize) {
+		var res dbutil.RowIter[store.LIDMapping]
+		if s.db.Dialect == dbutil.Postgres && PostgresArrayWrapper != nil {
+			res = convertLIDRow.NewRowIter(s.db.Query(
+				ctx,
+				`SELECT lid, pn FROM whatsmeow_lid_map WHERE lid = ANY($1)`,
+				PostgresArrayWrapper(chunk),
+			))
+		} else {
+			placeholders := make([]string, len(chunk))
+			for i := range chunk {
+				placeholders[i] = fmt.Sprintf("$%d", i+1)
+			}
+			res = convertLIDRow.NewRowIter(s.db.Query(
+				ctx,
+				fmt.Sprintf(`SELECT lid, pn FROM whatsmeow_lid_map WHERE lid IN (%s)`, strings.Join(placeholders, ",")),
+				exslices.CastToAny(chunk)...,
+			))
+		}
+		err := s.scanManyLids(res, addToResult)
+		if err != nil {
+			return result, err
+		}
+	}
+	return result, nil
 }
 
 func (s *CachedLIDMap) PutLIDMapping(ctx context.Context, lid, pn types.JID) error {

--- a/store/store.go
+++ b/store/store.go
@@ -188,6 +188,7 @@ type LIDStore interface {
 	GetPNForLID(ctx context.Context, lid types.JID) (types.JID, error)
 	GetLIDForPN(ctx context.Context, pn types.JID) (types.JID, error)
 	GetManyLIDsForPNs(ctx context.Context, pns []types.JID) (map[types.JID]types.JID, error)
+	GetManyPNsForLIDs(ctx context.Context, lids []types.JID) (map[types.JID]types.JID, error)
 }
 
 type AllSessionSpecificStores interface {


### PR DESCRIPTION
Adds GetManyPNsForLIDs, the inverse of GetManyLIDsForPNs. Callers holding a list of LIDs (group participant lists, for example) had to fall back to one GetPNForLID query per JID.
Based on [https://github.com/tulir/whatsmeow/pull/974](https://github.com/tulir/whatsmeow/pull/974) by @MartinSchere, which was written against the old scanManyLids(dbutil.Rows, ...) signature and doesn't compile now that it takes a RowIter. Differences:
- Mirrors GetManyLIDsForPNs: the query is wrapped with convertLIDRow.NewRowIter.
- The resolved JID keeps the device ID instead of being reduced with ToNonAD(), matching both the sibling function and this function's own cache-hit path.
- Lookups are chunked at 300 LIDs so a large uncached input doesn't blow SQLite's bind parameter limit; results and cache updates are merged across chunks.
- The debug logging added to group.go and user.go is left out.
Happy to close this if @MartinSchere wants to update #974 instead.
Verified with go build, go vet, go test -race ./... and staticcheck.
- I have read and followed the contributing guidelines at [https://docs.mau.fi/bridges/general/contributing.html](https://docs.mau.fi/bridges/general/contributing.html)