### PR TITLE
client: add opt-in SkipStatusBroadcasts

### DIFF
--- a/client.go
+++ b/client.go
@@ -180,6 +180,20 @@ type Client struct {
 	// If false, decrypting a message from untrusted devices will fail.
 	AutoTrustIdentity bool
 
+	// SkipStatusBroadcasts makes the client ack and discard incoming status
+	// broadcasts (JID status@broadcast) without attempting to decrypt them.
+	//
+	// Status broadcasts are frequently undecryptable on a companion device,
+	// which is not a problem in itself, but the decryption attempt and the
+	// retry receipt that follows are the slowest part of handling such a node.
+	// Because nodes are handled in order, a client that does not care about
+	// other people's statuses still pays that cost for every one of them, and
+	// real messages queue up behind it.
+	//
+	// Set this if the client never reads status broadcasts. Outgoing statuses
+	// sent by this account are unaffected, as are status nodes from newsletters.
+	SkipStatusBroadcasts bool
+
 	// Should SubscribePresence return an error if no privacy token is stored for the user?
 	ErrorOnSubscribePresenceWithoutToken bool
 

--- a/message.go
+++ b/message.go
@@ -58,6 +58,13 @@ func (cli *Client) handleEncryptedMessage(ctx context.Context, node *waBinary.No
 	if len(info.PushName) > 0 && info.PushName != "-" && (cli.MessengerConfig == nil || info.PushName != "username") {
 		go cli.updatePushName(ctx, info.Sender, info.SenderAlt, info, info.PushName)
 	}
+	if cli.SkipStatusBroadcasts && info.Chat == types.StatusBroadcastJID {
+		// Ack so the server stops resending, then drop it. Decrypting a status
+		// broadcast is the expensive path and this client does not want them.
+		cli.Log.Debugf("Skipping status broadcast %s from %s", info.ID, info.Sender)
+		cli.sendAck(ctx, node, 0)
+		return
+	}
 	if info.Sender.Server == types.NewsletterServer {
 		var cancelled bool
 		defer cli.maybeDeferredAck(ctx, node)(&cancelled)


### PR DESCRIPTION
Adds an opt-in `Client.SkipStatusBroadcasts`. When set, the client acks an incoming `status@broadcast` node and drops it, instead of trying to decrypt it.

Fixes #1259, which has the full measurements. The short version, from 18 days of logs on one account:

| measurement | value |
|---|---|
| log lines that are "node handling is taking long" / "took" warnings | 10,960 of 18,123 (**60%**) |
| those warnings whose node was `status@broadcast` | 7,271 of 7,304 (**99.5%**) |
| nodes that took exactly `1m15s` | 3,582 |

Status broadcasts are often undecryptable on a companion device. The failed decrypt and the retry receipt that follows are the slow part, and `handlerQueueLoop` runs nodes in order, so real messages queue behind each one. An account that never reads statuses pays that cost about 80 times a day.

After the change, measured over 12 minutes: 0 nodes over 5s, 0 over 30s.

### Notes on the implementation

- The check sits after the push-name update and before the newsletter branch, so it runs before any decrypt work.
- The node is still acked, so the server does not resend it.
- Outgoing statuses from the account are unaffected. So are status nodes from newsletters, which take the `NewsletterServer` path.
- Default is `false`. Callers that want statuses see no change.

Upgrading to current `main` already reduced these warnings a long way — this removes the rest for clients that opt in.

Happy to reshape this if you would rather the decision lived somewhere else, or if you want it driven by existing config rather than a new field.
