### PR TITLE
status: allow specifying recipients for broadcast messages

### DIFF
--- a/broadcast.go
+++ b/broadcast.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 
 	waBinary "go.mau.fi/whatsmeow/binary"
 	"go.mau.fi/whatsmeow/types"
@@ -26,22 +27,22 @@ func (cli *Client) getBroadcastListParticipants(ctx context.Context, jid types.J
 	if err != nil {
 		return nil, err
 	}
+	return cli.ensureSelfInBroadcastList(list)
+}
+
+// ensureSelfInBroadcastList adds the user's own JID to the given recipient list if it's not there yet,
+// so that the user's other devices also receive the sender key and can decrypt the message.
+func (cli *Client) ensureSelfInBroadcastList(list []types.JID) ([]types.JID, error) {
 	ownID := cli.getOwnID().ToNonAD()
 	if ownID.IsEmpty() {
 		return nil, ErrNotLoggedIn
 	}
-
-	selfIndex := -1
-	for i, participant := range list {
+	for _, participant := range list {
 		if participant.User == ownID.User {
-			selfIndex = i
-			break
+			return list, nil
 		}
 	}
-	if selfIndex < 0 {
-		list = append(list, ownID)
-	}
-	return list, nil
+	return append(slices.Clone(list), ownID), nil
 }
 
 func (cli *Client) getStatusBroadcastRecipients(ctx context.Context) ([]types.JID, error) {

--- a/send.go
+++ b/send.go
@@ -156,6 +156,11 @@ type SendRequestExtra struct {
 	Meta *types.MsgMetaInfo
 	// use this only if you know what you are doing
 	AdditionalNodes *[]waBinary.Node
+	// The recipients to send to when sending to a broadcast server JID (e.g. a status message).
+	// If this is empty, the recipients of status messages are resolved from the status privacy
+	// settings, and other broadcast lists are not supported. Your own JID is always included in
+	// the recipients even if it's not in this list.
+	Participants []types.JID
 }
 
 // SendMessage sends the given message.
@@ -311,6 +316,11 @@ func (cli *Client) SendMessage(ctx context.Context, to types.JID, message *waE2E
 				ownID = cli.getOwnLID()
 				// Why is this set to PN?
 				extraParams.addressingMode = types.AddressingModePN
+			}
+		} else if len(req.Participants) > 0 {
+			groupParticipants, err = cli.ensureSelfInBroadcastList(req.Participants)
+			if err != nil {
+				return
 			}
 		} else {
 			groupParticipants, err = cli.getBroadcastListParticipants(ctx, to)


### PR DESCRIPTION
Adds SendRequestExtra.Participants so a status broadcast can go to an explicit recipient list instead of the one derived from the status privacy settings, for sending to a specific audience or in chunks.
Based on [https://github.com/tulir/whatsmeow/pull/800](https://github.com/tulir/whatsmeow/pull/800) by @devlikepro, with one fix: the sender's own JID is always added to the caller's list via a helper shared with getBroadcastListParticipants. Without it the sender's other devices never receive the sender key distribution message and can't decrypt the user's own status. The helper clones the slice before appending so the caller's slice isn't modified. Also resolved against the ctx parameter getBroadcastListParticipants gained since.
Happy to close this if @devlikepro wants to take the fix into #800.
Verified with go build, go vet, go test -race ./... and staticcheck.
- I have read and followed the contributing guidelines at [https://docs.mau.fi/bridges/general/contributing.html](https://docs.mau.fi/bridges/general/contributing.html)