### PR TITLE
binary: don't panic on malformed nodes

### DIFF
--- a/binary/decoder.go
+++ b/binary/decoder.go
@@ -109,7 +109,7 @@ func (r *binaryDecoder) readPacked8(tag int) (string, error) {
 	}
 
 	ret := build.String()
-	if startByte>>7 != 0 {
+	if startByte>>7 != 0 && len(ret) > 0 {
 		ret = ret[:len(ret)-1]
 	}
 	return ret, nil
@@ -232,10 +232,19 @@ func (r *binaryDecoder) readJIDPair() (any, error) {
 		return nil, err
 	} else if server == nil {
 		return nil, ErrInvalidJIDType
-	} else if user == nil {
-		return types.NewJID("", server.(string)), nil
 	}
-	return types.NewJID(user.(string), server.(string)), nil
+	serverStr, ok := server.(string)
+	if !ok {
+		return nil, ErrInvalidJIDType
+	}
+	if user == nil {
+		return types.NewJID("", serverStr), nil
+	}
+	userStr, ok := user.(string)
+	if !ok {
+		return nil, ErrInvalidJIDType
+	}
+	return types.NewJID(userStr, serverStr), nil
 }
 
 func (r *binaryDecoder) readInteropJID() (any, error) {
@@ -257,8 +266,12 @@ func (r *binaryDecoder) readInteropJID() (any, error) {
 	} else if server != types.InteropServer {
 		return nil, fmt.Errorf("%w: expected %q, got %q", ErrInvalidJIDType, types.InteropServer, server)
 	}
+	userStr, ok := user.(string)
+	if !ok {
+		return nil, ErrInvalidJIDType
+	}
 	return types.JID{
-		User:       user.(string),
+		User:       userStr,
 		Device:     uint16(device),
 		Integrator: uint16(integrator),
 		Server:     types.InteropServer,
@@ -280,10 +293,14 @@ func (r *binaryDecoder) readFBJID() (any, error) {
 	} else if server != types.MessengerServer {
 		return nil, fmt.Errorf("%w: expected %q, got %q", ErrInvalidJIDType, types.MessengerServer, server)
 	}
+	userStr, ok := user.(string)
+	if !ok {
+		return nil, ErrInvalidJIDType
+	}
 	return types.JID{
-		User:   user.(string),
+		User:   userStr,
 		Device: uint16(device),
-		Server: server.(string),
+		Server: types.MessengerServer,
 	}, nil
 }
 
@@ -300,7 +317,11 @@ func (r *binaryDecoder) readADJID() (any, error) {
 	if err != nil {
 		return nil, err
 	}
-	return types.NewADJID(user.(string), agent, device), nil
+	userStr, ok := user.(string)
+	if !ok {
+		return nil, ErrInvalidJIDType
+	}
+	return types.NewADJID(userStr, agent, device), nil
 }
 
 func (r *binaryDecoder) readAttributes(n int) (Attrs, error) {
@@ -365,7 +386,11 @@ func (r *binaryDecoder) readNode() (*Node, error) {
 	if err != nil {
 		return nil, err
 	}
-	ret.Tag = rawDesc.(string)
+	tag, ok := rawDesc.(string)
+	if !ok {
+		return nil, ErrInvalidNode
+	}
+	ret.Tag = tag
 	if listSize == 0 || ret.Tag == "" {
 		return nil, ErrInvalidNode
 	}

--- a/binary/decoder.go
+++ b/binary/decoder.go
@@ -9,13 +9,19 @@ import (
 	"go.mau.fi/whatsmeow/types"
 )
 
+// maxDecodeDepth caps how many nested values the decoder descends into. The
+// wire format lets a frame nest a value inside itself for as many bytes as it
+// has, and a stack overflow is a fatal error that recover can't catch.
+const maxDecodeDepth = 256
+
 type binaryDecoder struct {
 	data  []byte
 	index int
+	depth int
 }
 
 func newDecoder(data []byte) *binaryDecoder {
-	return &binaryDecoder{data, 0}
+	return &binaryDecoder{data: data}
 }
 
 func (r *binaryDecoder) checkEOS(length int) error {
@@ -166,6 +172,16 @@ func (r *binaryDecoder) readListSize(tag int) (int, error) {
 }
 
 func (r *binaryDecoder) read(string bool) (any, error) {
+	if r.depth >= maxDecodeDepth {
+		return nil, fmt.Errorf("%w at position %d", ErrNodeTooDeep, r.index)
+	}
+	r.depth++
+	val, err := r.readValue(string)
+	r.depth--
+	return val, err
+}
+
+func (r *binaryDecoder) readValue(string bool) (any, error) {
 	tagByte, err := r.readByte()
 	if err != nil {
 		return nil, err

--- a/binary/decoder_test.go
+++ b/binary/decoder_test.go
@@ -1,0 +1,141 @@
+// Copyright (c) 2026 Tulir Asokan
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package binary_test
+
+import (
+	"reflect"
+	"testing"
+
+	"go.mau.fi/whatsmeow/binary"
+	"go.mau.fi/whatsmeow/types"
+)
+
+// TestMarshalUnmarshalRoundTrip verifies that the hardened decoder still decodes
+// valid nodes correctly: a node with attributes (including a JID, which exercises
+// the JIDPair reader) and nested content round-trips back to an equal value.
+func TestMarshalUnmarshalRoundTrip(t *testing.T) {
+	original := binary.Node{
+		Tag: "iq",
+		Attrs: binary.Attrs{
+			"id":   "abc",
+			"type": "result",
+			"from": types.NewJID("12345", types.DefaultUserServer),
+		},
+		Content: []binary.Node{
+			{Tag: "body", Content: []byte("hi")},
+		},
+	}
+	marshaled, err := binary.Marshal(original)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+	unpacked, err := binary.Unpack(marshaled)
+	if err != nil {
+		t.Fatalf("Unpack failed: %v", err)
+	}
+	decoded, err := binary.Unmarshal(unpacked)
+	if err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if !reflect.DeepEqual(*decoded, original) {
+		t.Errorf("round trip mismatch:\n original = %+v\n decoded  = %+v", original, *decoded)
+	}
+}
+
+// TestUnmarshalMalformedInputDoesNotPanic feeds the decoder binary nodes that are
+// well-formed enough to start decoding but contain a token of the wrong type where
+// a string is required (e.g. a list token in the node tag or JID user position).
+//
+// A malformed or malicious frame from the server must never crash the client, so
+// Unmarshal must return an error for all of these rather than panicking.
+func TestUnmarshalMalformedInputDoesNotPanic(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []byte
+	}{
+		// List8 node, size 1, tag token = ListEmpty -> read returns nil -> tag.(string)
+		{"node tag is nil", []byte{248, 1, 0}},
+		// List8 node, size 1, tag token = Nibble8 packed string with high bit set but length 0
+		{"empty packed-string tag", []byte{248, 1, 255, 128}},
+		// node "a" whose content is a JIDPair whose user sub-token is an empty list
+		{"jidpair user is a list", []byte{248, 2, 252, 1, 97, 250, 248, 0, 252, 1, 115}},
+		// node "a" whose content is a JIDPair whose user is empty and server is a list
+		{"jidpair server is a list", []byte{248, 2, 252, 1, 97, 250, 0, 248, 0}},
+		// node "a" whose content is an ADJID whose user sub-token is an empty list
+		{"adjid user is a list", []byte{248, 2, 252, 1, 97, 247, 1, 1, 248, 0}},
+		// node "a" whose content is an FBJID (server "msgr") whose user is an empty list
+		{"fbjid user is a list", []byte{248, 2, 252, 1, 97, 246, 248, 0, 0, 0, 252, 4, 109, 115, 103, 114}},
+		// node "a" whose content is an InteropJID (server "interop") whose user is an empty list
+		{"interopjid user is a list", []byte{248, 2, 252, 1, 97, 245, 248, 0, 0, 0, 0, 0, 252, 7, 105, 110, 116, 101, 114, 111, 112}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("Unmarshal panicked on malformed input: %v", r)
+				}
+			}()
+			if _, err := binary.Unmarshal(tc.input); err == nil {
+				t.Error("expected an error for malformed input, got nil")
+			}
+		})
+	}
+}
+
+// TestUnpackEmptyInputDoesNotPanic ensures Unpack returns an error instead of
+// panicking when given an empty payload (it reads the first byte as a flags byte).
+func TestUnpackEmptyInputDoesNotPanic(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []byte
+	}{
+		{"nil", nil},
+		{"empty", []byte{}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("Unpack panicked on empty input: %v", r)
+				}
+			}()
+			if _, err := binary.Unpack(tc.input); err == nil {
+				t.Error("expected an error for empty input, got nil")
+			}
+		})
+	}
+}
+
+// TestUnmarshalTruncatedInputDoesNotPanic feeds the decoder frames that are cut
+// off partway through a token, which is what a short or corrupted read from the
+// socket looks like. Every read must hit the end-of-stream check and return an
+// error instead of indexing past the buffer.
+func TestUnmarshalTruncatedInputDoesNotPanic(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []byte
+	}{
+		{"empty", []byte{}},
+		{"list8 without size", []byte{248}},
+		{"node without content", []byte{248, 2, 252, 1, 97}},
+		{"node tag shorter than declared length", []byte{248, 2, 252, 3, 97}},
+		{"packed string tag shorter than declared length", []byte{248, 2, 255, 3, 0}},
+		{"jidpair without server", []byte{248, 2, 252, 1, 97, 250, 252, 1, 98}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("Unmarshal panicked on truncated input: %v", r)
+				}
+			}()
+			if _, err := binary.Unmarshal(tc.input); err == nil {
+				t.Error("expected an error for truncated input, got nil")
+			}
+		})
+	}
+}

--- a/binary/decoder_test.go
+++ b/binary/decoder_test.go
@@ -7,6 +7,8 @@
 package binary_test
 
 import (
+	"bytes"
+	"errors"
 	"reflect"
 	"testing"
 
@@ -137,5 +139,60 @@ func TestUnmarshalTruncatedInputDoesNotPanic(t *testing.T) {
 				t.Error("expected an error for truncated input, got nil")
 			}
 		})
+	}
+}
+
+// TestUnmarshalDeeplyNestedInputDoesNotOverflowStack feeds the decoder frames
+// that nest a value inside itself for the whole length of the frame. Both stay
+// well under socket.FrameMaxSize, but before the depth limit they drove the
+// decoder millions of levels deep and killed the process with a stack overflow,
+// which is a fatal error that the recover in the read loop cannot catch.
+func TestUnmarshalDeeplyNestedInputDoesNotOverflowStack(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []byte
+	}{
+		// List8 node of size 2, tag token 1, content = List8 of size 1 -> next node
+		{"nested nodes", bytes.Repeat([]byte{248, 2, 1, 248, 1}, 2_500_000)},
+		// List8 node of size 2, tag token 1, content = JIDPair whose user is
+		// another JIDPair, and so on
+		{"nested jidpairs", append([]byte{248, 2, 1}, bytes.Repeat([]byte{250}, 2_500_000)...)},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("Unmarshal panicked on deeply nested input: %v", r)
+				}
+			}()
+			_, err := binary.Unmarshal(tc.input)
+			if !errors.Is(err, binary.ErrNodeTooDeep) {
+				t.Errorf("expected ErrNodeTooDeep, got %v", err)
+			}
+		})
+	}
+}
+
+// TestUnmarshalNestingWithinLimit ensures the depth limit doesn't reject nodes
+// that are nested far deeper than any real stanza but still within the cap.
+func TestUnmarshalNestingWithinLimit(t *testing.T) {
+	node := binary.Node{Tag: "leaf", Content: []byte("hi")}
+	for i := 0; i < 200; i++ {
+		node = binary.Node{Tag: "iq", Content: []binary.Node{node}}
+	}
+	marshaled, err := binary.Marshal(node)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+	unpacked, err := binary.Unpack(marshaled)
+	if err != nil {
+		t.Fatalf("Unpack failed: %v", err)
+	}
+	decoded, err := binary.Unmarshal(unpacked)
+	if err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if !reflect.DeepEqual(*decoded, node) {
+		t.Error("deeply nested node did not round trip")
 	}
 }

--- a/binary/errors.go
+++ b/binary/errors.go
@@ -9,4 +9,5 @@ var (
 	ErrInvalidNode    = errors.New("invalid node")
 	ErrInvalidToken   = errors.New("invalid token with tag")
 	ErrNonStringKey   = errors.New("non-string key")
+	ErrNodeTooDeep    = errors.New("too many nested nodes")
 )

--- a/binary/fuzz_test.go
+++ b/binary/fuzz_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 Tulir Asokan
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package binary_test
+
+import (
+	"testing"
+
+	"go.mau.fi/whatsmeow/binary"
+)
+
+// FuzzUnmarshal asserts the decoder never panics on arbitrary input: a malformed
+// or malicious frame from the server must always produce an error, never a crash.
+func FuzzUnmarshal(f *testing.F) {
+	seeds := [][]byte{
+		{248, 1, 0},
+		{248, 1, 255, 128},
+		{248, 2, 252, 1, 97, 250, 248, 0, 252, 1, 115},
+		{248, 2, 252, 1, 97, 247, 1, 1, 248, 0},
+		{248, 2, 252, 1, 97, 246, 248, 0, 0, 0, 252, 4, 109, 115, 103, 114},
+		{0},
+		{},
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, data []byte) {
+		_, _ = binary.Unmarshal(data)
+	})
+}
+
+// FuzzUnpack asserts Unpack never panics on arbitrary input.
+func FuzzUnpack(f *testing.F) {
+	for _, s := range [][]byte{{}, {0}, {1}, {2, 1, 2, 3}, {3, 4, 5}} {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, data []byte) {
+		_, _ = binary.Unpack(data)
+	})
+}

--- a/binary/unpack.go
+++ b/binary/unpack.go
@@ -19,6 +19,9 @@ import (
 // (without the first byte). There's currently no corresponding Pack function because Marshal
 // already returns the data with a leading zero (i.e. not compressed).
 func Unpack(data []byte) ([]byte, error) {
+	if len(data) == 0 {
+		return nil, io.ErrUnexpectedEOF
+	}
 	dataType, data := data[0], data[1:]
 	if 2&dataType > 0 {
 		if decompressor, err := zlib.NewReader(bytes.NewReader(data)); err != nil {


### PR DESCRIPTION
The node decoder had several unchecked type assertions and one unguarded slice expression that a single malformed frame could reach, and consumeFrames in socket/noisesocket.go has no recover(), so one bad frame from a buggy or hostile relay takes the whole process down. They now return ErrInvalidJIDType / ErrInvalidNode, and Unpack rejects empty input.
Based on [https://github.com/tulir/whatsmeow/pull/1160](https://github.com/tulir/whatsmeow/pull/1160) by @ThiagoBauken, plus:
- A truncated-input test covering frames cut off mid-token (short list header, short node tag, JID pair missing its server), which the original tests didn't exercise, and MPL headers on the new test files.
- A recursion depth cap. readNode and read recurse into each other unbounded, so a frame that nests a value inside itself for its whole length (a node whose only content is a list holding the next node, or a JIDPair whose user token is another JIDPair) goes as deep as it has bytes. A ~12.5 MB frame of either fits under socket.FrameMaxSize and blows the goroutine stack, which is fatal error: stack overflow, not a panic, so no recover() can catch it. The decoder now returns ErrNodeTooDeep past 256 levels; real stanzas are a handful of levels deep.
Happy to close this if @ThiagoBauken wants to add these to #1160.
Verified with go build, go vet, go test -race ./... and staticcheck.
- I have read and followed the contributing guidelines at [https://docs.mau.fi/bridges/general/contributing.html](https://docs.mau.fi/bridges/general/contributing.html)