### PR TITLE
store/sqlstore: key app state mutation MACs by index instead of version

### DIFF
--- a/store/sqlstore/store.go
+++ b/store/sqlstore/store.go
@@ -480,7 +480,7 @@ const (
 	getAppStateVersionQuery                 = `SELECT version, hash FROM whatsmeow_app_state_version WHERE jid=$1 AND name=$2`
 	deleteAppStateVersionQuery              = `DELETE FROM whatsmeow_app_state_version WHERE jid=$1 AND name=$2`
 	putAppStateMutationMACsQuery            = `INSERT INTO whatsmeow_app_state_mutation_macs (jid, name, version, index_mac, value_mac) VALUES `
-	putAppStateMutationMACsUpsert           = ` ON CONFLICT (jid, name, index_mac) DO UPDATE SET version=excluded.version, value_mac=excluded.value_mac`
+	putAppStateMutationMACsUpsert           = ` ON CONFLICT (jid, name, index_mac) DO UPDATE SET version=excluded.version, value_mac=excluded.value_mac WHERE whatsmeow_app_state_mutation_macs.version <= excluded.version`
 	deleteAppStateMutationMACsQueryPostgres = `DELETE FROM whatsmeow_app_state_mutation_macs WHERE jid=$1 AND name=$2 AND index_mac=ANY($3::bytea[])`
 	deleteAppStateMutationMACsQueryGeneric  = `DELETE FROM whatsmeow_app_state_mutation_macs WHERE jid=$1 AND name=$2 AND index_mac IN `
 	getAppStateMutationMACQuery             = `SELECT value_mac FROM whatsmeow_app_state_mutation_macs WHERE jid=$1 AND name=$2 AND index_mac=$3`

--- a/store/sqlstore/store.go
+++ b/store/sqlstore/store.go
@@ -480,9 +480,10 @@ const (
 	getAppStateVersionQuery                 = `SELECT version, hash FROM whatsmeow_app_state_version WHERE jid=$1 AND name=$2`
 	deleteAppStateVersionQuery              = `DELETE FROM whatsmeow_app_state_version WHERE jid=$1 AND name=$2`
 	putAppStateMutationMACsQuery            = `INSERT INTO whatsmeow_app_state_mutation_macs (jid, name, version, index_mac, value_mac) VALUES `
+	putAppStateMutationMACsUpsert           = ` ON CONFLICT (jid, name, index_mac) DO UPDATE SET version=excluded.version, value_mac=excluded.value_mac`
 	deleteAppStateMutationMACsQueryPostgres = `DELETE FROM whatsmeow_app_state_mutation_macs WHERE jid=$1 AND name=$2 AND index_mac=ANY($3::bytea[])`
 	deleteAppStateMutationMACsQueryGeneric  = `DELETE FROM whatsmeow_app_state_mutation_macs WHERE jid=$1 AND name=$2 AND index_mac IN `
-	getAppStateMutationMACQuery             = `SELECT value_mac FROM whatsmeow_app_state_mutation_macs WHERE jid=$1 AND name=$2 AND index_mac=$3 ORDER BY version DESC LIMIT 1`
+	getAppStateMutationMACQuery             = `SELECT value_mac FROM whatsmeow_app_state_mutation_macs WHERE jid=$1 AND name=$2 AND index_mac=$3`
 )
 
 func (s *SQLStore) PutAppStateVersion(ctx context.Context, name string, version uint64, hash [128]byte) error {
@@ -531,16 +532,39 @@ func (s *SQLStore) putAppStateMutationMACs(ctx context.Context, name string, ver
 		values[baseIndex+1] = mutation.ValueMAC
 		queryParts[i] = fmt.Sprintf(placeholderSyntax, baseIndex+1, baseIndex+2)
 	}
-	_, err := s.db.Exec(ctx, putAppStateMutationMACsQuery+strings.Join(queryParts, ","), values...)
+	_, err := s.db.Exec(ctx, putAppStateMutationMACsQuery+strings.Join(queryParts, ",")+putAppStateMutationMACsUpsert, values...)
 	return err
 }
 
 const mutationBatchSize = 400
 
+// dedupeMutationMACs keeps only the last MAC for each index. A single patch can set the same
+// index twice, and the upsert in putAppStateMutationMACs can't touch the same row twice in one
+// statement (Postgres rejects it outright).
+func dedupeMutationMACs(mutations []store.AppStateMutationMAC) []store.AppStateMutationMAC {
+	indices := make(map[[32]byte]int, len(mutations))
+	out := make([]store.AppStateMutationMAC, 0, len(mutations))
+	for _, mutation := range mutations {
+		if len(mutation.IndexMAC) != 32 {
+			out = append(out, mutation)
+			continue
+		}
+		key := *(*[32]byte)(mutation.IndexMAC)
+		if i, ok := indices[key]; ok {
+			out[i] = mutation
+			continue
+		}
+		indices[key] = len(out)
+		out = append(out, mutation)
+	}
+	return out
+}
+
 func (s *SQLStore) PutAppStateMutationMACs(ctx context.Context, name string, version uint64, mutations []store.AppStateMutationMAC) error {
 	if len(mutations) == 0 {
 		return nil
 	}
+	mutations = dedupeMutationMACs(mutations)
 	return s.db.DoTxn(ctx, nil, func(ctx context.Context) error {
 		for slice := range slices.Chunk(mutations, mutationBatchSize) {
 			err := s.putAppStateMutationMACs(ctx, name, version, slice)

--- a/store/sqlstore/upgrades/00-latest-schema.sql
+++ b/store/sqlstore/upgrades/00-latest-schema.sql
@@ -1,4 +1,4 @@
--- v0 -> v15 (compatible with v8+): Latest schema
+-- v0 -> v16 (compatible with v8+): Latest schema
 CREATE TABLE whatsmeow_device (
 	jid TEXT PRIMARY KEY,
 	lid TEXT,
@@ -95,7 +95,7 @@ CREATE TABLE whatsmeow_app_state_mutation_macs (
 	index_mac bytea          CHECK ( length(index_mac) = 32 ),
 	value_mac bytea NOT NULL CHECK ( length(value_mac) = 32 ),
 
-	PRIMARY KEY (jid, name, version, index_mac),
+	PRIMARY KEY (jid, name, index_mac),
 	FOREIGN KEY (jid, name) REFERENCES whatsmeow_app_state_version(jid, name) ON DELETE CASCADE ON UPDATE CASCADE
 );
 

--- a/store/sqlstore/upgrades/16-app-state-mutation-mac-index.sql
+++ b/store/sqlstore/upgrades/16-app-state-mutation-mac-index.sql
@@ -1,0 +1,32 @@
+-- v16 (compatible with v8+): Only keep the latest MAC for each app state mutation index
+-- transaction: sqlite-fkey-off
+-- only: postgres until "end only"
+DELETE FROM whatsmeow_app_state_mutation_macs AS superseded
+USING whatsmeow_app_state_mutation_macs AS latest
+WHERE superseded.jid = latest.jid
+  AND superseded.name = latest.name
+  AND superseded.index_mac = latest.index_mac
+  AND superseded.version < latest.version;
+ALTER TABLE whatsmeow_app_state_mutation_macs DROP CONSTRAINT whatsmeow_app_state_mutation_macs_pkey;
+ALTER TABLE whatsmeow_app_state_mutation_macs ADD PRIMARY KEY (jid, name, index_mac);
+-- end only postgres
+-- only: sqlite until "end only"
+CREATE TABLE whatsmeow_app_state_mutation_macs_v16 (
+	jid       TEXT,
+	name      TEXT,
+	version   BIGINT,
+	index_mac bytea          CHECK ( length(index_mac) = 32 ),
+	value_mac bytea NOT NULL CHECK ( length(value_mac) = 32 ),
+
+	PRIMARY KEY (jid, name, index_mac),
+	FOREIGN KEY (jid, name) REFERENCES whatsmeow_app_state_version(jid, name) ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO whatsmeow_app_state_mutation_macs_v16 (jid, name, version, index_mac, value_mac)
+SELECT jid, name, version, index_mac, value_mac
+FROM (
+	SELECT *, ROW_NUMBER() OVER (PARTITION BY jid, name, index_mac ORDER BY version DESC) AS rn
+	FROM whatsmeow_app_state_mutation_macs
+) WHERE rn = 1;
+DROP TABLE whatsmeow_app_state_mutation_macs;
+ALTER TABLE whatsmeow_app_state_mutation_macs_v16 RENAME TO whatsmeow_app_state_mutation_macs;
+-- end only sqlite


### PR DESCRIPTION
The whatsmeow_app_state_mutation_macs primary key included the app state version, so every patch for an already-known index inserted another row and nothing cleaned the old ones up; a session with 48k contacts had 4.3M rows for 102k distinct indexes. The key is now (jid, name, index_mac) with an upsert, the lookup drops its ORDER BY version DESC LIMIT 1, and upgrade 16 dedupes existing rows and swaps the key (Postgres deletes superseded rows and swaps the constraint, SQLite rebuilds the table with foreign keys disabled for the swap).
Based on [https://github.com/tulir/whatsmeow/pull/1240](https://github.com/tulir/whatsmeow/pull/1240) by @Elimeshi1, with two fixes:
- The Postgres self-join aliases are "superseded" and "latest" instead of "old" and "new", which Postgres 18 gives special meaning to in RETURNING.
- The DO UPDATE is guarded with a version check so a write only lands when it's at least as new as the stored row. With the version gone from the key the upsert alone decides which MAC survives, and an unconditional one lets a replayed or out-of-order older patch clobber a newer MAC that the next encode then reads. Equal versions still overwrite, so replays of the same patch and same-index duplicates within one batch behave as before. The clause has no placeholders, so the generated VALUES numbering is untouched.
Happy to close this if @Elimeshi1 wants to take both into #1240.
Verified with go build, go vet, go test -race ./... and staticcheck. The full upgrade table was run against Postgres 16 and SQLite: fresh install reaches v16 on both, a seeded v15 database with duplicate index rows collapses to one row per index keeping the highest version, the foreign key cascade from whatsmeow_app_state_version survives the SQLite rebuild, and an older-version write leaves the newer MAC in place, including a 1000-mutation multi-chunk batch replayed at a lower version.
- I have read and followed the contributing guidelines at [https://docs.mau.fi/bridges/general/contributing.html](https://docs.mau.fi/bridges/general/contributing.html)