### PR TITLE
store: add paginated contact queries to ContactStore

### DIFF
--- a/store/noop.go
+++ b/store/noop.go
@@ -193,6 +193,10 @@ func (n *NoopStore) GetAllContacts(ctx context.Context) (map[types.JID]types.Con
 	return nil, n.Error
 }
 
+func (n *NoopStore) GetContactsPage(ctx context.Context, limit, offset int) (*ContactPage, error) {
+	return nil, n.Error
+}
+
 func (n *NoopStore) PutMutedUntil(ctx context.Context, chat types.JID, mutedUntil time.Time) error {
 	return n.Error
 }

--- a/store/sqlstore/store.go
+++ b/store/sqlstore/store.go
@@ -604,6 +604,16 @@ const (
 	getAllContactsQuery = `
 		SELECT their_jid, first_name, full_name, push_name, business_name, redacted_phone FROM whatsmeow_contacts WHERE our_jid=$1
 	`
+	getContactsCountQuery = `
+		SELECT COUNT(*) FROM whatsmeow_contacts WHERE our_jid=$1
+	`
+	getContactsPageQuery = `
+		SELECT their_jid, first_name, full_name, push_name, business_name, redacted_phone
+		FROM whatsmeow_contacts
+		WHERE our_jid=$1
+		ORDER BY their_jid
+		LIMIT $2 OFFSET $3
+	`
 )
 
 var putContactNamesMassInsertBuilder = dbutil.NewMassInsertBuilder[store.ContactEntry, [1]any](
@@ -812,6 +822,44 @@ func (s *SQLStore) GetAllContacts(ctx context.Context) (map[types.JID]types.Cont
 		return true, nil
 	})
 	return output, err
+}
+
+func (s *SQLStore) GetContactsPage(ctx context.Context, limit, offset int) (*store.ContactPage, error) {
+	if limit < 1 {
+		return &store.ContactPage{Items: []store.ContactPageItem{}}, nil
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	var total int
+	err := s.db.QueryRow(ctx, getContactsCountQuery, s.JID).Scan(&total)
+	if err != nil {
+		return nil, err
+	}
+
+	page := &store.ContactPage{
+		Items: make([]store.ContactPageItem, 0, min(limit, total)),
+		Total: total,
+	}
+	if offset >= total {
+		return page, nil
+	}
+
+	s.contactCacheLock.Lock()
+	defer s.contactCacheLock.Unlock()
+	err = convertContactRow.NewRowIter(s.db.Query(ctx, getContactsPageQuery, s.JID, limit, offset)).Iter(func(tuple *contactTuple) (bool, error) {
+		page.Items = append(page.Items, store.ContactPageItem{
+			JID:  tuple.JID,
+			Info: *tuple.Info,
+		})
+		s.contactCache[tuple.JID] = tuple.Info
+		return true, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return page, nil
 }
 
 const (

--- a/store/store.go
+++ b/store/store.go
@@ -99,6 +99,16 @@ func (rpe RedactedPhoneEntry) GetMassInsertValues() [2]any {
 	return [...]any{rpe.JID.String(), rpe.RedactedPhone}
 }
 
+type ContactPageItem struct {
+	JID  types.JID
+	Info types.ContactInfo
+}
+
+type ContactPage struct {
+	Items []ContactPageItem
+	Total int
+}
+
 type ContactStore interface {
 	PutPushName(ctx context.Context, user types.JID, pushName string) (bool, string, error)
 	PutBusinessName(ctx context.Context, user types.JID, businessName string) (bool, string, error)
@@ -107,6 +117,7 @@ type ContactStore interface {
 	PutManyRedactedPhones(ctx context.Context, entries []RedactedPhoneEntry) error
 	GetContact(ctx context.Context, user types.JID) (types.ContactInfo, error)
 	GetAllContacts(ctx context.Context) (map[types.JID]types.ContactInfo, error)
+	GetContactsPage(ctx context.Context, limit, offset int) (*ContactPage, error)
 }
 
 var MutedForever = time.Date(9999, 12, 31, 23, 59, 59, 999999999, time.UTC)


### PR DESCRIPTION
Adds ContactStore.GetContactsPage: a COUNT plus a LIMIT/OFFSET select ordered by their_jid that populates the existing contact cache while iterating, so a caller showing one page of a very large contact list doesn't have to load all of it.
Based on [https://github.com/tulir/whatsmeow/pull/1175](https://github.com/tulir/whatsmeow/pull/1175) by @thiagohenrique7. The sqlite-backed tests and the direct github.com/mattn/go-sqlite3 cgo dependency they pulled in are dropped: the repo has no sqlstore test setup, the dependency would only exist for those tests, and the go.mod change had no matching go.sum entry so it didn't build. The query result is wrapped with the same NewRowIter form GetAllContacts uses.
Happy to close this if @thiagohenrique7 prefers to update #1175.
Verified with go build, go vet, go test -race ./... and staticcheck.
- I have read and followed the contributing guidelines at [https://docs.mau.fi/bridges/general/contributing.html](https://docs.mau.fi/bridges/general/contributing.html)