### PR TITLE
request: correlate ACK waiters by ID, class and type

### DIFF
--- a/ackresponse.go
+++ b/ackresponse.go
@@ -1,0 +1,35 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package whatsmeow
+
+import waBinary "go.mau.fi/whatsmeow/binary"
+
+type ackResponseKey struct {
+	id, class, receiptType string
+}
+
+// WaitResponseForACK registers before sending a stanza whose ID can also appear
+// in unrelated ACKs. Only an ACK with the requested ID, class and type consumes
+// this waiter; ordinary ID-only waiters continue to receive other responses.
+// Calls for the same key must be serialized. The caller must invoke cancel when
+// finished; it removes only this registration and never closes a channel that a
+// concurrent response dispatcher may already have detached.
+func (cli *Client) WaitResponseForACK(id, class, receiptType string) (<-chan *waBinary.Node, func()) {
+	key := ackResponseKey{id, class, receiptType}
+	ch := make(chan *waBinary.Node, 1)
+	cli.responseWaitersLock.Lock()
+	if cli.ackResponseWaiters == nil {
+		cli.ackResponseWaiters = make(map[ackResponseKey]chan *waBinary.Node)
+	}
+	cli.ackResponseWaiters[key] = ch
+	cli.responseWaitersLock.Unlock()
+	return ch, func() {
+		cli.responseWaitersLock.Lock()
+		if cli.ackResponseWaiters[key] == ch {
+			delete(cli.ackResponseWaiters, key)
+		}
+		cli.responseWaitersLock.Unlock()
+	}
+}

--- a/ackresponse_test.go
+++ b/ackresponse_test.go
@@ -1,0 +1,160 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package whatsmeow
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	waBinary "go.mau.fi/whatsmeow/binary"
+	"go.mau.fi/whatsmeow/store"
+)
+
+func mediaACK(id string) *waBinary.Node {
+	return &waBinary.Node{Tag: "ack", Attrs: waBinary.Attrs{
+		"id": id, "class": "receipt", "type": "server-error", "error": "429",
+	}}
+}
+
+func TestACKResponseMatchesBeforeConsumingWaiter(t *testing.T) {
+	for _, unrelated := range []*waBinary.Node{
+		{Tag: "ack", Attrs: waBinary.Attrs{"id": "M", "class": "receipt"}},
+		{Tag: "ack", Attrs: waBinary.Attrs{"id": "M", "class": "receipt", "type": "read"}},
+		{Tag: "ack", Attrs: waBinary.Attrs{"id": "M", "class": "message", "type": "server-error"}},
+		{Tag: "ack", Attrs: waBinary.Attrs{"id": "other", "class": "receipt", "type": "server-error"}},
+		{Tag: "iq", Attrs: waBinary.Attrs{"id": "M", "type": "result"}},
+	} {
+		t.Run(fmt.Sprint(unrelated), func(t *testing.T) {
+			cli := NewClient(&store.Device{}, nil)
+			response, cancel := cli.WaitResponseForACK("M", "receipt", "server-error")
+			defer cancel()
+			if cli.receiveResponse(context.Background(), unrelated) {
+				t.Fatal("unrelated response consumed the qualified waiter")
+			}
+			ack := mediaACK("M")
+			// Deliver both frames before reading the channel. Re-registering
+			// after receiving the first frame would lose this second frame.
+			if !cli.receiveResponse(context.Background(), ack) {
+				t.Fatal("matching media ACK lost its waiter")
+			}
+			if got := <-response; got != ack {
+				t.Fatalf("got %v, want the media-retry rejection", got)
+			}
+			if cli.receiveResponse(context.Background(), ack) {
+				t.Fatal("matching ACK did not remove its waiter")
+			}
+		})
+	}
+}
+
+func TestACKResponseCoexistsWithIDOnlyWaiter(t *testing.T) {
+	for _, mediaFirst := range []bool{false, true} {
+		t.Run(fmt.Sprint(mediaFirst), func(t *testing.T) {
+			cli := NewClient(&store.Device{}, nil)
+			other := cli.waitResponse("M")
+			response, cancel := cli.WaitResponseForACK("M", "receipt", "server-error")
+			defer cancel()
+			ack := mediaACK("M")
+			delivery := &waBinary.Node{Tag: "ack", Attrs: waBinary.Attrs{"id": "M", "class": "receipt"}}
+			frames := []*waBinary.Node{delivery, ack}
+			if mediaFirst {
+				frames[0], frames[1] = frames[1], frames[0]
+			}
+			for _, frame := range frames {
+				if !cli.receiveResponse(context.Background(), frame) {
+					t.Fatalf("lost response %v", frame)
+				}
+			}
+			if got := <-other; got != delivery {
+				t.Fatal("ID-only waiter received the media ACK")
+			}
+			if got := <-response; got != ack {
+				t.Fatal("qualified waiter received the delivery ACK")
+			}
+		})
+	}
+}
+
+func TestACKResponseCancellationPreservesOtherWaiters(t *testing.T) {
+	cli := NewClient(&store.Device{}, nil)
+	_, cancelOld := cli.WaitResponseForACK("M", "receipt", "server-error")
+	if !cli.receiveResponse(context.Background(), mediaACK("M")) {
+		t.Fatal("first ACK was not delivered")
+	}
+	response, cancelNew := cli.WaitResponseForACK("M", "receipt", "server-error")
+	defer cancelNew()
+	other := cli.waitResponse("M")
+	cancelOld()
+	cancelOld()
+	ack := mediaACK("M")
+	if !cli.receiveResponse(context.Background(), ack) {
+		t.Fatal("old cancellation removed the successor")
+	}
+	if got := <-response; got != ack {
+		t.Fatal("successor received a cleanup response")
+	}
+	delivery := &waBinary.Node{Tag: "ack", Attrs: waBinary.Attrs{"id": "M", "class": "receipt"}}
+	if !cli.receiveResponse(context.Background(), delivery) {
+		t.Fatal("cancellation removed the ID-only waiter")
+	}
+	if got := <-other; got != delivery {
+		t.Fatal("ID-only waiter received a cleanup response")
+	}
+}
+
+func TestACKResponseDisconnectReleasesWaiter(t *testing.T) {
+	for _, node := range []*waBinary.Node{nil, xmlStreamEndNode, {Tag: "stream:error"}} {
+		t.Run(fmt.Sprint(node), func(t *testing.T) {
+			cli := NewClient(&store.Device{}, nil)
+			response, cancel := cli.WaitResponseForACK("M", "receipt", "server-error")
+			defer cancel()
+			cli.clearResponseWaiters(node)
+			if got := <-response; got != node {
+				t.Fatalf("disconnect returned %v, want %v", got, node)
+			}
+			if cli.receiveResponse(context.Background(), mediaACK("M")) {
+				t.Fatal("disconnect retained the waiter")
+			}
+		})
+	}
+}
+
+func TestACKResponseCancelUnansweredWaiter(t *testing.T) {
+	cli := NewClient(&store.Device{}, nil)
+	response, cancel := cli.WaitResponseForACK("M", "receipt", "server-error")
+	cancel()
+	cancel()
+	if cli.receiveResponse(context.Background(), mediaACK("M")) {
+		t.Fatal("cancelled registration still accepted a response")
+	}
+	select {
+	case <-response:
+		t.Fatal("cancellation closed or delivered to the response channel")
+	default:
+	}
+}
+
+func TestACKResponseCancellationRacesDeliveryAndDisconnect(t *testing.T) {
+	cli := NewClient(&store.Device{}, nil)
+	for range 500 {
+		_, cancel := cli.WaitResponseForACK("M", "receipt", "server-error")
+		start := make(chan struct{})
+		var done sync.WaitGroup
+		for _, action := range []func(){
+			func() { cli.receiveResponse(context.Background(), mediaACK("M")) },
+			func() { cli.clearResponseWaiters(xmlStreamEndNode) },
+			cancel,
+		} {
+			done.Go(func() { <-start; action() })
+		}
+		close(start)
+		done.Wait()
+		if cli.receiveResponse(context.Background(), mediaACK("M")) {
+			t.Fatal("completed cancellation left a response waiter")
+		}
+	}
+}

--- a/client.go
+++ b/client.go
@@ -115,6 +115,7 @@ type Client struct {
 	mediaConnLock  sync.Mutex
 
 	responseWaiters     map[string]chan<- *waBinary.Node
+	ackResponseWaiters  map[ackResponseKey]chan *waBinary.Node
 	responseWaitersLock sync.Mutex
 
 	nodeHandlers      map[string]nodeHandler

--- a/request.go
+++ b/request.go
@@ -50,6 +50,10 @@ func (cli *Client) clearResponseWaiters(node *waBinary.Node) {
 		}
 	}
 	cli.responseWaiters = make(map[string]chan<- *waBinary.Node)
+	for _, waiter := range cli.ackResponseWaiters {
+		waiter <- node
+	}
+	clear(cli.ackResponseWaiters)
 	cli.responseWaitersLock.Unlock()
 }
 
@@ -74,6 +78,20 @@ func (cli *Client) receiveResponse(ctx context.Context, data *waBinary.Node) boo
 		return false
 	}
 	cli.responseWaitersLock.Lock()
+	if data.Tag == "ack" {
+		class, _ := data.Attrs["class"].(string)
+		receiptType, _ := data.Attrs["type"].(string)
+		key := ackResponseKey{id, class, receiptType}
+		if waiter, found := cli.ackResponseWaiters[key]; found {
+			delete(cli.ackResponseWaiters, key)
+			cli.responseWaitersLock.Unlock()
+			select {
+			case waiter <- data:
+			case <-ctx.Done():
+			}
+			return true
+		}
+	}
 	waiter, ok := cli.responseWaiters[id]
 	if !ok {
 		cli.responseWaitersLock.Unlock()


### PR DESCRIPTION
Delivery receipts and media retry receipts can reuse a message ID. An ID-only response waiter can accept a delivery ACK first, causing the actual media retry ACK (including a 429 rejection) to be dropped. Filtering the received response and re-registering cannot handle consecutive frames reliably.

Add `Client.WaitResponseForACK` for callers that need to correlate by ID, ACK class, and type. The dispatcher matches qualified registrations before removing them, while preserving ordinary ID-only waiters. Cancellation removes only the original registration without closing a channel that response delivery may already have detached; disconnects release qualified waiters too. Existing `SendMediaRetryReceipt` behavior is unchanged.

Tests cover consecutive unrelated and matching ACKs, ID-only waiter coexistence in both delivery orders, successor-safe cancellation, unanswered cancellation, disconnect cleanup, and 500 cancellation/delivery/disconnect races.

Validation on current upstream main with Go 1.26.1:

- `GOTOOLCHAIN=local go test -race ./... -timeout=2m`
- `GOTOOLCHAIN=local go vet ./...`
- `git diff --check`

This draft, including its implementation, tests, and description, was prepared with AI assistance and is awaiting author review.

### Checklist

* [ ] I have read and followed the contributing guidelines at <https://docs.mau.fi/bridges/general/contributing.html>
